### PR TITLE
feat: Add setting to hide indicator parameters in UI

### DIFF
--- a/src/components/settings/SettingsModal.svelte
+++ b/src/components/settings/SettingsModal.svelte
@@ -16,6 +16,7 @@
     let autoFetchBalance: boolean;
     let showSidebars: boolean;
     let showTechnicals: boolean;
+    let hideIndicatorParams: boolean;
     let hideUnfilledOrders: boolean;
     let feePreference: 'maker' | 'taker';
     let hotkeyMode: HotkeyMode;
@@ -117,6 +118,7 @@
             autoFetchBalance = $settingsStore.autoFetchBalance;
             showSidebars = $settingsStore.showSidebars;
             showTechnicals = $settingsStore.showTechnicals;
+            hideIndicatorParams = $settingsStore.hideIndicatorParams;
             hideUnfilledOrders = $settingsStore.hideUnfilledOrders;
             positionViewMode = $settingsStore.positionViewMode || 'detailed';
             feePreference = $settingsStore.feePreference;
@@ -189,6 +191,7 @@
             autoFetchBalance,
             showSidebars,
             showTechnicals,
+            hideIndicatorParams,
             hideUnfilledOrders,
             feePreference,
             hotkeyMode,
@@ -813,6 +816,16 @@
 
                 {:else if activeTab === 'indicators'}
                     <div class="flex flex-col gap-4 overflow-x-hidden" role="tabpanel" id="tab-indicators">
+
+                         <!-- Indicator Params Toggle (Global Display) -->
+                        <label class="flex items-center justify-between p-3 rounded bg-[var(--bg-tertiary)] hover:bg-[var(--bg-primary)] cursor-pointer border border-[var(--border-color)]">
+                             <div class="flex flex-col">
+                                <span class="text-sm font-bold">{$_('settings.hideIndicatorParams') || 'Hide Indicator Parameters'}</span>
+                                <span class="text-xs text-[var(--text-secondary)]">Show cleaner names (e.g. "RSI" instead of "RSI (14)") in panels.</span>
+                            </div>
+                            <input type="checkbox" bind:checked={hideIndicatorParams} class="accent-[var(--accent-color)] h-4 w-4 rounded" />
+                        </label>
+
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
                             <!-- Left Column -->

--- a/src/components/shared/TechnicalsPanel.svelte
+++ b/src/components/shared/TechnicalsPanel.svelte
@@ -27,6 +27,7 @@
     $: timeframe = $tradeStore.analysisTimeframe || '1h';
     $: showPanel = $settingsStore.showTechnicals && isVisible;
     $: indicatorSettings = $indicatorStore;
+    $: hideParams = $settingsStore.hideIndicatorParams;
 
     // React to Market Store updates for real-time processing
     $: wsData = symbol ? ($marketStore[symbol] || $marketStore[symbol.replace('P', '')] || $marketStore[symbol + 'USDT']) : null;
@@ -185,6 +186,13 @@
         return val.toDecimalPlaces(4).toString();
     }
 
+    function formatIndicatorName(name: string, hide: boolean): string {
+        if (hide) {
+             return name.split('(')[0].trim();
+        }
+        return name;
+    }
+
     function toggleTimeframePopup() {
         showTimeframePopup = !showTimeframePopup;
     }
@@ -297,7 +305,7 @@
                 <h4 class="text-xs font-bold text-[var(--text-secondary)] uppercase">Oscillators</h4>
                 <div class="text-xs grid grid-cols-[1fr_auto_auto] gap-x-4 gap-y-1">
                     {#each data.oscillators as osc}
-                        <span class="text-[var(--text-primary)]">{osc.name}</span>
+                        <span class="text-[var(--text-primary)]">{formatIndicatorName(osc.name, hideParams)}</span>
                         <span class="text-right text-[var(--text-secondary)] font-mono">{formatVal(osc.value)}</span>
                         <span class="text-right font-bold {getActionColor(osc.action)}">{osc.action}</span>
                     {/each}
@@ -307,7 +315,7 @@
                 <h4 class="text-xs font-bold text-[var(--text-secondary)] uppercase">Moving Averages</h4>
                 <div class="text-xs grid grid-cols-[1fr_auto_auto] gap-x-4 gap-y-1">
                     {#each data.movingAverages as ma}
-                        <span class="text-[var(--text-primary)]">{ma.name}</span>
+                        <span class="text-[var(--text-primary)]">{formatIndicatorName(ma.name, hideParams)}</span>
                         <span class="text-right text-[var(--text-secondary)] font-mono">{formatVal(ma.value)}</span>
                         <span class="text-right font-bold {getActionColor(ma.action)}">{ma.action}</span>
                     {/each}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -36,6 +36,7 @@ export interface Settings {
     // Indicator & Timeframe Settings
     favoriteTimeframes: string[];
     syncRsiTimeframe: boolean;
+    hideIndicatorParams: boolean;
 
     // ImgBB Settings
     imgbbApiKey: string;
@@ -84,6 +85,7 @@ const defaultSettings: Settings = {
     },
     favoriteTimeframes: ['5m', '15m', '1h', '4h'],
     syncRsiTimeframe: true,
+    hideIndicatorParams: false,
     imgbbApiKey: '71a5689343bb63d5c85a76e4375f1d0b',
     imgbbExpiration: 0,
     isDeepDiveUnlocked: false,
@@ -189,6 +191,7 @@ function loadSettingsFromLocalStorage(): Settings {
             apiKeys: settings.apiKeys,
             favoriteTimeframes: settings.favoriteTimeframes ?? defaultSettings.favoriteTimeframes,
             syncRsiTimeframe: settings.syncRsiTimeframe ?? defaultSettings.syncRsiTimeframe,
+            hideIndicatorParams: settings.hideIndicatorParams ?? defaultSettings.hideIndicatorParams,
             imgbbApiKey: settings.imgbbApiKey,
             imgbbExpiration: settings.imgbbExpiration,
             isDeepDiveUnlocked: settings.isDeepDiveUnlocked,


### PR DESCRIPTION
    Adds a new toggle in Settings > Technicals to hide parameters from indicator
    labels (e.g., displaying "RSI" instead of "RSI (14)"). This applies to
    both the Market Overview and Technicals Panel components.

    Changes:
    - Added `hideIndicatorParams` to `settingsStore`.
    - Added "Hide Indicator Parameters" toggle in `SettingsModal`.
    - Updated `MarketOverview` and `TechnicalsPanel` to respect the setting.
    - Added localization keys.