### PR TITLE
Fix: Ensure mobile interactivity for Trade Setup input

### DIFF
--- a/src/components/inputs/TradeSetupInputs.svelte
+++ b/src/components/inputs/TradeSetupInputs.svelte
@@ -248,14 +248,14 @@
           onboardingService.trackFirstInput();
         }}
         onkeydown={handleKeyDownSymbol}
-        class="input-field w-full px-4 py-2 rounded-md pr-10 relative z-10"
+        class="input-field w-full px-4 py-2 rounded-md pr-10 relative z-30 touch-manipulation"
         placeholder={$_("dashboard.tradeSetupInputs.symbolPlaceholder")}
         autocomplete="off"
         inputmode="text"
       />
       <button
         type="button"
-        class="price-fetch-btn absolute top-1/2 right-2 -translate-y-1/2 z-20 {isPriceFetching
+        class="price-fetch-btn absolute top-1/2 right-2 -translate-y-1/2 z-40 {isPriceFetching
           ? 'animate-spin'
           : ''}"
         title={$_("dashboard.tradeSetupInputs.fetchPriceTitle")}


### PR DESCRIPTION
- Increased z-index of input field to 30 and fetch button to 40 to overcome potential overlaps from sibling components (like PortfolioInputs or TagInputs).
- Added `touch-manipulation` class to disable double-tap zoom on the input.
- Retained `isolate` and `inputmode` improvements from previous iteration.
- Verified that no elements overlap the input center in test environment.