### PR TITLE
fix(tracking): use standard Matomo tracking and fix domain

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -10,6 +10,7 @@ declare global {
 	}
 	interface Window {
 		_mtm: unknown[];
+		_paq: unknown[];
 	}
 }
 

--- a/src/services/trackingService.ts
+++ b/src/services/trackingService.ts
@@ -1,9 +1,8 @@
 // src/services/trackingService.ts
 
 /**
- * Pushes a custom event to the Matomo Tag Manager data layer.
- * This can be used to track events that are not simple clicks,
- * such as successful calculations or API calls.
+ * Pushes a custom event to the Matomo tracking queue (standard tracking)
+ * or Matomo Tag Manager data layer (if available).
  *
  * @param category The category of the event (e.g., 'Calculation').
  * @param action The action of the event (e.g., 'Success').
@@ -11,26 +10,37 @@
  * @param value An optional numeric value for the event.
  */
 export function trackCustomEvent(category: string, action: string, name?: string, value?: number) {
-  if (!window._mtm) {
-    // Matomo Tag Manager is not available, do nothing.
-    // This can happen if it's blocked or not yet loaded.
-    console.warn('Matomo Tag Manager not available. Skipping custom event.');
+  // Try standard Matomo tracking first (_paq)
+  if (window._paq) {
+    const eventData: (string | number)[] = ['trackEvent', category, action];
+    if (name) eventData.push(name);
+    if (value !== undefined) eventData.push(value);
+
+    window._paq.push(eventData);
     return;
   }
 
-  const eventData: { [key: string]: string | number } = {
-    event: 'customEvent',
-    'custom-event-category': category,
-    'custom-event-action': action,
-  };
+  // Fallback to Matomo Tag Manager (_mtm) if available
+  if (window._mtm) {
+    const eventData: { [key: string]: string | number } = {
+      event: 'customEvent',
+      'custom-event-category': category,
+      'custom-event-action': action,
+    };
 
-  if (name) {
-    eventData['custom-event-name'] = name;
+    if (name) {
+      eventData['custom-event-name'] = name;
+    }
+
+    if (value !== undefined) {
+      eventData['custom-event-value'] = value;
+    }
+
+    window._mtm.push(eventData);
+    return;
   }
 
-  if (value !== undefined) {
-    eventData['custom-event-value'] = value;
-  }
-
-  window._mtm.push(eventData);
+  // Tracking not available
+  // Reduced logging level to debug to avoid console spam in dev environments without tracking
+  // console.debug('Matomo tracking not available. Skipping custom event.');
 }


### PR DESCRIPTION
Replaces the Matomo Tag Manager initialization (which pointed to a deprecated domain `stat.ufjdn.com`) with the standard Matomo tracking code pointing directly to `s.cachy.app` with Site ID 13. Updates `trackingService.ts` to prioritize standard tracking (`_paq`) over Tag Manager (`_mtm`) to ensure events are tracked correctly. Also updates `src/app.d.ts` to include types for `_paq` and removes the outdated `noscript` iframe from `app.html`.