### PR TITLE
feat: Add AI Chat Assistant to Side Panel

### DIFF
--- a/src/components/settings/SettingsModal.svelte
+++ b/src/components/settings/SettingsModal.svelte
@@ -44,8 +44,11 @@
     // AI Settings
     let aiProviderState: AiProvider;
     let openaiApiKey: string;
+    let openaiModel: string;
     let geminiApiKey: string;
+    let geminiModel: string;
     let anthropicApiKey: string;
+    let anthropicModel: string;
 
     // Separate API keys per provider
     let bitunixKeys: ApiKeys = { key: '', secret: '' };
@@ -115,8 +118,11 @@
 
             aiProviderState = $settingsStore.aiProvider || 'gemini';
             openaiApiKey = $settingsStore.openaiApiKey || '';
+            openaiModel = $settingsStore.openaiModel || 'gpt-4o';
             geminiApiKey = $settingsStore.geminiApiKey || '';
+            geminiModel = $settingsStore.geminiModel || 'gemini-2.0-flash';
             anthropicApiKey = $settingsStore.anthropicApiKey || '';
+            anthropicModel = $settingsStore.anthropicModel || 'claude-3-5-sonnet-20240620';
 
             favoriteTimeframes = [...$settingsStore.favoriteTimeframes];
             favoriteTimeframesInput = favoriteTimeframes.join(', '); // Init text input
@@ -165,9 +171,12 @@
             imgbbApiKey,
             imgbbExpiration,
             aiProvider: aiProviderState,
-            openaiApiKey: openaiApiKey,
-            geminiApiKey: geminiApiKey,
-            anthropicApiKey: anthropicApiKey,
+            openaiApiKey,
+            openaiModel,
+            geminiApiKey,
+            geminiModel,
+            anthropicApiKey,
+            anthropicModel,
             apiKeys: {
                 bitunix: bitunixKeys,
                 binance: binanceKeys
@@ -492,33 +501,51 @@
                         </select>
                     </div>
 
-                    <div class="flex flex-col gap-3 pt-2 border-t border-[var(--border-color)]">
-                        <div class="flex flex-col gap-1">
-                            <label for="openai-key" class="text-xs flex items-center gap-2">
-                                <span>OpenAI API Key</span>
+                    <div class="flex flex-col gap-4 pt-4 border-t border-[var(--border-color)]">
+                        <!-- OpenAI Section -->
+                        <div class="flex flex-col gap-2">
+                            <label for="openai-key" class="text-xs font-bold flex items-center gap-2">
+                                <span>OpenAI</span>
                                 {#if aiProviderState === 'openai'}<span class="w-1.5 h-1.5 rounded-full bg-[var(--accent-color)]"></span>{/if}
                             </label>
-                            <input id="openai-key" type="password" bind:value={openaiApiKey} class="input-field p-1 px-2 rounded text-sm" placeholder="sk-..." />
+                            <input id="openai-key" type="password" bind:value={openaiApiKey} class="input-field p-1 px-2 rounded text-sm mb-1" placeholder="API Key (sk-...)" />
+                            <div class="flex items-center gap-2">
+                                <span class="text-[10px] text-[var(--text-secondary)] w-12">Model:</span>
+                                <input type="text" bind:value={openaiModel} class="input-field p-1 px-2 rounded text-xs flex-1 bg-[var(--bg-secondary)] border border-[var(--border-color)]" placeholder="gpt-4o" />
+                            </div>
                         </div>
 
-                        <div class="flex flex-col gap-1">
-                            <label for="gemini-key" class="text-xs flex items-center gap-2">
-                                <span>Google Gemini API Key</span>
+                        <!-- Gemini Section -->
+                        <div class="flex flex-col gap-2 border-t border-[var(--border-color)] pt-3">
+                            <label for="gemini-key" class="text-xs font-bold flex items-center gap-2">
+                                <span>Google Gemini</span>
                                 {#if aiProviderState === 'gemini'}<span class="w-1.5 h-1.5 rounded-full bg-[var(--accent-color)]"></span>{/if}
                             </label>
-                            <input id="gemini-key" type="password" bind:value={geminiApiKey} class="input-field p-1 px-2 rounded text-sm" placeholder="AIza..." />
+                            <input id="gemini-key" type="password" bind:value={geminiApiKey} class="input-field p-1 px-2 rounded text-sm mb-1" placeholder="API Key (AIza...)" />
+                            <div class="flex items-center gap-2">
+                                <span class="text-[10px] text-[var(--text-secondary)] w-12">Model:</span>
+                                <input type="text" bind:value={geminiModel} class="input-field p-1 px-2 rounded text-xs flex-1 bg-[var(--bg-secondary)] border border-[var(--border-color)]" placeholder="gemini-2.0-flash" />
+                            </div>
+                            <p class="text-[10px] text-[var(--text-secondary)] italic">
+                                Use <code>gemini-1.5-flash</code> if <code>gemini-2.0-flash</code> is rate limited.
+                            </p>
                         </div>
 
-                        <div class="flex flex-col gap-1">
-                            <label for="anthropic-key" class="text-xs flex items-center gap-2">
-                                <span>Anthropic API Key</span>
+                        <!-- Anthropic Section -->
+                        <div class="flex flex-col gap-2 border-t border-[var(--border-color)] pt-3">
+                            <label for="anthropic-key" class="text-xs font-bold flex items-center gap-2">
+                                <span>Anthropic</span>
                                 {#if aiProviderState === 'anthropic'}<span class="w-1.5 h-1.5 rounded-full bg-[var(--accent-color)]"></span>{/if}
                             </label>
-                            <input id="anthropic-key" type="password" bind:value={anthropicApiKey} class="input-field p-1 px-2 rounded text-sm" placeholder="sk-ant-..." />
+                            <input id="anthropic-key" type="password" bind:value={anthropicApiKey} class="input-field p-1 px-2 rounded text-sm mb-1" placeholder="API Key (sk-ant-...)" />
+                            <div class="flex items-center gap-2">
+                                <span class="text-[10px] text-[var(--text-secondary)] w-12">Model:</span>
+                                <input type="text" bind:value={anthropicModel} class="input-field p-1 px-2 rounded text-xs flex-1 bg-[var(--bg-secondary)] border border-[var(--border-color)]" placeholder="claude-3-5-sonnet-20240620" />
+                            </div>
                         </div>
                     </div>
 
-                    <p class="text-[10px] text-[var(--text-secondary)] mt-1 italic">
+                    <p class="text-[10px] text-[var(--text-secondary)] mt-2 italic border-t border-[var(--border-color)] pt-2">
                         Your API keys are stored locally in your browser and are never saved to our servers. They are only used to communicate directly with the AI providers.
                     </p>
                 </div>

--- a/src/services/hotkeyService.test.ts
+++ b/src/services/hotkeyService.test.ts
@@ -77,8 +77,11 @@ describe('HotkeyService', () => {
             sidePanelMode: 'chat',
             aiProvider: 'gemini',
             openaiApiKey: '',
+            openaiModel: 'gpt-4o',
             geminiApiKey: '',
+            geminiModel: 'gemini-2.0-flash',
             anthropicApiKey: '',
+            anthropicModel: 'claude-3-5-sonnet-20240620',
             disclaimerAccepted: true
         });
 

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -98,9 +98,20 @@ Format responses with Markdown.`;
                 const endpoint = `/api/ai/${provider}`;
 
                 let apiKey = '';
-                if (provider === 'openai') apiKey = settings.openaiApiKey;
-                if (provider === 'gemini') apiKey = settings.geminiApiKey;
-                if (provider === 'anthropic') apiKey = settings.anthropicApiKey;
+                let model = '';
+
+                if (provider === 'openai') {
+                    apiKey = settings.openaiApiKey;
+                    model = settings.openaiModel;
+                }
+                if (provider === 'gemini') {
+                    apiKey = settings.geminiApiKey;
+                    model = settings.geminiModel;
+                }
+                if (provider === 'anthropic') {
+                    apiKey = settings.anthropicApiKey;
+                    model = settings.anthropicModel;
+                }
 
                 if (!apiKey) {
                     throw new Error(`API Key for ${provider} is missing in Settings.`);
@@ -129,7 +140,8 @@ Format responses with Markdown.`;
                         'x-api-key': apiKey
                     },
                     body: JSON.stringify({
-                        messages: apiMessages
+                        messages: apiMessages,
+                        model: model // Pass the model from settings
                     })
                 });
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -47,8 +47,11 @@ export interface Settings {
     // AI Chat Settings
     aiProvider: AiProvider;
     openaiApiKey: string;
+    openaiModel: string;
     geminiApiKey: string;
+    geminiModel: string;
     anthropicApiKey: string;
+    anthropicModel: string;
 
     // Legal
     disclaimerAccepted: boolean;
@@ -77,10 +80,16 @@ const defaultSettings: Settings = {
     isDeepDiveUnlocked: false,
     enableSidePanel: false,
     sidePanelMode: 'notes',
+
+    // AI Defaults
     aiProvider: 'gemini',
     openaiApiKey: '',
+    openaiModel: 'gpt-4o',
     geminiApiKey: '',
+    geminiModel: 'gemini-2.0-flash', // Defaulting to 2.0-flash as requested, but user can change it
     anthropicApiKey: '',
+    anthropicModel: 'claude-3-5-sonnet-20240620',
+
     disclaimerAccepted: false
 };
 
@@ -129,8 +138,13 @@ function loadSettingsFromLocalStorage(): Settings {
         // 4. Ensure AI Settings defaults
         if (!settings.aiProvider) settings.aiProvider = defaultSettings.aiProvider;
         if (!settings.openaiApiKey) settings.openaiApiKey = defaultSettings.openaiApiKey;
+        if (!settings.openaiModel) settings.openaiModel = defaultSettings.openaiModel;
+
         if (!settings.geminiApiKey) settings.geminiApiKey = defaultSettings.geminiApiKey;
+        if (!settings.geminiModel) settings.geminiModel = defaultSettings.geminiModel;
+
         if (!settings.anthropicApiKey) settings.anthropicApiKey = defaultSettings.anthropicApiKey;
+        if (!settings.anthropicModel) settings.anthropicModel = defaultSettings.anthropicModel;
 
 
         // Clean up keys not in interface
@@ -157,8 +171,11 @@ function loadSettingsFromLocalStorage(): Settings {
             sidePanelMode: settings.sidePanelMode ?? defaultSettings.sidePanelMode,
             aiProvider: settings.aiProvider,
             openaiApiKey: settings.openaiApiKey,
+            openaiModel: settings.openaiModel,
             geminiApiKey: settings.geminiApiKey,
+            geminiModel: settings.geminiModel,
             anthropicApiKey: settings.anthropicApiKey,
+            anthropicModel: settings.anthropicModel,
             disclaimerAccepted: settings.disclaimerAccepted ?? defaultSettings.disclaimerAccepted
         };
 


### PR DESCRIPTION
- Added new 'AI Chat' mode to Side Panel with OpenAI, Gemini, and Anthropic support.
- Implemented secure backend proxies for AI providers to handle API calls without exposing keys or CORS issues.
- Added Settings UI for managing AI API keys and selecting the default provider.
- Created `aiStore` to manage chat state, history persistence, and context gathering (Market Data, Positions, Journal).
- Implemented streaming response handling for a responsive chat experience.
- Integrated `marked` for Markdown rendering in chat messages.
- Fixed deprecated meta tag for mobile web app capability.
- Updated Gemini model to `gemini-2.0-flash`.