### PR TITLE
Fix i18n violations in HotkeySettings and suppress false positives

### DIFF
--- a/src/components/settings/HotkeySettings.svelte
+++ b/src/components/settings/HotkeySettings.svelte
@@ -80,14 +80,18 @@
     });
 
     if (existingAction) {
-      conflictWarning = `"${newCombo}" is already used by "${existingAction.label}"`;
+      conflictWarning = $_("settings.hotkeys.conflictWarning", {
+        values: { newCombo, existingLabel: existingAction.label },
+      });
       // We don't save yet, just warn.
       // Actually, usually it's better to just highlight the conflict or auto-unbind.
       // Let's simple allow overwrite for now but maybe show a visual indicator?
       // For this version: simple overwrite is fine, but let's confirm.
       if (
         !confirm(
-          `"${newCombo}" is used by "${existingAction.label}". Overwrite?`,
+          $_("settings.hotkeys.conflictConfirm", {
+            values: { newCombo, existingLabel: existingAction.label },
+          }),
         )
       ) {
         return;
@@ -107,7 +111,7 @@
   }
 
   function resetToDefaults() {
-    if (confirm("Reset all custom hotkeys to defaults?")) {
+    if (confirm($_("settings.hotkeys.resetConfirm"))) {
       customHotkeys = {};
       settingsState.customHotkeys = {};
     }
@@ -168,7 +172,7 @@
                 }}
               >
                 {editingId === action.id
-                  ? "Press Key..."
+                  ? $_("settings.hotkeys.pressKey")
                   : getDisplayKey(action)}
               </button>
             </div>

--- a/src/components/shared/PowerToggle.svelte
+++ b/src/components/shared/PowerToggle.svelte
@@ -78,7 +78,7 @@
         trackCustomEvent(
             "ProStatus",
             "Toggle",
-            settingsState.isPro ? "Activated" : "Deactivated",
+            settingsState.isPro ? "Activated" : "Deactivated", // trackCustomEvent
         );
 
         if (settingsState.isPro) {

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -520,6 +520,12 @@
     "fontFamily": "Font Family",
     "forceEnglishTechnicalTerms": "Technical terms in English (Entry, TP, etc.)",
     "language": "Language",
+    "hotkeys": {
+      "conflictWarning": "\"{newCombo}\" is already used by \"{existingLabel}\"",
+      "conflictConfirm": "\"{newCombo}\" is used by \"{existingLabel}\". Overwrite?",
+      "resetConfirm": "Reset all custom hotkeys to defaults?",
+      "pressKey": "Press Key..."
+    },
     "backup": "Backup",
     "restore": "Restore",
     "reset": "Reset Data",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -152,14 +152,14 @@
     };
 
     window.addEventListener("error", handleGlobalError);
-    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+    window.addEventListener("unhandledrejection", handleUnhandledRejection); // event
 
     // Theme is already initialized in uiStore, no need to set it here
 
     return () => {
       window.removeEventListener("error", handleGlobalError);
       window.removeEventListener(
-        "unhandledrejection",
+        "unhandledrejection", // event
         handleUnhandledRejection,
       );
     };


### PR DESCRIPTION
Resolved 3 i18n violations reported by the linter:
1. `src/components/settings/HotkeySettings.svelte`: Extracted dynamic conflict warning and confirmation messages to `settings.hotkeys.*` in `en.json`.
2. `src/components/shared/PowerToggle.svelte`: Added linter suppression for analytics event tracking which should remain in English.
3. `src/routes/+layout.svelte`: Added linter suppression for standard DOM event name "unhandledrejection".

Verified that the linter now passes and the Hotkey Settings UI renders correctly with translations.

---
*PR created automatically by Jules for task [13285314516859627409](https://jules.google.com/task/13285314516859627409) started by @mydcc*