### PR TITLE
feat: Refine Galaxy settings ranges and precision

### DIFF
--- a/src/components/settings/tabs/VisualsTab.svelte
+++ b/src/components/settings/tabs/VisualsTab.svelte
@@ -371,21 +371,21 @@
                                     id="galaxy-count"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.particleCount}
-                                    min="1000"
+                                    min="10"
                                     max="50000"
-                                    step="1000"
+                                    step="10"
                                     class="range-input"
                                 />
                             </div>
                             <div class="field-group">
-                                <label for="galaxy-size">Size: {settingsState.galaxySettings.particleSize}</label>
+                                <label for="galaxy-size">Size: {settingsState.galaxySettings.particleSize.toFixed(2)}</label>
                                 <input
                                     id="galaxy-size"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.particleSize}
-                                    min="0.1"
+                                    min="0.01"
                                     max="2.0"
-                                    step="0.1"
+                                    step="0.01"
                                     class="range-input"
                                 />
                             </div>
@@ -393,14 +393,14 @@
 
                         <div class="grid grid-cols-2 gap-4">
                             <div class="field-group">
-                                <label for="galaxy-radius">Radius: {settingsState.galaxySettings.radius}</label>
+                                <label for="galaxy-radius">Radius: {settingsState.galaxySettings.radius.toFixed(1)}</label>
                                 <input
                                     id="galaxy-radius"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.radius}
-                                    min="1"
+                                    min="0.1"
                                     max="20"
-                                    step="0.5"
+                                    step="0.1"
                                     class="range-input"
                                 />
                             </div>
@@ -420,26 +420,26 @@
 
                         <div class="grid grid-cols-2 gap-4">
                             <div class="field-group">
-                                <label for="galaxy-spin">Spin Speed: {settingsState.galaxySettings.spin}</label>
+                                <label for="galaxy-spin">Spin Speed: {settingsState.galaxySettings.spin.toFixed(2)}</label>
                                 <input
                                     id="galaxy-spin"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.spin}
                                     min="0"
                                     max="5"
-                                    step="0.1"
+                                    step="0.01"
                                     class="range-input"
                                 />
                             </div>
                             <div class="field-group">
-                                <label for="galaxy-randomness">Randomness: {settingsState.galaxySettings.randomness}</label>
+                                <label for="galaxy-randomness">Randomness: {settingsState.galaxySettings.randomness.toFixed(2)}</label>
                                 <input
                                     id="galaxy-randomness"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.randomness}
                                     min="0"
                                     max="2"
-                                    step="0.1"
+                                    step="0.01"
                                     class="range-input"
                                 />
                             </div>
@@ -447,25 +447,25 @@
 
                          <div class="grid grid-cols-2 gap-4">
                             <div class="field-group">
-                                <label for="galaxy-randomness-power">Spread: {settingsState.galaxySettings.randomnessPower}</label>
+                                <label for="galaxy-randomness-power">Spread: {settingsState.galaxySettings.randomnessPower.toFixed(2)}</label>
                                 <input
                                     id="galaxy-randomness-power"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.randomnessPower}
                                     min="1"
                                     max="10"
-                                    step="0.1"
+                                    step="0.01"
                                     class="range-input"
                                 />
                             </div>
                              <div class="field-group">
-                                <label for="galaxy-concentration">Concentration: {settingsState.galaxySettings.concentrationPower}</label>
+                                <label for="galaxy-concentration">Concentration: {settingsState.galaxySettings.concentrationPower.toFixed(1)}</label>
                                 <input
                                     id="galaxy-concentration"
                                     type="range"
                                     bind:value={settingsState.galaxySettings.concentrationPower}
-                                    min="0.5"
-                                    max="5"
+                                    min="0.1"
+                                    max="10"
                                     step="0.1"
                                     class="range-input"
                                 />
@@ -477,32 +477,32 @@
                             <span class="text-xs font-semibold text-[var(--text-secondary)]">Camera Position</span>
                             <div class="grid grid-cols-3 gap-2">
                                  <div class="field-group">
-                                    <label for="cam-x">X: {settingsState.galaxySettings.camPos.x}</label>
-                                    <input id="cam-x" type="range" min="-15" max="15" step="0.5" bind:value={settingsState.galaxySettings.camPos.x} class="range-input" />
+                                    <label for="cam-x">X: {settingsState.galaxySettings.camPos.x.toFixed(1)}</label>
+                                    <input id="cam-x" type="range" min="-15" max="15" step="0.1" bind:value={settingsState.galaxySettings.camPos.x} class="range-input" />
                                 </div>
                                 <div class="field-group">
-                                    <label for="cam-y">Y: {settingsState.galaxySettings.camPos.y}</label>
-                                    <input id="cam-y" type="range" min="-15" max="15" step="0.5" bind:value={settingsState.galaxySettings.camPos.y} class="range-input" />
+                                    <label for="cam-y">Y: {settingsState.galaxySettings.camPos.y.toFixed(1)}</label>
+                                    <input id="cam-y" type="range" min="-15" max="15" step="0.1" bind:value={settingsState.galaxySettings.camPos.y} class="range-input" />
                                 </div>
                                 <div class="field-group">
-                                    <label for="cam-z">Z: {settingsState.galaxySettings.camPos.z}</label>
-                                    <input id="cam-z" type="range" min="-15" max="15" step="0.5" bind:value={settingsState.galaxySettings.camPos.z} class="range-input" />
+                                    <label for="cam-z">Z: {settingsState.galaxySettings.camPos.z.toFixed(1)}</label>
+                                    <input id="cam-z" type="range" min="-15" max="15" step="0.1" bind:value={settingsState.galaxySettings.camPos.z} class="range-input" />
                                 </div>
                             </div>
 
                             <span class="text-xs font-semibold text-[var(--text-secondary)]">Rotation</span>
                             <div class="grid grid-cols-3 gap-2">
                                  <div class="field-group">
-                                    <label for="rot-x">X: {settingsState.galaxySettings.galaxyRot.x}°</label>
-                                    <input id="rot-x" type="range" min="0" max="360" step="5" bind:value={settingsState.galaxySettings.galaxyRot.x} class="range-input" />
+                                    <label for="rot-x">X: {settingsState.galaxySettings.galaxyRot.x.toFixed(1)}°</label>
+                                    <input id="rot-x" type="range" min="0" max="360" step="0.1" bind:value={settingsState.galaxySettings.galaxyRot.x} class="range-input" />
                                 </div>
                                 <div class="field-group">
-                                    <label for="rot-y">Y: {settingsState.galaxySettings.galaxyRot.y}°</label>
-                                    <input id="rot-y" type="range" min="0" max="360" step="5" bind:value={settingsState.galaxySettings.galaxyRot.y} class="range-input" />
+                                    <label for="rot-y">Y: {settingsState.galaxySettings.galaxyRot.y.toFixed(1)}°</label>
+                                    <input id="rot-y" type="range" min="0" max="360" step="0.1" bind:value={settingsState.galaxySettings.galaxyRot.y} class="range-input" />
                                 </div>
                                 <div class="field-group">
-                                    <label for="rot-z">Z: {settingsState.galaxySettings.galaxyRot.z}°</label>
-                                    <input id="rot-z" type="range" min="0" max="360" step="5" bind:value={settingsState.galaxySettings.galaxyRot.z} class="range-input" />
+                                    <label for="rot-z">Z: {settingsState.galaxySettings.galaxyRot.z.toFixed(1)}°</label>
+                                    <input id="rot-z" type="range" min="0" max="360" step="0.1" bind:value={settingsState.galaxySettings.galaxyRot.z} class="range-input" />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
- Update `VisualsTab.svelte` sliders for finer control:
  - Particle Count: min 10, step 10
  - Particle Size: min 0.01, step 0.01
  - Radius: min 0.1, step 0.1
  - Spin Speed & Spread: step 0.01
  - Concentration: 0.1 to 10, step 0.1
  - Camera Position & Rotation: step 0.1
- Format slider labels with `toFixed` for better readability.