### PR TITLE
Add option to force English technical terms in German locale

### DIFF
--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -28,7 +28,13 @@ const TECHNICAL_KEYS = [
   "dashboard.generalInputs.shortButton",
   "dashboard.tradeSetupInputs.entryPricePlaceholder",
   "dashboard.summaryResults.breakEvenPriceLabel",
+  "dashboard.summaryResults.entryFeeLabel",
+  "dashboard.summaryResults.estimatedLiquidationPriceLabel",
+  "dashboard.summaryResults.requiredMarginLabel",
+  "dashboard.summaryResults.maxNetLossLabel",
+  "dashboard.exitFeeLabel",
   "dashboard.visualBar.entry",
+  "dashboard.visualBar.netProfitLabel",
 
   // Journal
   "journal.table.entry",


### PR DESCRIPTION
- Implemented hybrid locale `de-tech` in `src/locales/i18n.ts` that merges English values for specific technical keys into the German dictionary.
- Added `forceEnglishTechnicalTerms` setting to `settingsStore`.
- Added toggle for this setting in `SettingsModal` (General Tab), visible only when German is selected.
- Defined extensive list of technical keys including Entry, Exit, TP, SL, Fees, Margins, and Indicator names.