### PR TITLE
fix(news): resolve app freeze, update nitter instances, and improve l…

### DIFF
--- a/src/components/shared/NewsSentimentPanel.svelte
+++ b/src/components/shared/NewsSentimentPanel.svelte
@@ -47,21 +47,19 @@
     !analysis ? 50 : ((analysis.score + 1) / 2) * 100,
   );
 
-  onMount(() => {
-    // Only load if enabled and keys are present
-    if (
-      settingsState.enableNewsAnalysis &&
-      (settingsState.cryptoPanicApiKey || settingsState.newsApiKey)
-    ) {
-      newsStore.refresh(symbol);
-    }
-  });
-
   $effect(() => {
     // React to symbol changes automatically
-    if (settingsState.enableNewsAnalysis) {
-      // Trigger refresh when symbol changes. newsStore handles deduplication.
-      newsStore.refresh(symbol);
+    if (
+      settingsState.enableNewsAnalysis &&
+      symbol // Ensure symbol is defined
+    ) {
+      untrack(() => {
+        // Only trigger if not already loading for this symbol to avoid race conditions
+        // although store handles deduplication, we want to be safe in the effect
+        if (!newsStore.isLoading || newsStore.lastSymbol !== symbol) {
+           newsStore.refresh(symbol);
+        }
+      });
     }
   });
 

--- a/src/services/rssParserService.ts
+++ b/src/services/rssParserService.ts
@@ -18,13 +18,18 @@ export const rssParserService = {
         ? { xCmd: { type: input.split(":")[1], value: input.split(":")[2] } }
         : { url: input };
 
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 15000); // 15s client timeout
+
       const response = await fetch("/api/rss-fetch", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(body),
+        signal: controller.signal,
       });
+      clearTimeout(timeoutId);
 
       if (!response.ok) {
         return [];

--- a/src/stores/news.svelte.ts
+++ b/src/stores/news.svelte.ts
@@ -25,6 +25,11 @@ class NewsStore {
   async refresh(symbol?: string, force = false) {
     if (!settingsState.enableNewsAnalysis) return;
 
+    // Prevent concurrent loads for the same symbol
+    if (this.isLoading && symbol === this.lastSymbol && !force) {
+        return;
+    }
+
     // Avoid redundant loads for same symbol unless forced
     if (
       !force &&


### PR DESCRIPTION
…inks

- Fixes infinite loop/freeze issue by adding client-side timeouts (15s) in `rssParserService.ts` and concurrency guards in `newsStore.svelte.ts` and `NewsSentimentPanel.svelte`.
- Updates `src/routes/api/rss-fetch/+server.ts` with a working list of Nitter instances.
- Enhances Nitter scraping to provide direct x.com links.
- Implements graceful error handling to prevent 500 errors on fetch failure.