### PR TITLE
Enhance Journal Quality Chart layout with large centered doughnut and…

### DIFF
--- a/src/components/shared/JournalView.svelte
+++ b/src/components/shared/JournalView.svelte
@@ -704,50 +704,53 @@
                 <BarChart data={monthlyData} title="Monthly PnL" description="Aggregierter Gewinn/Verlust pro Kalendermonat." />
             </div>
         {:else if activePreset === 'quality'}
-            <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)] flex flex-col justify-between overflow-hidden">
-                <!-- Top Row: Chart (Left) + Stats (Right) -->
-                <div class="flex flex-row items-center justify-between gap-4 flex-1">
-                    <!-- Left: Chart -->
-                    <div class="h-24 w-24 relative flex-shrink-0">
-                        <DoughnutChart
-                            data={winLossChartData}
-                            title=""
-                            description="Detaillierte Verteilung der Trades (Long/Short, Win/Loss/BE)."
-                            options={{ plugins: { legend: { display: false } } }}
-                        />
-                        <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
-                            <div class="text-center">
-                                <div class="text-[9px] text-[var(--text-secondary)] leading-tight">Win Rate</div>
-                                <div class="text-xs font-bold text-[var(--text-primary)]">{qualData.stats.winRate.toFixed(1)}%</div>
+            <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)] flex flex-col justify-between overflow-hidden relative">
+                <!-- Top Area: Layered Layout -->
+                <div class="relative flex-1 min-h-[160px] w-full">
+
+                    <!-- Layer 0: Chart (Centered & Larger) -->
+                    <div class="absolute inset-0 flex items-center justify-center z-0">
+                        <div class="h-44 w-44 relative">
+                            <DoughnutChart
+                                data={winLossChartData}
+                                title=""
+                                description="Detaillierte Verteilung der Trades (Long/Short, Win/Loss/BE)."
+                                options={{ plugins: { legend: { display: false } } }}
+                            />
+                            <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+                                <div class="text-center">
+                                    <div class="text-[10px] text-[var(--text-secondary)] leading-tight">Win Rate</div>
+                                    <div class="text-sm font-bold text-[var(--text-primary)]">{qualData.stats.winRate.toFixed(1)}%</div>
+                                </div>
                             </div>
                         </div>
                     </div>
 
-                    <!-- Right: Stats (Vertical Column) -->
-                    <div class="flex flex-col gap-2 text-sm flex-1 items-end text-right">
-                        <div class="flex flex-col">
-                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider">Profit Factor</span>
-                            <span class="font-mono font-bold {qualData.detailedStats.profitFactor >= 1.5 ? 'text-[var(--success-color)]' : qualData.detailedStats.profitFactor >= 1 ? 'text-[var(--warning-color)]' : 'text-[var(--danger-color)]'}">
+                    <!-- Layer 1: Stats (Right Aligned & Overlaid) -->
+                    <div class="absolute inset-y-0 right-0 flex flex-col justify-center items-end gap-2 text-sm z-10 pointer-events-none">
+                        <div class="flex flex-col items-end pointer-events-auto">
+                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider drop-shadow-md">Profit Factor</span>
+                            <span class="font-mono font-bold drop-shadow-md {qualData.detailedStats.profitFactor >= 1.5 ? 'text-[var(--success-color)]' : qualData.detailedStats.profitFactor >= 1 ? 'text-[var(--warning-color)]' : 'text-[var(--danger-color)]'}">
                                 {qualData.detailedStats.profitFactor.toFixed(2)}
                             </span>
                         </div>
-                        <div class="flex flex-col">
-                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider">Expectancy</span>
-                            <span class="font-mono font-bold {qualData.detailedStats.expectancy > 0 ? 'text-[var(--success-color)]' : 'text-[var(--danger-color)]'}">
+                        <div class="flex flex-col items-end pointer-events-auto">
+                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider drop-shadow-md">Expectancy</span>
+                            <span class="font-mono font-bold drop-shadow-md {qualData.detailedStats.expectancy > 0 ? 'text-[var(--success-color)]' : 'text-[var(--danger-color)]'}">
                                 ${qualData.detailedStats.expectancy.toFixed(2)}
                             </span>
                         </div>
-                        <div class="flex flex-col">
-                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider">Avg Win / Loss</span>
-                            <div class="flex items-baseline justify-end gap-1">
+                        <div class="flex flex-col items-end pointer-events-auto">
+                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider drop-shadow-md">Avg Win / Loss</span>
+                            <div class="flex items-baseline justify-end gap-1 drop-shadow-md">
                                 <span class="font-bold text-[var(--success-color)]">${qualData.detailedStats.avgWin.toFixed(2)}</span>
                                 <span class="text-[var(--text-secondary)]">/</span>
                                 <span class="font-bold text-[var(--danger-color)]">${qualData.detailedStats.avgLoss.toFixed(2)}</span>
                             </div>
                         </div>
-                        <div class="flex flex-col">
-                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider">Win Rate L/S</span>
-                            <div class="flex items-baseline justify-end gap-1">
+                        <div class="flex flex-col items-end pointer-events-auto">
+                            <span class="text-[var(--text-secondary)] text-[10px] uppercase tracking-wider drop-shadow-md">Win Rate L/S</span>
+                            <div class="flex items-baseline justify-end gap-1 drop-shadow-md">
                                 <span class="font-bold whitespace-nowrap" style="color: {hexToRgba(themeColors.success, 1)}">L: {qualData.detailedStats.winRateLong.toFixed(0)}%</span>
                                 <span class="text-[var(--text-secondary)]">|</span>
                                 <span class="font-bold whitespace-nowrap" style="color: {hexToRgba(themeColors.success, 0.6)}">S: {qualData.detailedStats.winRateShort.toFixed(0)}%</span>
@@ -756,8 +759,8 @@
                     </div>
                 </div>
 
-                <!-- Bottom Row: Legend (Full Width) -->
-                <div class="flex flex-wrap justify-center gap-x-3 gap-y-1 mt-3 pt-2 border-t border-[var(--border-color)] w-full">
+                <!-- Bottom Row: Legend (Full Width, Z-20 to sit above chart if needed) -->
+                <div class="flex flex-wrap justify-center gap-x-3 gap-y-1 mt-2 pt-2 border-t border-[var(--border-color)] w-full relative z-20 bg-[var(--bg-secondary)]">
                     <div class="flex items-center gap-1.5 text-[11px] text-[var(--text-primary)]">
                         <span class="w-2.5 h-2.5 rounded-full" style="background: {hexToRgba(themeColors.success, 1)}"></span>Win Long
                     </div>


### PR DESCRIPTION
… overlaid stats

- Updated `JournalView.svelte` to implement a layered tile design:
  - The Doughnut Chart is now larger (h-44 w-44) and centered in the tile.
  - Statistics are positioned to the right with `z-10` and `pointer-events-none` container to allow interaction with the chart below.
  - Text visibility improved with `drop-shadow-md` for layering over the chart.
- Verified visual layout with Playwright (chart centered, stats readable, legend bottom).