### PR TITLE
Fix Technicals flickering by hardening timestamp and kline update logic

### DIFF
--- a/src/components/shared/TechnicalsPanel.svelte
+++ b/src/components/shared/TechnicalsPanel.svelte
@@ -8,7 +8,7 @@
     import { apiService } from "../../services/apiService";
     import { technicalsService } from "../../services/technicalsService";
     import type { TechnicalsData } from "../../services/technicalsTypes"; // Import strict types
-    import { normalizeTimeframeInput } from "../../utils/utils";
+    import { normalizeTimeframeInput, parseTimestamp } from "../../utils/utils";
     import { Decimal } from "decimal.js";
     import Tooltip from "../shared/Tooltip.svelte";
 
@@ -97,8 +97,8 @@
         if (!newKline) return;
 
         // Strict Validation: Ensure incoming data is valid
-        // Check timestamps and prices to prevent corruption (e.g. 0 values)
-        const time = newKline.time || 0;
+        // Use parseTimestamp to ensure seconds/ms consistency with REST history
+        const time = parseTimestamp(newKline.time);
         const close = newKline.close ? new Decimal(newKline.close) : new Decimal(0);
 
         if (time <= 0 || close.lte(0)) {
@@ -108,10 +108,9 @@
 
         const lastIdx = klinesHistory.length - 1;
         const lastHistoryCandle = klinesHistory[lastIdx];
-        const lastTime = lastHistoryCandle.time || lastHistoryCandle.ts || 0;
+        const lastTime = lastHistoryCandle.time || lastHistoryCandle.ts || 0; // Already parsed by apiService
 
         // Ensure we handle Decimal objects or strings/numbers correctly for history
-        // marketStore already sends Decimals for prices, but we double-check just in case.
         const newCandleObj = {
             open: newKline.open ? new Decimal(newKline.open) : new Decimal(0),
             high: newKline.high ? new Decimal(newKline.high) : new Decimal(0),
@@ -122,6 +121,7 @@
         };
 
         // Determine if newKline is the SAME candle as the last one in history, or a NEW one
+        // Using strict time comparison after normalization
         if (time > lastTime && lastTime > 0) {
             // New candle started!
             klinesHistory = [...klinesHistory, newCandleObj];
@@ -134,6 +134,7 @@
             newHistory[lastIdx] = newCandleObj;
             klinesHistory = newHistory;
         }
+        // If time < lastTime, it's an old update (out of order), ignore it to protect history.
 
         updateTechnicals();
     }

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -418,7 +418,9 @@ class BitunixWebSocketService {
                         l: data.l,
                         c: data.c,
                         b: data.b || data.v, // volume might be b (base vol) or v? Bitunix usually uses b for base volume in ticker, check kline
-                        t: data.t || Date.now() // data.t is usually the kline start time
+                        // Use data.id (often timestamp in Bitunix) or data.ts as fallbacks.
+                        // Only use Date.now() as a last resort to prevent infinite candle generation if timestamp is missing.
+                        t: data.t || data.id || data.ts || Date.now()
                     });
                 }
             }


### PR DESCRIPTION
- Modified `src/services/bitunixWs.ts` to use `id` or `ts` as fallbacks for timestamps, preventing `Date.now()` default which caused ghost candles.
- Updated `src/components/shared/TechnicalsPanel.svelte` to use `parseTimestamp` for strict comparison, ensuring live updates merge into the current candle instead of appending new ones.
- These changes stabilize Pivot Points and Oscillators by ensuring the historical data array remains consistent during live updates.