### PR TITLE
feat: improve history list data and add unfilled orders filter

### DIFF
--- a/src/components/shared/OrderHistoryList.svelte
+++ b/src/components/shared/OrderHistoryList.svelte
@@ -83,8 +83,10 @@
 
                         <!-- Col 3: Financials -->
                         <div class="flex flex-col items-end justify-center pl-1">
-                             <!-- Entry/Exit Price -->
-                            <span class="text-xs font-mono text-[var(--text-primary)] mb-0.5">{formatDynamicDecimal(order.price)}</span>
+                             <!-- Entry/Exit Price: Prefer AvgPrice (Execution) over Price (Limit) if available -->
+                            <span class="text-xs font-mono text-[var(--text-primary)] mb-0.5">
+                                {formatDynamicDecimal(order.avgPrice && Number(order.avgPrice) > 0 ? order.avgPrice : order.price)}
+                            </span>
 
                             <!-- PnL -->
                              {#if order.realizedPnL && Number(order.realizedPnL) !== 0}

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -235,7 +235,7 @@
     "interval1m": "Every 1m",
     "interval10m": "Every 10m",
     "showSidebars": "Show Sidebars",
-    "hideUnfilledOrders": "Show only executed orders",
+    "hideUnfilledOrders": "Hide Unfilled Orders",
     "feePreference": "Fee Preference",
     "feePreferenceDesc": "Select which fee rate to use by default when syncing from API.",
     "providerLabel": "Exchange Provider",

--- a/src/routes/api/orders/+server.ts
+++ b/src/routes/api/orders/+server.ts
@@ -134,6 +134,7 @@ async function fetchBitunixHistoryOrders(apiKey: string, apiSecret: string): Pro
         price: parseFloat(o.price || '0'),
         amount: parseFloat(o.qty || '0'),
         filled: parseFloat(o.tradeQty || '0'),
+        avgPrice: parseFloat(o.avgPrice || o.averagePrice || '0'),
         realizedPnL: parseFloat(o.realizedPNL || '0'),
         fee: parseFloat(o.fee || '0'),
         role: o.role, // Assuming 'MAKER' or 'TAKER' or similar string


### PR DESCRIPTION
- Added `hideUnfilledOrders` toggle to Settings (General tab) and `settingsStore`.
- Implemented filtering in `PositionsSidebar.svelte` to hide orders with 0 filled amount when enabled.
- Updated `OrderHistoryList.svelte` to display execution price (`avgPrice`) instead of limit price (`price`) if available, fixing missing prices for market orders.
- Replaced cryptic single-letter badges with full text labels (Limit, Market).
- Updated backend `src/routes/api/orders/+server.ts` to map `avgPrice` from Bitunix API response.
- Added English and German translations.