### PR TITLE
feat: Add interactive 3D Galaxy background

### DIFF
--- a/src/themes.css
+++ b/src/themes.css
@@ -155,6 +155,9 @@
    Meteorite Theme - Vollständige Farbpalette
    ================================================================= */
 .theme-meteorite {
+  /* --- Galaxy Overrides --- */
+  --galaxy-bg: #03020a;
+
   /* --- Core Colors --- */
   --core-purple: #4e21e7;
   --core-meteorite: #433f65;
@@ -254,6 +257,9 @@
    Steel Theme - Vollständige Farbpalette
    ================================================================= */
 .theme-steel {
+  /* --- Galaxy Overrides --- */
+  --galaxy-bg: #02040a;
+
   /* --- Core Colors --- */
   --core-purple: #4e21e7;
   --core-meteorite: #433f65;


### PR DESCRIPTION
- Add `ThreeBackground.svelte` component with configurable galaxy particles
- Integrate `three` and `@types/three` dependencies
- Add 'Galaxy (3D)' option to Visual Settings with parameter controls
- Implement dynamic theming using CSS variable resolution (`resolveColor`)
- Add theme-specific CSS overrides for Steel and Meteorite themes
- Persist galaxy settings in `settings.svelte.ts`