### PR TITLE
feat: Enhance Technicals Panel width and naming

### DIFF
--- a/src/components/shared/TechnicalsPanel.svelte
+++ b/src/components/shared/TechnicalsPanel.svelte
@@ -172,7 +172,7 @@
 <svelte:window on:click={handleClickOutside} />
 
 {#if showPanel}
-    <div class="technicals-panel p-3 flex flex-col gap-2 w-full md:w-72 transition-all relative">
+    <div class="technicals-panel p-3 flex flex-col gap-2 w-full md:w-80 transition-all relative">
 
         <!-- Header -->
         <div class="flex justify-between items-center pb-2 timeframe-selector-container relative">

--- a/src/services/technicalsService.ts
+++ b/src/services/technicalsService.ts
@@ -91,7 +91,7 @@ export const technicalsService = {
                 else if (stoch.k > 80 && stoch.d > 80 && stoch.k < stoch.d) stochAction = 'Sell';
             }
             oscillators.push({
-                name: `Stoch %K (${stochK}, ${stochD}, 3)`,
+                name: `Stoch (${stochK}, ${stochD}, 3)`,
                 value: stoch ? stoch.k : 0,
                 action: stochAction
             });


### PR DESCRIPTION
- Increased `TechnicalsPanel` width to 20rem (`w-80`) to improve layout.
- Renamed 'Stoch %K' to 'Stoch' in `technicalsService.ts` to prevent line breaks.
- Updated `SettingsModal` to fix accessibility of enable/disable toggles for non-Pro users.
- Ensured Pivot Points section is only rendered if enabled.
- Updated unit tests to reflect naming changes.