### PR TITLE
Enhance CachyLog: Intercept global console and add test trigger

### DIFF
--- a/src/components/settings/SettingsModal.svelte
+++ b/src/components/settings/SettingsModal.svelte
@@ -1090,6 +1090,17 @@
 
         {:else if activeTab === 'system'}
             <div class="flex flex-col gap-4" role="tabpanel" id="tab-system">
+                <!-- CachyLog Test -->
+                <div class="p-3 border border-[var(--border-color)] rounded bg-[var(--bg-tertiary)] flex flex-col gap-2">
+                     <h4 class="text-sm font-bold">CachyLog Debug</h4>
+                     <p class="text-xs text-[var(--text-secondary)] mb-2">
+                         Trigger a test log on the server to verify browser console logging (CL: prefix).
+                     </p>
+                     <button class="btn btn-secondary text-sm w-full" on:click={() => fetch('/api/test-log', { method: 'POST' })}>
+                        Trigger Server Log
+                     </button>
+                </div>
+
                  <!-- Backup -->
                 <div class="p-3 border border-[var(--border-color)] rounded bg-[var(--bg-tertiary)] flex flex-col gap-2">
                      <h4 class="text-sm font-bold">{$_('settings.backup')}</h4>

--- a/src/routes/api/test-log/+server.ts
+++ b/src/routes/api/test-log/+server.ts
@@ -1,0 +1,14 @@
+import { json } from '@sveltejs/kit';
+import { logger } from '$lib/server/logger';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async () => {
+    logger.info('Test Log: This is an INFO message from the server.');
+    logger.warn('Test Log: This is a WARNING message from the server.', { riskLevel: 'medium' });
+    logger.error('Test Log: This is an ERROR message from the server.', { errorId: 123, stack: 'mock stack trace' });
+
+    // Auch ein normales console.log testen, falls wir den Interceptor aktivieren
+    console.log('Test Log: This is a standard console.log from the server.');
+
+    return json({ success: true, message: 'Logs generated' });
+};


### PR DESCRIPTION
- Intercept global server console.log/warn/error in src/hooks.server.ts to capture all server activity
- Add POST /api/test-log endpoint to generate test logs
- Add 'Trigger Server Log' button in Settings > System tab to verify functionality
- Ensure all logs are streamed to browser console via existing SSE connection