### PR TITLE
fix: provide both any and maskable pwa icons

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -18,6 +18,18 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
- Updated `static/site.webmanifest` to explicitly list icon entries for both `"purpose": "any"` and `"purpose": "maskable"`.
- This dual configuration ensures Android has a valid candidate for adaptive splash screens (fixing the white background issue) while maintaining compatibility for standard shortcuts.