### PR TITLE
Refactor Journal 'Quality' chart to use standard Flexbox layout

### DIFF
--- a/src/components/shared/JournalView.svelte
+++ b/src/components/shared/JournalView.svelte
@@ -738,7 +738,7 @@
 
                 <!-- Title: Centered Top (Simulating Chart.js Title) -->
                 <div class="w-full text-center mb-2">
-                    <span class="text-xs font-bold text-[#94a3b8] uppercase">{$_('journal.deepDive.charts.titles.winRate')}</span>
+                    <span class="text-xs font-bold text-[#94a3b8]">{$_('journal.deepDive.charts.titles.winRate')}</span>
                 </div>
 
                 <!-- Main Content: Chart & Stats -->


### PR DESCRIPTION
- Replaced complex absolute positioning with a standard flex-row layout.
- Moved 'Win Rate' header to center top of the tile, matching standard Chart.js title styling.
- Aligned statistics to the right with 2 decimal precision.
- Moved tooltip icon to bottom-left corner.
- Removed large central percentage text.