### PR TITLE
fix(api): update Nitter instances and use direct x.com links

### DIFF
--- a/src/routes/api/rss-fetch/+server.ts
+++ b/src/routes/api/rss-fetch/+server.ts
@@ -104,10 +104,18 @@ function scrapeNitterHTML(html: string, baseUrl: string): any[] {
 
     const tweetId = hashString(textContent);
 
+    // Try to find the tweet link
+    const linkMatch = block.match(/<a\s+[^>]*href=["']([^"']+)["'][^>]*class=["'][^"']*tweet-link[^"']*["']/);
+    let tweetUrl = `https://x.com/search?q=${encodeURIComponent(textContent.substring(0, 50))}`;
+
+    if (linkMatch && linkMatch[1]) {
+      tweetUrl = `https://x.com${linkMatch[1]}`;
+    }
+
     items.push({
       id: tweetId,
       title: textContent.substring(0, 100) + (textContent.length > 100 ? "..." : ""),
-      url: `https://${baseUrl}`,
+      url: tweetUrl,
       source: baseUrl,
       published_at: new Date().toISOString(),
       description: textContent


### PR DESCRIPTION
Updates the list of Nitter instances in `src/routes/api/rss-fetch/+server.ts` to a user-provided working set. Modifies the Nitter scraper to extract direct tweet links or construct x.com search URLs, ensuring users are directed to the original platform instead of proxy instances. Adds graceful error handling for fetch failures to prevent 500 errors.