### PR TITLE
Enforce Decimal.js usage in API and Frontend

### DIFF
--- a/src/components/inputs/PortfolioInputs.svelte
+++ b/src/components/inputs/PortfolioInputs.svelte
@@ -115,7 +115,7 @@
         throw new Error(data.error || "Failed to fetch balance");
       }
 
-      if (typeof data.balance === "number") {
+      if (typeof data.balance === "number" || typeof data.balance === "string") {
         tradeState.update((s) => ({ ...s, accountSize: data.balance }));
         if (!silent) {
           uiState.showFeedback("save"); // Show success feedback

--- a/src/components/shared/AccountSummary.svelte
+++ b/src/components/shared/AccountSummary.svelte
@@ -19,21 +19,22 @@
   import { formatDynamicDecimal } from "../../utils/utils";
   import { _ } from "../../locales/i18n";
   import AccountTooltip from "./AccountTooltip.svelte";
+  import { Decimal } from "decimal.js";
 
+  type FinancialValue = number | string | Decimal;
 
-  
   interface Props {
-    available?: number;
-    margin?: number;
-    pnl?: number;
+    available?: FinancialValue;
+    margin?: FinancialValue;
+    pnl?: FinancialValue;
     currency?: string;
     // Extended props
-    frozen?: number;
-    transfer?: number;
-    bonus?: number;
+    frozen?: FinancialValue;
+    transfer?: FinancialValue;
+    bonus?: FinancialValue;
     positionMode?: string;
-    crossUnrealizedPNL?: number;
-    isolationUnrealizedPNL?: number;
+    crossUnrealizedPNL?: FinancialValue;
+    isolationUnrealizedPNL?: FinancialValue;
   }
 
   let {
@@ -102,10 +103,10 @@
     >
     <span
       class="text-sm font-bold"
-      class:text-[var(--success-color)]={pnl > 0}
-      class:text-[var(--danger-color)]={pnl < 0}
+      class:text-[var(--success-color)]={new Decimal(pnl || 0).gt(0)}
+      class:text-[var(--danger-color)]={new Decimal(pnl || 0).lt(0)}
     >
-      {pnl > 0 ? "+" : ""}{formatDynamicDecimal(pnl, 2)}
+      {new Decimal(pnl || 0).gt(0) ? "+" : ""}{formatDynamicDecimal(pnl, 2)}
       {currency}
     </span>
   </div>

--- a/src/routes/api/account/+server.ts
+++ b/src/routes/api/account/+server.ts
@@ -25,6 +25,8 @@ import {
   generateBitgetSignature,
   validateBitgetKeys,
 } from "../../../utils/server/bitget";
+import { Decimal } from "decimal.js";
+import { formatApiNum } from "../../../utils/utils";
 
 export const POST: RequestHandler = async ({ request }) => {
   const { exchange, apiKey, apiSecret, passphrase } = await request.json();
@@ -112,23 +114,23 @@ async function fetchBitunixAccount(
 
   if (!data) throw new Error("No account data found");
 
-  const available = parseFloat(data.available || "0");
-  const margin = parseFloat(data.margin || "0");
-  const crossPnL = parseFloat(data.crossUnrealizedPNL || "0");
-  const isoPnL = parseFloat(data.isolationUnrealizedPNL || "0");
-  const totalPnL = crossPnL + isoPnL;
+  const available = new Decimal(data.available || "0");
+  const margin = new Decimal(data.margin || "0");
+  const crossPnL = new Decimal(data.crossUnrealizedPNL || "0");
+  const isoPnL = new Decimal(data.isolationUnrealizedPNL || "0");
+  const totalPnL = crossPnL.plus(isoPnL);
 
   return {
-    available,
-    margin,
-    totalUnrealizedPnL: totalPnL,
+    available: formatApiNum(available),
+    margin: formatApiNum(margin),
+    totalUnrealizedPnL: formatApiNum(totalPnL),
     marginCoin: data.marginCoin,
-    frozen: parseFloat(data.frozen || "0"),
-    transfer: parseFloat(data.transfer || "0"),
-    bonus: parseFloat(data.bonus || "0"),
+    frozen: formatApiNum(data.frozen),
+    transfer: formatApiNum(data.transfer),
+    bonus: formatApiNum(data.bonus),
     positionMode: data.positionMode,
-    crossUnrealizedPNL: crossPnL,
-    isolationUnrealizedPNL: isoPnL,
+    crossUnrealizedPNL: formatApiNum(crossPnL),
+    isolationUnrealizedPNL: formatApiNum(isoPnL),
   };
 }
 
@@ -162,12 +164,12 @@ async function fetchBitgetAccount(
 
     // Bitget fields: available, locked, equity, usdtEquity, unrealizedPL
     return {
-        available: parseFloat(data.available || "0"),
-        margin: parseFloat(data.locked || "0"), // locked margin?
-        totalUnrealizedPnL: parseFloat(data.unrealizedPL || "0"),
+        available: formatApiNum(data.available),
+        margin: formatApiNum(data.locked), // locked margin?
+        totalUnrealizedPnL: formatApiNum(data.unrealizedPL),
         marginCoin: data.marginCoin,
-        frozen: parseFloat(data.locked || "0"), // Bitget usually groups margin/frozen in locked
+        frozen: formatApiNum(data.locked), // Bitget usually groups margin/frozen in locked
         // Map other fields as needed
-        equity: parseFloat(data.equity || "0")
+        equity: formatApiNum(data.equity)
     };
 }


### PR DESCRIPTION
This PR addresses the "Tiefenprüfung" request to ensure `decimal.js` is used consistently across the system to prevent floating-point errors.

**Key Changes:**

1.  **Backend API (`src/routes/api/`)**:
    *   Refactored `account/+server.ts`, `positions/+server.ts`, and `balance/+server.ts`.
    *   Replaced native `parseFloat` and arithmetic operators (`+`, `-`) with `Decimal` equivalents (`new Decimal()`, `.plus()`, etc.).
    *   Updated these endpoints to return financial values as **strings** (using `formatApiNum` helper) instead of native numbers. This prevents precision loss during JSON serialization and transport.

2.  **Frontend Logic**:
    *   **`src/components/inputs/PortfolioInputs.svelte`**: Updated `handleFetchBalance` to accept string values for `data.balance` (previously threw an error if not a number).
    *   **`src/components/shared/AccountSummary.svelte`**: Relaxed `Props` interface to accept `string | number | Decimal` to accommodate the new API string responses.
    *   **`src/components/shared/AccountTooltip.svelte`**: Rewrote equity and margin level calculations to use `Decimal` chaining instead of native addition. This ensures that summing stringified numbers (e.g., "100" + "50") behaves mathematically correct ("150") rather than concatenating ("10050").

**Verification:**
*   Verified that `src/utils/utils.ts` contains the necessary `formatApiNum` and `formatDynamicDecimal` helpers.
*   Ran `vitest` on `src/tests/precision.test.ts` and `src/tests/decimal-enforcement.test.ts`, which passed successfully.
*   Verified that frontend components use helpers (`formatDynamicDecimal`) that safely handle the new string/Decimal types.

This ensures a robust, zero-tolerance approach to precision errors in financial data handling.

---
*PR created automatically by Jules for task [2381862325449950704](https://jules.google.com/task/2381862325449950704) started by @mydcc*