### PR TITLE
feat: Add AI Chat Assistant to Side Panel

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -27,6 +27,7 @@
 		<link rel="manifest" href="/manifest.json" />
 		<link rel="apple-touch-icon" href="/icon-192.png" />
 		<meta name="theme-color" content="#0f172a" />
+		<meta name="mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 

--- a/src/routes/api/ai/gemini/+server.ts
+++ b/src/routes/api/ai/gemini/+server.ts
@@ -10,13 +10,6 @@ export const POST: RequestHandler = async ({ request }) => {
             return json({ error: 'Missing API Key' }, { status: 401 });
         }
 
-        // Convert standard messages format to Gemini format
-        // Standard: [{ role: 'user', content: '...' }, { role: 'system', content: '...' }]
-        // Gemini: { contents: [{ role: 'user', parts: [{ text: '...' }] }] }
-        // Note: Gemini doesn't support 'system' role in 'contents' for v1beta, but supports 'system_instruction' separately in latest API.
-        // For simplicity/compatibility, we will merge system prompt into the first user message or use v1beta1 models that support it better.
-        // We will use 'gemini-1.5-flash' as default.
-
         let systemInstruction = undefined;
         const contents = [];
 
@@ -31,8 +24,11 @@ export const POST: RequestHandler = async ({ request }) => {
             }
         }
 
-        const selectedModel = model || 'gemini-1.5-flash';
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/${selectedModel}:generateContent?key=${apiKey}`;
+        // Use 'gemini-2.0-flash' as requested/verified by user
+        const selectedModel = model || 'gemini-2.0-flash';
+
+        // Use streamGenerateContent?alt=sse for Server-Sent Events
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/${selectedModel}:streamGenerateContent?alt=sse&key=${apiKey}`;
 
         const payload: any = { contents };
         if (systemInstruction) {
@@ -52,20 +48,13 @@ export const POST: RequestHandler = async ({ request }) => {
             return json({ error: err.error?.message || 'Gemini API Error' }, { status: response.status });
         }
 
-        const data = await response.json();
-
-        // Normalize response to OpenAI format for frontend consistency
-        const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
-        const normalized = {
-            choices: [{
-                message: {
-                    role: 'assistant',
-                    content: text
-                }
-            }]
-        };
-
-        return json(normalized);
+        return new Response(response.body, {
+            headers: {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive'
+            }
+        });
 
     } catch (e: any) {
         console.error('Gemini Proxy Error:', e);

--- a/src/routes/api/ai/openai/+server.ts
+++ b/src/routes/api/ai/openai/+server.ts
@@ -17,9 +17,10 @@ export const POST: RequestHandler = async ({ request }) => {
                 'Authorization': `Bearer ${apiKey}`
             },
             body: JSON.stringify({
-                model: model || 'gpt-4o', // Default to GPT-4o if not specified
+                model: model || 'gpt-4o',
                 messages: messages,
-                max_tokens: 2000
+                max_tokens: 2000,
+                stream: true // Enable streaming
             })
         });
 
@@ -28,8 +29,14 @@ export const POST: RequestHandler = async ({ request }) => {
             return json({ error: err.error?.message || 'OpenAI API Error' }, { status: response.status });
         }
 
-        const data = await response.json();
-        return json(data);
+        // Return the stream directly
+        return new Response(response.body, {
+            headers: {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive'
+            }
+        });
 
     } catch (e: any) {
         console.error('OpenAI Proxy Error:', e);


### PR DESCRIPTION
- Added new 'AI Chat' mode to Side Panel with OpenAI, Gemini, and Anthropic support.
- Implemented secure backend proxies for AI providers to handle API calls without exposing keys or CORS issues.
- Added Settings UI for managing AI API keys and selecting the default provider.
- Created `aiStore` to manage chat state, history persistence, and context gathering (Market Data, Positions, Journal).
- Implemented streaming response handling for a responsive chat experience.
- Integrated `marked` for Markdown rendering in chat messages.
- Fixed deprecated meta tag for mobile web app capability.
- Updated Gemini model to `gemini-2.0-flash`.