### PR TITLE
Optimize build chunk size and fix warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,23 @@ export default defineConfig({
 	},
 	ssr: {
 		noExternal: ['intl-messageformat', '@formatjs/icu-messageformat-parser', '@formatjs/icu-skeleton-parser', 'svelte-i18n']
+	},
+	build: {
+		rollupOptions: {
+			output: {
+				manualChunks: (id) => {
+					if (id.includes('node_modules')) {
+						if (id.includes('chart.js') || id.includes('svelte-chartjs')) {
+							return 'chart-vendor';
+						}
+						if (id.includes('decimal.js') || id.includes('crypto-js')) {
+							return 'math-vendor';
+						}
+						return 'vendor';
+					}
+				}
+			}
+		},
+		chunkSizeWarningLimit: 1000
 	}
 });


### PR DESCRIPTION
- Update `vite.config.ts` to implement manual chunks for large dependencies (chart.js, decimal.js, etc.).
- Increase `chunkSizeWarningLimit` to 1000kB.
- This resolves the "Some chunks are larger than 500 kBs" warning.