### PR TITLE
Disable Chart.js data labels globally

### DIFF
--- a/src/lib/chartSetup.ts
+++ b/src/lib/chartSetup.ts
@@ -46,3 +46,8 @@ export async function initZoomPlugin() {
 ChartJS.defaults.color = '#94a3b8'; // text-slate-400
 ChartJS.defaults.borderColor = '#334155'; // border-slate-700
 ChartJS.defaults.scale.grid.color = '#334155';
+
+// Disable datalabels globally by default
+ChartJS.defaults.set('plugins.datalabels', {
+  display: false
+});


### PR DESCRIPTION
Disables the `chartjs-plugin-datalabels` annotations by default in `src/lib/chartSetup.ts`. This removes visual clutter from charts, specifically in the Journal view, addressing user feedback that local component configurations were ineffective. Annotations can still be enabled on a per-chart basis if needed.