### PR TITLE
feat: enhance journal calendar heatmap

### DIFF
--- a/src/components/shared/JournalView.svelte
+++ b/src/components/shared/JournalView.svelte
@@ -277,6 +277,14 @@
     // Calendar Data
     $: calendarData = calculator.getCalendarData(journal);
 
+    function handleCalendarClick(event: CustomEvent) {
+        const dateStr = event.detail.date;
+        // Set filters to this date
+        filterDateStart = dateStr;
+        filterDateEnd = dateStr;
+        // Optionally scroll to table?
+    }
+
     $: availableYears = (() => {
         const years = new Set<number>();
         years.add(new Date().getFullYear()); // Always include current year
@@ -1139,7 +1147,7 @@
                         </select>
                     </div>
                     <div class="w-full">
-                        <CalendarHeatmap data={calendarData} year={selectedYear} />
+                        <CalendarHeatmap data={calendarData} year={selectedYear} on:click={handleCalendarClick} />
                     </div>
                 </div>
             {/if}


### PR DESCRIPTION
- Modified `src/lib/calculator.ts` to aggregate additional daily metrics: `winCount`, `lossCount`, and `bestSymbol` (highest PnL asset).
- Updated `src/components/shared/charts/CalendarHeatmap.svelte` to display monthly PnL and trade counts in the header.
- Enhanced tooltips in the heatmap to show PnL, trade counts (win/loss), and the top performing asset for the day.
- Implemented click interactivity: clicking a day in the heatmap now filters the Journal table to show trades from that specific date.
- Added accessibility attributes (`role="button"`, `tabindex="0"`) to interactive heatmap cells.