### PR TITLE
Fix DecimalError crash on 'MARKET' string in API orders

### DIFF
--- a/src/routes/api/orders/+server.ts
+++ b/src/routes/api/orders/+server.ts
@@ -310,17 +310,17 @@ async function fetchBitunixPendingOrders(apiKey: string, apiSecret: string): Pro
     symbol: o.symbol,
     type: o.type,
     side: o.side,
-    price: new Decimal(o.price || "0").toNumber(), // Precision: Use priceStr
+    price: safeDecimal(o.price).toNumber(), // Precision: Use priceStr
     priceStr: formatApiNum(o.price) || "0",
-    amount: new Decimal(o.qty || "0").toNumber(), // Precision: Use amountStr
+    amount: safeDecimal(o.qty).toNumber(), // Precision: Use amountStr
     amountStr: formatApiNum(o.qty) || "0",
-    filled: new Decimal(o.tradeQty || "0").toNumber(),
+    filled: safeDecimal(o.tradeQty).toNumber(),
     filledStr: formatApiNum(o.tradeQty) || "0",
     status: o.status || "UNKNOWN",
     time: o.ctime || 0,
-    fee: new Decimal(o.fee || "0").toNumber(),
+    fee: safeDecimal(o.fee).toNumber(),
     feeStr: formatApiNum(o.fee) || "0",
-    realizedPNL: new Decimal(o.realizedPNL || "0").toNumber(),
+    realizedPNL: safeDecimal(o.realizedPNL).toNumber(),
     realizedPNLStr: formatApiNum(o.realizedPNL) || "0",
   }));
 }
@@ -335,6 +335,15 @@ function cleanPayload<T extends object>(payload: T): T {
     }
   });
   return cleaned;
+}
+
+function safeDecimal(value: any): Decimal {
+  try {
+    if (value === null || value === undefined) return new Decimal(0);
+    return new Decimal(value);
+  } catch (e) {
+    return new Decimal(0);
+  }
 }
 
 async function fetchBitunixHistoryOrders(apiKey: string, apiSecret: string, limit = 20): Promise<NormalizedOrder[]> {
@@ -371,17 +380,17 @@ async function fetchBitunixHistoryOrders(apiKey: string, apiSecret: string, limi
     symbol: o.symbol,
     type: o.type,
     side: o.side,
-    price: new Decimal(o.price || "0").toNumber(),
+    price: safeDecimal(o.price).toNumber(),
     priceStr: formatApiNum(o.price) || "0",
-    amount: new Decimal(o.qty || "0").toNumber(),
+    amount: safeDecimal(o.qty).toNumber(),
     amountStr: formatApiNum(o.qty) || "0",
-    filled: new Decimal(o.tradeQty || "0").toNumber(),
+    filled: safeDecimal(o.tradeQty).toNumber(),
     filledStr: formatApiNum(o.tradeQty) || "0",
-    avgPrice: new Decimal(o.avgPrice || o.averagePrice || "0").toNumber(),
+    avgPrice: safeDecimal(o.avgPrice || o.averagePrice).toNumber(),
     avgPriceStr: formatApiNum(o.avgPrice || o.averagePrice) || "0",
-    realizedPNL: new Decimal(o.realizedPNL || "0").toNumber(),
+    realizedPNL: safeDecimal(o.realizedPNL).toNumber(),
     realizedPNLStr: formatApiNum(o.realizedPNL) || "0",
-    fee: new Decimal(o.fee || "0").toNumber(),
+    fee: safeDecimal(o.fee).toNumber(),
     feeStr: formatApiNum(o.fee) || "0",
     status: o.status || "UNKNOWN",
     time: o.ctime || 0,
@@ -495,17 +504,17 @@ async function fetchBitgetPendingOrders(
         symbol: o.symbol,
         type: o.orderType,
         side: o.side, // open_long etc
-        price: new Decimal(o.price || "0").toNumber(),
+        price: safeDecimal(o.price).toNumber(),
         priceStr: formatApiNum(o.price) || "0",
-        amount: new Decimal(o.size || "0").toNumber(),
+        amount: safeDecimal(o.size).toNumber(),
         amountStr: formatApiNum(o.size) || "0",
-        filled: new Decimal(o.filledQty || "0").toNumber(),
+        filled: safeDecimal(o.filledQty).toNumber(),
         filledStr: formatApiNum(o.filledQty) || "0",
         status: o.status, // new, partial_fill
         time: parseInt(o.cTime),
-        fee: new Decimal(o.fee || "0").toNumber(),
+        fee: safeDecimal(o.fee).toNumber(),
         feeStr: formatApiNum(o.fee) || "0",
-        realizedPNL: new Decimal(o.totalProfits || "0").toNumber(),
+        realizedPNL: safeDecimal(o.totalProfits).toNumber(),
         realizedPNLStr: formatApiNum(o.totalProfits) || "0",
     }));
 }
@@ -548,19 +557,19 @@ async function fetchBitgetHistoryOrders(
         symbol: o.symbol,
         type: o.orderType,
         side: o.side,
-        price: new Decimal(o.price || "0").toNumber(),
+        price: safeDecimal(o.price).toNumber(),
         priceStr: formatApiNum(o.price) || "0",
-        amount: new Decimal(o.size || "0").toNumber(),
+        amount: safeDecimal(o.size).toNumber(),
         amountStr: formatApiNum(o.size) || "0",
-        filled: new Decimal(o.filledQty || "0").toNumber(),
+        filled: safeDecimal(o.filledQty).toNumber(),
         filledStr: formatApiNum(o.filledQty) || "0",
-        avgPrice: new Decimal(o.priceAvg || "0").toNumber(),
+        avgPrice: safeDecimal(o.priceAvg).toNumber(),
         avgPriceStr: formatApiNum(o.priceAvg) || "0",
         status: o.state, // filled, canceled
         time: parseInt(o.cTime),
-        fee: new Decimal(o.fee || "0").toNumber(),
+        fee: safeDecimal(o.fee).toNumber(),
         feeStr: formatApiNum(o.fee) || "0",
-        realizedPNL: new Decimal(o.totalProfits || "0").toNumber(),
+        realizedPNL: safeDecimal(o.totalProfits).toNumber(),
         realizedPNLStr: formatApiNum(o.totalProfits) || "0",
     }));
 }

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { parseDateString, parseTimestamp, escapeHtml, parseAiValue } from "./utils";
+import { parseDateString, parseTimestamp, escapeHtml, parseAiValue, parseDecimal } from "./utils";
 
 describe("parseTimestamp", () => {
   const NOW = Date.now();
@@ -179,5 +179,38 @@ describe("parseAiValue", () => {
     expect(parseAiValue(null as any)).toBe(0);
     expect(parseAiValue(undefined as any)).toBe(0);
     expect(parseAiValue("")).toBe(0);
+  });
+});
+
+describe("parseDecimal", () => {
+  it("should return Decimal(0) for null/undefined", () => {
+    expect(parseDecimal(null).toNumber()).toBe(0);
+    expect(parseDecimal(undefined).toNumber()).toBe(0);
+  });
+
+  it("should parse valid numeric strings", () => {
+    expect(parseDecimal("123.45").toNumber()).toBe(123.45);
+    expect(parseDecimal("0").toNumber()).toBe(0);
+    expect(parseDecimal("-10.5").toNumber()).toBe(-10.5);
+  });
+
+  it("should parse numbers", () => {
+    expect(parseDecimal(100).toNumber()).toBe(100);
+  });
+
+  it("should handle English thousands separators", () => {
+    // 1,234.56 -> 1234.56
+    expect(parseDecimal("1,234.56").toNumber()).toBe(1234.56);
+  });
+
+  it("should handle German format", () => {
+    // 1.234,56 -> 1234.56
+    expect(parseDecimal("1.234,56").toNumber()).toBe(1234.56);
+  });
+
+  it("should handle invalid strings (like 'MARKET') by returning 0", () => {
+    expect(parseDecimal("MARKET").toNumber()).toBe(0);
+    expect(parseDecimal("LIMIT").toNumber()).toBe(0);
+    expect(parseDecimal("abc").toNumber()).toBe(0);
   });
 });


### PR DESCRIPTION
This PR fixes a runtime crash in the `/api/orders` endpoint where `new Decimal("MARKET")` was throwing an error.

The Bitunix API occasionally returns the string "MARKET" in the `price` field for market orders, causing `decimal.js` to throw an invalid argument error.

Changes:
1.  Modified `src/routes/api/orders/+server.ts` to introduce a `safeDecimal` helper function.
2.  Refactored `fetchBitunixPendingOrders`, `fetchBitunixHistoryOrders`, `fetchBitgetPendingOrders`, and `fetchBitgetHistoryOrders` to use `safeDecimal` instead of `new Decimal` directly.
3.  `safeDecimal` wraps `new Decimal()` in a try-catch block and returns `Decimal(0)` on failure, effectively handling "MARKET" or other non-numeric strings safely.
4.  Added unit tests for `parseDecimal` in `src/utils/utils.test.ts` to ensure the shared utility also handles such cases correctly in the future (though `+server.ts` uses a local strict implementation).

---
*PR created automatically by Jules for task [14768706188262499697](https://jules.google.com/task/14768706188262499697) started by @mydcc*