### PR TITLE
Update default Gemini model to gemini-2.5-flash

### DIFF
--- a/src/components/settings/SettingsModal.svelte
+++ b/src/components/settings/SettingsModal.svelte
@@ -122,7 +122,7 @@
             openaiApiKey = $settingsStore.openaiApiKey || '';
             openaiModel = $settingsStore.openaiModel || 'gpt-4o';
             geminiApiKey = $settingsStore.geminiApiKey || '';
-            geminiModel = $settingsStore.geminiModel || 'gemini-1.5-flash';
+            geminiModel = $settingsStore.geminiModel || 'gemini-2.0-flash';
             anthropicApiKey = $settingsStore.anthropicApiKey || '';
             anthropicModel = $settingsStore.anthropicModel || 'claude-3-5-sonnet-20240620';
 
@@ -527,10 +527,10 @@
                             <input id="gemini-key" type="password" bind:value={geminiApiKey} class="input-field p-1 px-2 rounded text-sm mb-1" placeholder="API Key (AIza...)" />
                             <div class="flex items-center gap-2">
                                 <span class="text-[10px] text-[var(--text-secondary)] w-12">Model:</span>
-                                <input type="text" bind:value={geminiModel} class="input-field p-1 px-2 rounded text-xs flex-1 bg-[var(--bg-secondary)] border border-[var(--border-color)]" placeholder="gemini-1.5-flash" />
+                                <input type="text" bind:value={geminiModel} class="input-field p-1 px-2 rounded text-xs flex-1 bg-[var(--bg-secondary)] border border-[var(--border-color)]" placeholder="gemini-2.5-flash" />
                             </div>
                             <p class="text-[10px] text-[var(--text-secondary)] italic">
-                                You can try <code>gemini-2.0-flash</code> for newer features if available.
+                                Use <code>gemini-1.5-flash</code> if the 2.5 version is unavailable.
                             </p>
                         </div>
 

--- a/src/routes/api/ai/gemini/+server.ts
+++ b/src/routes/api/ai/gemini/+server.ts
@@ -24,8 +24,8 @@ export const POST: RequestHandler = async ({ request }) => {
             }
         }
 
-        // Use 'gemini-1.5-flash' as the stable default for free tier
-        const selectedModel = model || 'gemini-1.5-flash';
+        // Use 'gemini-2.5-flash' as the current stable version
+        const selectedModel = model || 'gemini-2.5-flash';
 
         // Use streamGenerateContent?alt=sse for Server-Sent Events
         const url = `https://generativelanguage.googleapis.com/v1beta/models/${selectedModel}:streamGenerateContent?alt=sse&key=${apiKey}`;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -89,7 +89,7 @@ const defaultSettings: Settings = {
     openaiApiKey: '',
     openaiModel: 'gpt-4o',
     geminiApiKey: '',
-    geminiModel: 'gemini-2.0-flash', // Defaulting to 2.0-flash as requested, but user can change it
+    geminiModel: 'gemini-2.5-flash', // Defaulting to 2.5-flash as the stable version
     anthropicApiKey: '',
     anthropicModel: 'claude-3-5-sonnet-20240620',
 


### PR DESCRIPTION
Updated the default Gemini model from `gemini-2.0-flash` to `gemini-2.5-flash` in `src/routes/api/ai/gemini/+server.ts` and `src/stores/settingsStore.ts` to address connection issues reported by users. Updated the `SettingsModal` placeholder and helper text to reflect this change and provide clearer fallback guidance.