### PR TITLE
fix(api): add User-Agent header to bitunix proxy

### DIFF
--- a/src/routes/api/klines/+server.ts
+++ b/src/routes/api/klines/+server.ts
@@ -53,9 +53,16 @@ async function fetchBitunixKlines(symbol: string, interval: string, limit: numbe
         limit: limit.toString()
     }).toString();
 
-    const response = await fetch(`${baseUrl}${path}?${queryString}`);
+    const response = await fetch(`${baseUrl}${path}?${queryString}`, {
+        headers: {
+            'User-Agent': 'CachyApp/1.0',
+            'Accept': 'application/json'
+        }
+    });
 
     if (!response.ok) {
+        const text = await response.text();
+        console.error(`Bitunix API error ${response.status}: ${text}`);
         throw new Error(`Bitunix API error: ${response.status}`);
     }
 

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -150,4 +150,5 @@ export interface JournalEntry {
     realizedPnl?: Decimal;
     isManual?: boolean;
     tags?: string[];
+    screenshot?: string;
 }


### PR DESCRIPTION
- Added `User-Agent` and `Accept` headers to `src/routes/api/klines/+server.ts` to prevent Bitunix API blocking.
- Added improved error logging to server-side kline proxy.
- Added optional `screenshot` field to `TradeValues` interface in `types.ts`.