### PR TITLE
fix: Allow Configurable News API Endpoint & Relax Filters

### DIFF
--- a/src/components/settings/tabs/GeneralTab.svelte
+++ b/src/components/settings/tabs/GeneralTab.svelte
@@ -270,6 +270,19 @@
                 title="Get Key"
               >Get Key</a>
           </div>
+          <!-- Endpoint Config for CryptoPanic -->
+          <div class="mt-1">
+             <label for="cryptopanic-url" class="text-[10px] text-[var(--text-tertiary)] flex items-center gap-1 cursor-pointer">
+                <span>Advanced: Custom API Endpoint</span>
+             </label>
+             <input
+                id="cryptopanic-url"
+                type="text"
+                class="input-field p-1.5 rounded border border-[var(--border-color)] bg-[var(--bg-tertiary)] text-xs w-full mt-1"
+                placeholder="https://cryptopanic.com/api/v1/posts/"
+                bind:value={settingsState.cryptoPanicBaseUrl}
+             />
+          </div>
         </div>
 
         <div class="flex flex-col gap-1">

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -51,8 +51,8 @@ export const newsService = {
     // Prioritize CryptoPanic for crypto
     if (cryptoPanicApiKey) {
       try {
+        // Relaxed filter to ensure data availability
         const params: any = {
-          filter: "important",
           public: "true",
         };
         if (symbol) {
@@ -67,6 +67,7 @@ export const newsService = {
           body: JSON.stringify({
             source: "cryptopanic",
             apiKey: cryptoPanicApiKey,
+            baseUrl: settingsState.cryptoPanicBaseUrl,
             params,
           }),
         });

--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -86,6 +86,7 @@ export interface Settings {
     minChatProfitFactor: number;
     fontFamily: string;
     cryptoPanicApiKey?: string;
+    cryptoPanicBaseUrl?: string;
     newsApiKey?: string;
     enableNewsAnalysis: boolean;
 }
@@ -150,6 +151,7 @@ const defaultSettings: Settings = {
     minChatProfitFactor: 0.0,
     fontFamily: "Inter",
     cryptoPanicApiKey: "",
+    cryptoPanicBaseUrl: "https://cryptopanic.com/api/v1/posts/",
     newsApiKey: "",
     enableNewsAnalysis: false,
 };
@@ -216,6 +218,7 @@ class SettingsManager {
     minChatProfitFactor = $state<number>(defaultSettings.minChatProfitFactor);
     fontFamily = $state<string>(defaultSettings.fontFamily);
     cryptoPanicApiKey = $state<string | undefined>(defaultSettings.cryptoPanicApiKey);
+    cryptoPanicBaseUrl = $state<string | undefined>(defaultSettings.cryptoPanicBaseUrl);
     newsApiKey = $state<string | undefined>(defaultSettings.newsApiKey);
     enableNewsAnalysis = $state<boolean>(defaultSettings.enableNewsAnalysis);
 
@@ -300,6 +303,7 @@ class SettingsManager {
             this.minChatProfitFactor = merged.minChatProfitFactor;
             this.fontFamily = merged.fontFamily;
             this.cryptoPanicApiKey = merged.cryptoPanicApiKey;
+            this.cryptoPanicBaseUrl = merged.cryptoPanicBaseUrl;
             this.newsApiKey = merged.newsApiKey;
             this.enableNewsAnalysis = merged.enableNewsAnalysis;
 
@@ -387,6 +391,7 @@ class SettingsManager {
             minChatProfitFactor: this.minChatProfitFactor,
             fontFamily: this.fontFamily,
             cryptoPanicApiKey: this.cryptoPanicApiKey,
+            cryptoPanicBaseUrl: this.cryptoPanicBaseUrl,
             newsApiKey: this.newsApiKey,
             enableNewsAnalysis: this.enableNewsAnalysis,
         };


### PR DESCRIPTION
- Added `cryptoPanicBaseUrl` to Settings to allow custom API endpoints (e.g. proxies).
- Added input field for Custom Endpoint in General Tab (CryptoPanic section).
- Updated Proxy and Service to respect the custom Base URL.
- Removed `filter: "important"` from CryptoPanic requests to ensure news data is returned even for less volatile assets.