### PR TITLE
fix: revert pwa icon purpose to 'any'

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -25,7 +25,10 @@
 		<meta property="twitter:image" content="https://www.cachy.app/twitter-image.jpg" /> <!-- Replace with your actual image URL -->
 
 		<link rel="manifest" href="/manifest.json" />
+		<link rel="apple-touch-icon" href="/icon-192.png" />
 		<meta name="theme-color" content="#0f172a" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
 		%sveltekit.head%
 

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -11,13 +11,13 @@
       "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     }
   ]
 }


### PR DESCRIPTION
- Changed `static/manifest.json` icon `purpose` from `"any maskable"` back to `"any"`. Using "maskable" for transparent icons was causing Android to render a white background on the splash screen.
- Added standard PWA meta tags (`apple-mobile-web-app-capable`, `apple-touch-icon`, `apple-mobile-web-app-status-bar-style`) to `src/app.html` for improved iOS/Android compatibility.