### PR TITLE
feat: Add Leakage Report (Loss Attribution) to Journal Deep Dive

### DIFF
--- a/src/components/shared/JournalView.svelte
+++ b/src/components/shared/JournalView.svelte
@@ -526,6 +526,25 @@
         }]
     } : null;
 
+    // Leakage (Attribution)
+    $: leakageData = calculator.getLeakageData(journal);
+    $: leakageTagData = {
+        labels: leakageData.worstTags.map(t => t.label),
+        datasets: [{
+            label: 'PnL',
+            data: leakageData.worstTags.map(t => t.pnl),
+            backgroundColor: themeColors.danger
+        }]
+    };
+    $: leakageTimingData = {
+        labels: leakageData.worstHours.map(h => `${h.hour}h`),
+        datasets: [{
+            label: 'Gross Loss',
+            data: leakageData.worstHours.map(h => h.loss), // Absolute positive values for display
+            backgroundColor: themeColors.danger
+        }]
+    };
+
     // --- Table State ---
     let currentPage = 1;
     let itemsPerPage = 10;
@@ -1125,6 +1144,7 @@
             presets={[
                 { id: 'forecast', label: $_('journal.deepDive.forecast') },
                 { id: 'trends', label: $_('journal.deepDive.trends') },
+                { id: 'leakage', label: $_('journal.deepDive.leakage') },
                 { id: 'timing', label: $_('journal.deepDive.timing') },
                 { id: 'assets', label: $_('journal.deepDive.assets') },
                 { id: 'risk', label: $_('journal.deepDive.risk') },
@@ -1164,6 +1184,22 @@
                              {$_('journal.noData')} (Min 20 Trades)
                          </div>
                     {/if}
+                 </div>
+            {:else if activeDeepDivePreset === 'leakage'}
+                 <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)] flex flex-col justify-center">
+                    <div class="flex flex-col items-center gap-2">
+                         <div class="text-[10px] text-[var(--text-secondary)] uppercase tracking-wider">{$_('journal.deepDive.charts.labels.profitRetention')}</div>
+                         <div class="text-4xl font-bold {leakageData.profitRetention > 50 ? 'text-[var(--success-color)]' : 'text-[var(--warning-color)]'}">
+                             {leakageData.profitRetention.toFixed(1)}%
+                         </div>
+                         <div class="text-xs text-[var(--text-secondary)] mt-2">{$_('journal.deepDive.charts.labels.feeImpact')}: <span class="text-[var(--danger-color)]">-{leakageData.feeImpact.toFixed(1)}%</span></div>
+                    </div>
+                 </div>
+                 <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)]">
+                     <BarChart data={leakageTagData} title="Strategy Leakage" horizontal={true} description={$_('journal.deepDive.charts.descriptions.leakageTags')} />
+                 </div>
+                 <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)]">
+                     <BarChart data={leakageTimingData} title="Time Leakage (Worst Hours)" description={$_('journal.deepDive.charts.descriptions.leakageTiming')} />
                  </div>
             {:else if activeDeepDivePreset === 'timing'}
                  <div class="chart-tile bg-[var(--bg-secondary)] p-4 rounded-lg border border-[var(--border-color)]">

--- a/src/locales/locales/de.json
+++ b/src/locales/locales/de.json
@@ -227,6 +227,7 @@
       "title": "Deep Dive",
       "forecast": "Prognose",
       "trends": "Trends",
+      "leakage": "Verluste",
       "timing": "Zeit",
       "assets": "Assets",
       "risk": "Risiko",
@@ -273,6 +274,8 @@
             "heatmap": "Täglicher PnL Kalender"
         },
         "descriptions": {
+            "leakageTags": "Strategien oder Tags, die den größten Verlust verursachen.",
+            "leakageTiming": "Zeiten, in denen die größten Verluste auftreten.",
             "equityCurve": "Verlauf des Gesamtkapitals basierend auf allen abgeschlossenen Trades.",
             "drawdown": "Zeigt den Rückgang vom letzten Höchststand des Kapitals (Equity High).",
             "monthlyPnl": "Aggregierter Gewinn/Verlust pro Kalendermonat.",
@@ -306,6 +309,9 @@
         "labels": {
             "forecast": "Forecast",
             "trends": "Trends",
+            "leakage": "Leakage",
+            "profitRetention": "Profit Retention",
+            "feeImpact": "Fee Impact",
             "equity": "Equity",
             "pnl": "PnL ($)",
             "pnlY": "PnL",

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -227,6 +227,7 @@
       "title": "Deep Dive",
       "forecast": "Forecast",
       "trends": "Trends",
+      "leakage": "Leakage",
       "timing": "Timing",
       "assets": "Assets",
       "risk": "Risk",
@@ -273,6 +274,8 @@
             "heatmap": "Daily PnL Heatmap"
         },
         "descriptions": {
+            "leakageTags": "Strategies or tags causing the biggest losses.",
+            "leakageTiming": "Times when the biggest losses occur.",
             "equityCurve": "Total capital progression based on all closed trades.",
             "drawdown": "Shows the decline from the last equity high.",
             "monthlyPnl": "Aggregated profit/loss per calendar month.",
@@ -306,6 +309,9 @@
         "labels": {
             "forecast": "Forecast",
             "trends": "Trends",
+            "leakage": "Leakage",
+            "profitRetention": "Profit Retention",
+            "feeImpact": "Fee Impact",
             "equity": "Equity",
             "pnl": "PnL ($)",
             "pnlY": "PnL",


### PR DESCRIPTION
- Implement `getLeakageData` in calculator to analyze Profit Retention, Fee Impact, and identify loss drivers (Tags, Time).
- Add "Leakage" tab to Journal Deep Dive with efficiency scorecards and charts for Worst Tags and Worst Hours.
- Integrate previous Forecast (Monte Carlo) and Trends (Rolling Stats) features.
- Update localization (DE/EN) for new report metrics.