### PR TITLE
Fix duplicate declaration of positionViewMode in SettingsModal

### DIFF
--- a/src/components/settings/SettingsModal.svelte
+++ b/src/components/settings/SettingsModal.svelte
@@ -73,10 +73,9 @@
             autoFetchBalance = $settingsStore.autoFetchBalance;
             showSidebars = $settingsStore.showSidebars;
             hideUnfilledOrders = $settingsStore.hideUnfilledOrders;
-            positionViewMode = $settingsStore.positionViewMode;
+            positionViewMode = $settingsStore.positionViewMode || 'detailed';
             feePreference = $settingsStore.feePreference;
             hotkeyMode = $settingsStore.hotkeyMode;
-            positionViewMode = $settingsStore.positionViewMode || 'detailed';
             isPro = $settingsStore.isPro;
 
             // Deep copy keys to avoid binding issues


### PR DESCRIPTION
- Removed the duplicate `let positionViewMode` declaration in `SettingsModal.svelte`.
- Preserved the correctly typed declaration.
- Fixed a potential regression from a previous edit.