### PR TITLE
Fix OMS sync with WebSocket updates

### DIFF
--- a/src/services/bitunixWs.test.ts
+++ b/src/services/bitunixWs.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { bitunixWs } from './bitunixWs';
+import { omsService } from './omsService';
+
+// Mock dependencies
+vi.mock('./omsService', () => ({
+  omsService: {
+    updatePosition: vi.fn(),
+    updateOrder: vi.fn(),
+  }
+}));
+
+vi.mock('../stores/market.svelte', () => ({
+  marketState: {
+    updateSymbol: vi.fn(),
+    updateDepth: vi.fn(),
+    updateSymbolKlines: vi.fn(),
+    updateTelemetry: vi.fn(),
+    connectionStatus: 'connected',
+  }
+}));
+
+vi.mock('../stores/account.svelte', () => ({
+  accountState: {
+    updatePositionFromWs: vi.fn(),
+    updateOrderFromWs: vi.fn(),
+    updateBalanceFromWs: vi.fn(),
+  }
+}));
+
+vi.mock('../stores/settings.svelte', () => ({
+  settingsState: {
+    enableNetworkLogs: false,
+    apiKeys: {},
+    capabilities: { marketData: true },
+    apiProvider: 'bitunix',
+  }
+}));
+
+vi.mock('./connectionManager', () => ({
+  connectionManager: {
+    onProviderConnected: vi.fn(),
+    onProviderDisconnected: vi.fn(),
+  }
+}));
+
+vi.mock('./mdaService', () => ({
+  mdaService: {
+    normalizeTicker: vi.fn(),
+    normalizeKlines: vi.fn(),
+  }
+}));
+
+// Access private method via any
+const service = bitunixWs as any;
+
+describe('BitunixWebSocketService Sync', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should sync position updates to omsService', () => {
+        const msg = {
+            ch: 'position',
+            data: {
+                symbol: 'BTCUSDT',
+                side: 'LONG',
+                qty: '1.5',
+                averagePrice: '50000',
+                unrealizedPNL: '100',
+                leverage: '10',
+                marginMode: 'cross'
+            }
+        };
+
+        // Call handleMessage with private type to bypass strict validation checks for public messages if any
+        service.handleMessage(msg, 'private');
+
+        expect(omsService.updatePosition).toHaveBeenCalled();
+    });
+
+    it('should sync order updates to omsService', () => {
+        const msg = {
+            ch: 'order',
+            data: {
+                orderId: '123',
+                symbol: 'BTCUSDT',
+                side: 'BUY',
+                type: 'LIMIT',
+                orderStatus: 'NEW',
+                price: '50000',
+                qty: '1',
+                dealAmount: '0',
+                ctime: 1234567890
+            }
+        };
+
+        service.handleMessage(msg, 'private');
+
+        expect(omsService.updateOrder).toHaveBeenCalled();
+    });
+});

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -22,8 +22,11 @@ import { CONSTANTS } from "../lib/constants";
 import { normalizeSymbol } from "../utils/symbolUtils";
 import { connectionManager } from "./connectionManager";
 import { mdaService } from "./mdaService";
+import { omsService } from "./omsService";
 import { logger } from "./logger";
 import CryptoJS from "crypto-js";
+import { Decimal } from "decimal.js";
+import type { OMSPosition, OMSOrder, OMSOrderStatus } from "./omsTypes";
 import type {
   BitunixWSMessage,
   BitunixPriceData,
@@ -50,6 +53,50 @@ const CONNECTION_TIMEOUT_MS = 3000;
 interface Subscription {
   symbol: string;
   channel: string;
+}
+
+function mapToOMSPosition(data: any): OMSPosition {
+  const isClose = data.event === "CLOSE";
+  const amount = isClose ? new Decimal(0) : new Decimal(data.qty || 0);
+
+  return {
+    symbol: data.symbol,
+    side: (data.side || "").toLowerCase() as "long" | "short",
+    amount: amount,
+    entryPrice: new Decimal(data.averagePrice || data.avgOpenPrice || 0),
+    unrealizedPnl: new Decimal(data.unrealizedPNL || 0),
+    leverage: Number(data.leverage || 0),
+    marginMode: (data.marginMode || "cross").toLowerCase() as "cross" | "isolated",
+    liquidationPrice: data.liquidationPrice
+      ? new Decimal(data.liquidationPrice)
+      : undefined,
+  };
+}
+
+function mapToOMSOrder(data: any): OMSOrder {
+  const statusMap: Record<string, OMSOrderStatus> = {
+    NEW: "pending",
+    PARTIALLY_FILLED: "pending",
+    FILLED: "filled",
+    CANCELED: "cancelled",
+    CANCELLED: "cancelled",
+    REJECTED: "rejected",
+    EXPIRED: "expired",
+  };
+
+  const status = statusMap[data.orderStatus] || "pending";
+
+  return {
+    id: String(data.orderId),
+    symbol: data.symbol,
+    side: (data.side || "").toLowerCase() as "buy" | "sell",
+    type: (data.type || "").toLowerCase() as "limit" | "market",
+    status: status,
+    price: new Decimal(data.price || 0),
+    amount: new Decimal(data.qty || data.amount || 0),
+    filledAmount: new Decimal(data.dealAmount || 0),
+    timestamp: Number(data.ctime || Date.now()),
+  };
 }
 
 class BitunixWebSocketService {
@@ -970,17 +1017,27 @@ class BitunixWebSocketService {
         const data = validatedMessage.data;
         if (data) {
           if (Array.isArray(data))
-            data.forEach((item: any) =>
-              accountState.updatePositionFromWs(item),
-            );
-          else accountState.updatePositionFromWs(data);
+            data.forEach((item: any) => {
+              accountState.updatePositionFromWs(item);
+              omsService.updatePosition(mapToOMSPosition(item));
+            });
+          else {
+            accountState.updatePositionFromWs(data);
+            omsService.updatePosition(mapToOMSPosition(data));
+          }
         }
       } else if (validatedMessage.ch === "order") {
         const data = validatedMessage.data;
         if (data) {
           if (Array.isArray(data))
-            data.forEach((item: any) => accountState.updateOrderFromWs(item));
-          else accountState.updateOrderFromWs(data);
+            data.forEach((item: any) => {
+              accountState.updateOrderFromWs(item);
+              omsService.updateOrder(mapToOMSOrder(item));
+            });
+          else {
+            accountState.updateOrderFromWs(data);
+            omsService.updateOrder(mapToOMSOrder(data));
+          }
         }
       } else if (validatedMessage.ch === "wallet") {
         const data = validatedMessage.data;


### PR DESCRIPTION
This change addresses a critical data integrity issue where the Order Management System (OMS) was not receiving real-time updates from the WebSocket connection. This caused `omsService` to have stale data, preventing users from closing positions via the UI (since `tradeService` relies on `omsService` for position details).

Changes:
1.  Updated `src/services/bitunixWs.ts` to import `omsService` and mapped `position` and `order` channel messages to `omsService.updatePosition` and `omsService.updateOrder` respectively.
2.  Implemented robust data mapping helpers using `Decimal.js` to ensure precision and type safety.
3.  Added a new test file `src/services/bitunixWs.test.ts` which mocks `omsService` and verifies that it receives updates when `handleMessage` processes relevant WebSocket messages.

This ensures that the OMS state is always synchronized with the exchange state as received via WebSocket.

---
*PR created automatically by Jules for task [3531358615792242829](https://jules.google.com/task/3531358615792242829) started by @mydcc*