### PR TITLE
fix: android pwa white splash screen

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -10,12 +10,14 @@
     {
       "src": "/icon-192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }


### PR DESCRIPTION
- Updated `static/manifest.json` to include `"purpose": "any maskable"` for PWA icons. This instructs Android to use the provided icons in a generated splash screen with the correct background color, resolving the issue where a white card was displayed.