### PR TITLE
fix: Ensure galaxy settings merge correctly to prevent crash

### DIFF
--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -999,7 +999,13 @@ export class SettingsManager {
         defaultSettings.backgroundAnimationIntensity;
       this.videoPlaybackSpeed =
         merged.videoPlaybackSpeed ?? defaultSettings.videoPlaybackSpeed;
-      this.galaxySettings = merged.galaxySettings || defaultSettings.galaxySettings;
+
+      // Deep merge galaxy settings to ensure new fields (camPos, galaxyRot) are populated if missing in old storage
+      this.galaxySettings = {
+        ...defaultSettings.galaxySettings,
+        ...(merged.galaxySettings || {})
+      };
+
       this.enableNetworkLogs =
         merged.enableNetworkLogs ?? defaultSettings.enableNetworkLogs;
 


### PR DESCRIPTION
- Deep merge `galaxySettings` in `SettingsManager.load()` to ensure `camPos` and `galaxyRot` are populated from defaults if missing in local storage.
- Fixes `TypeError: Cannot read properties of undefined (reading 'x')` for users with existing settings.