### PR TITLE
fix: resolve sw chrome-extension error and fix xrp symbol parsing

### DIFF
--- a/src/routes/api/klines/+server.ts
+++ b/src/routes/api/klines/+server.ts
@@ -9,12 +9,19 @@ export async function GET({ url }) {
         return json({ error: 'Symbol is required' }, { status: 400 });
     }
 
-    // Normalize symbol if needed (remove P, .P suffix if Bitunix expects standard)
-    // Bitunix usually expects e.g. BTCUSDT
-    let apiSymbol = symbol.replace('.P', '').replace('P', '');
-    if (!apiSymbol.endsWith('USDT')) {
-         // Handle cases if any
+    // Symbol is already normalized by the frontend service, but let's ensure no legacy suffixes remain.
+    // Only strip .P suffix explicitly if it exists at the end.
+    // We do NOT strip 'P' globally to avoid breaking symbols like XRPUSDT or PEPEUSDT.
+    let apiSymbol = symbol;
+    if (apiSymbol.endsWith('.P')) {
+        apiSymbol = apiSymbol.slice(0, -2);
     }
+    // Also handle trailing 'P' if it's not part of the base symbol name (complex heuristic, but mostly safer to trust frontend)
+    // Legacy support: if symbol is strictly 'USDTP' suffix?
+    // The frontend logic `normalizeSymbol` is robust. We should trust it mostly.
+
+    // Safety check for legacy double-P removal if normalized was incomplete
+    // But importantly, do NOT replace 'P' inside the string (like XRP).
 
     try {
         const apiUrl = `https://fapi.bitunix.com/api/v1/futures/market/kline?symbol=${apiSymbol}&interval=${interval}&limit=${limit}`;

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -34,6 +34,9 @@ self.addEventListener('fetch', (event) => {
     // ignore POST requests etc
     if (event.request.method !== 'GET') return;
 
+    // Ignore non-http/https requests (e.g. chrome-extension://)
+    if (!event.request.url.startsWith('http')) return;
+
     async function respond() {
         const url = new URL(event.request.url);
         const cache = await caches.open(CACHE);

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -106,6 +106,7 @@ export const apiService = {
                 close: new Decimal(kline.close),
             }));
         } catch (e) {
+            console.error(`fetchBitunixKlines error for ${symbol}:`, e);
             if (e instanceof Error && (e.message.startsWith('apiErrors.') || e.message.startsWith('bitunixErrors.'))) {
                 throw e;
             }


### PR DESCRIPTION
- In `src/service-worker.ts`, add a check to ignore non-http requests to prevent `chrome-extension` errors in the console.
- In `src/routes/api/klines/+server.ts`, modify the symbol normalization logic to prevent incorrect stripping of 'P' from valid symbols like XRPUSDT, while still handling '.P' suffixes correctly.
- In `src/services/apiService.ts`, improve error logging for kline fetching to include the specific symbol causing the error.