### PR TITLE
feat: Display indicator parameters in Technicals Panel

### DIFF
--- a/src/services/technicalsService.test.ts
+++ b/src/services/technicalsService.test.ts
@@ -61,9 +61,11 @@ describe('technicalsService', () => {
         const result = technicalsService.calculateTechnicals(klines, settings);
         const names = result.oscillators.map(o => o.name);
 
-        expect(names.some(n => n.includes('CCI (10)'))).toBe(true);
-        // The service now outputs `ADX (Smooth, DI Len)` -> `ADX (10, 10)`
+        // Updated expectations to match new naming convention (Value, Smoothing/Signal)
+        // CCI default smoothing is 14 if not provided
+        expect(names.some(n => n.includes('CCI (10, 14)'))).toBe(true);
         expect(names.some(n => n.includes('ADX (10, 10)'))).toBe(true);
         expect(names.some(n => n.includes('Momentum (5)'))).toBe(true);
+        expect(names.some(n => n.includes('Awesome Osc. (2, 5)'))).toBe(true);
     });
 });

--- a/src/services/technicalsService.ts
+++ b/src/services/technicalsService.ts
@@ -62,11 +62,12 @@ export const technicalsService = {
 
         // 1. RSI
         const rsiLen = settings?.rsi?.length || 14;
+        const rsiSigLen = settings?.rsi?.signalLength || 14;
         const rsiSource = getSource(settings?.rsi?.source || 'close');
         const rsiVal = indicators.calculateRSI(rsiSource, rsiLen);
 
         oscillators.push({
-            name: `RSI (${rsiLen})`,
+            name: `RSI (${rsiLen}, ${rsiSigLen})`,
             value: rsiVal ?? new Decimal(0),
             action: this.getRsiAction(rsiVal)
         });
@@ -170,7 +171,7 @@ export const technicalsService = {
         else if (cciVal.gt(cciThreshold)) cciAction = 'Sell';
 
         oscillators.push({
-            name: `CCI (${cciLen})`,
+            name: `CCI (${cciLen}, ${cciSmoothLen})`,
             value: cciVal,
             signal: cciSignalVal,
             action: cciAction
@@ -211,7 +212,7 @@ export const technicalsService = {
         else if (aoVal.lt(0)) aoAction = 'Sell';
 
         oscillators.push({
-            name: `Awesome Osc.`,
+            name: `Awesome Osc. (${aoFast}, ${aoSlow})`,
             value: aoVal,
             action: aoAction
         });
@@ -266,7 +267,7 @@ export const technicalsService = {
         }
 
         oscillators.push({
-            name: `MACD (${macdFast}, ${macdSlow})`,
+            name: `MACD (${macdFast}, ${macdSlow}, ${macdSig})`,
             value: macdVal,
             signal: macdSignalVal,
             action: macdAction


### PR DESCRIPTION
- Updated `technicalsService.ts` to include detailed configuration parameters (e.g., smoothing lengths, signal lengths) in the generated indicator names (e.g., `RSI (14, 14)` instead of `RSI (14)`).
- Updated `technicalsService.test.ts` to verify the new naming convention.