### PR TITLE
Add dynamic Three.js Galaxy background

### DIFF
--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -86,8 +86,6 @@ export interface GalaxySettings {
   randomness: number;
   randomnessPower: number;
   concentrationPower: number;
-  insideColor: string; // Hex
-  outsideColor: string; // Hex
 }
 
 export interface Settings {
@@ -362,8 +360,6 @@ const defaultSettings: Settings = {
     randomness: 1.0,
     randomnessPower: 8.0,
     concentrationPower: 1.5,
-    insideColor: "#6366f1",
-    outsideColor: "#8b5cf6",
   },
   enableNetworkLogs: false,
   logSettings: {


### PR DESCRIPTION
- Install `three` dependency
- Implement `ThreeBackground.svelte` with dynamic theme coloring via CSS variables
- Update Settings store to include galaxy parameters (removed hardcoded colors)
- Add "Galaxy (3D)" option to Visuals settings tab
- Integrate into `BackgroundRenderer.svelte`