### PR TITLE
Optimize Journal Quality Chart tooltip placement

### DIFF
--- a/src/components/shared/JournalView.svelte
+++ b/src/components/shared/JournalView.svelte
@@ -704,9 +704,17 @@
                 <BarChart data={monthlyData} title="Monthly PnL" description="Aggregierter Gewinn/Verlust pro Kalendermonat." />
             </div>
         {:else if activePreset === 'quality'}
-            <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)] flex flex-col justify-between overflow-hidden relative">
+            <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)] flex flex-col justify-between relative">
                 <!-- Top Area: Layered Layout -->
                 <div class="relative flex-1 min-h-[160px] w-full">
+
+                    <!-- Tooltip (Bottom Left of Chart Area) -->
+                    <div class="absolute bottom-1 left-1 z-30">
+                        <Tooltip
+                            text="Detaillierte Verteilung der Trades (Long/Short, Win/Loss/BE)."
+                            alignment="left"
+                        />
+                    </div>
 
                     <!-- Layer 0: Chart (Centered & Larger) -->
                     <div class="absolute inset-0 flex items-center justify-center z-0">
@@ -714,7 +722,6 @@
                             <DoughnutChart
                                 data={winLossChartData}
                                 title=""
-                                description="Detaillierte Verteilung der Trades (Long/Short, Win/Loss/BE)."
                                 options={{ plugins: { legend: { display: false } } }}
                             />
                             <div class="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/src/components/shared/Tooltip.svelte
+++ b/src/components/shared/Tooltip.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   export let text = '';
+  export let alignment: 'center' | 'left' | 'right' = 'center';
   let visible = false;
   let tooltipEl: HTMLElement;
 
@@ -29,7 +30,7 @@
       bind:this={tooltipEl}
       id="tooltip-text"
       role="tooltip"
-      class="tooltip-content"
+      class="tooltip-content {alignment}"
     >
       {text}
     </div>
@@ -68,8 +69,6 @@
     position: absolute;
     z-index: 10;
     bottom: 140%;
-    left: 50%;
-    transform: translateX(-50%);
     font-size: 0.8rem;
     font-weight: 500;
     box-shadow: var(--shadow-tooltip);
@@ -77,14 +76,43 @@
     pointer-events: none;
     text-transform: none;
   }
+
+  .tooltip-content.center {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .tooltip-content.left {
+    left: -0.5rem;
+    transform: none;
+  }
+
+  .tooltip-content.right {
+    right: -0.5rem;
+    transform: none;
+  }
+
   .tooltip-content::after {
     content: "";
     position: absolute;
     top: 100%;
-    left: 50%;
-    margin-left: -5px;
     border-width: 5px;
     border-style: solid;
     border-color: var(--bg-tertiary) transparent transparent transparent;
+  }
+
+  .tooltip-content.center::after {
+    left: 50%;
+    margin-left: -5px;
+  }
+
+  .tooltip-content.left::after {
+    left: 0.6rem;
+    margin-left: -5px;
+  }
+
+  .tooltip-content.right::after {
+    right: 0.6rem;
+    margin-right: -5px;
   }
 </style>


### PR DESCRIPTION
- Updated `Tooltip.svelte` to support an `alignment` prop ('center', 'left', 'right') for precise popup positioning.
- Modified `JournalView.svelte` to position the Quality chart tooltip at the bottom-left of the chart area (`alignment="left"`, `absolute bottom-1 left-1`).
- Adjusted layout to ensure the tooltip popup is not clipped (`overflow-visible` container, high z-index).
- Verified correct positioning (arrow aligned with icon) and readability via Playwright screenshots.