### PR TITLE
Add option to force English technical terms in German locale

### DIFF
--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -17,7 +17,6 @@ import * as de from "./locales/de.json";
 // We use dot notation strings which we will resolve against the English dictionary.
 const TECHNICAL_KEYS = [
   // Dashboard & Trading
-  "dashboard.entry",
   "dashboard.type",
   "dashboard.price",
   "dashboard.amount",
@@ -37,6 +36,7 @@ const TECHNICAL_KEYS = [
   "dashboard.visualBar.netProfitLabel",
 
   // Journal
+  "journal.entry",
   "journal.table.entry",
   "journal.table.exit",
   "journal.table.type",


### PR DESCRIPTION
- Implemented hybrid locale `de-tech` in `src/locales/i18n.ts` that merges English values for specific technical keys into the German dictionary.
- Added `forceEnglishTechnicalTerms` setting to `settingsStore`.
- Added toggle for this setting in `SettingsModal` (General Tab), visible only when German is selected.
- Defined extensive list of technical keys including Entry, Exit, TP, SL, Fees, Margins, and Indicator names.
- Fixed an issue where `dashboard.entry` was incorrectly referenced; replaced with valid keys.