### PR TITLE
Restructure UI: Left Control Panel & Visibility Toggles

### DIFF
--- a/src/components/settings/tabs/TradingTab.svelte
+++ b/src/components/settings/tabs/TradingTab.svelte
@@ -216,6 +216,32 @@
                     <label class="toggle-card mb-4">
                         <div class="flex flex-col">
                             <span class="text-sm font-medium"
+                                >Market Overview Tiles</span
+                            >
+                            <span
+                                class="text-[10px] text-[var(--text-secondary)]"
+                                >Show market data tiles in sidebar</span
+                            >
+                        </div>
+                        <Toggle bind:checked={settingsState.showMarketOverview} />
+                    </label>
+
+                    <label class="toggle-card mb-4">
+                        <div class="flex flex-col">
+                            <span class="text-sm font-medium"
+                                >Market Sentiment</span
+                            >
+                            <span
+                                class="text-[10px] text-[var(--text-secondary)]"
+                                >Show sentiment analysis panel</span
+                            >
+                        </div>
+                        <Toggle bind:checked={settingsState.showMarketSentiment} />
+                    </label>
+
+                    <label class="toggle-card mb-4">
+                        <div class="flex flex-col">
+                            <span class="text-sm font-medium"
                                 >{$_("settings.showTechnicals")}</span
                             >
                             <span

--- a/src/components/shared/LeftControlPanel.svelte
+++ b/src/components/shared/LeftControlPanel.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import { settingsState } from "../../stores/settings.svelte";
+  import { uiState } from "../../stores/ui.svelte";
+  import { _ } from "../../locales/i18n";
+  import { icons } from "../../lib/constants";
+  import Tooltip from "./Tooltip.svelte";
+  import { trackClick } from "../../lib/actions";
+
+  // Additional Icons not in constants (or defined locally for specificity)
+  const ICONS = {
+    dashboard: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>`,
+    overview: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16"><path d="M1 2.5A1.5 1.5 0 0 1 2.5 1h3A1.5 1.5 0 0 1 7 2.5v3A1.5 1.5 0 0 1 5.5 7h-3A1.5 1.5 0 0 1 1 5.5v-3zM2.5 2a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zm6.5.5A1.5 1.5 0 0 1 10.5 1h3A1.5 1.5 0 0 1 15 2.5v3A1.5 1.5 0 0 1 13.5 7h-3A1.5 1.5 0 0 1 9 5.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zM1 10.5A1.5 1.5 0 0 1 2.5 9h3A1.5 1.5 0 0 1 7 10.5v3A1.5 1.5 0 0 1 5.5 15h-3A1.5 1.5 0 0 1 1 13.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zm6.5.5A1.5 1.5 0 0 1 10.5 9h3a1.5 1.5 0 0 1 1.5 1.5v3a1.5 1.5 0 0 1-1.5 1.5h-3A1.5 1.5 0 0 1 9 13.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3z"/></svg>`,
+    sentiment: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>`, // Activity/Lightning bolt for sentiment/energy
+  };
+</script>
+
+<aside
+  class="fixed left-0 z-50 flex flex-col gap-2 p-2 bg-[var(--bg-secondary)] rounded-r-2xl border-y border-r border-[var(--border-color)] shadow-xl transition-all duration-300"
+  style="top: 38vh;"
+>
+  <!-- Dashboard Button -->
+  <button
+    class="control-btn"
+    onclick={() => uiState.toggleMarketDashboardModal(true)}
+    title={$_("marketDashboard.buttonTitle") || "Market Overview"}
+    use:trackClick={{
+        category: "Navigation",
+        action: "Click",
+        name: "OpenMarketDashboard",
+    }}
+  >
+    {@html ICONS.dashboard}
+  </button>
+
+  <!-- Settings Button -->
+  <button
+    class="control-btn"
+    onclick={() => uiState.toggleSettingsModal(true)}
+    title={$_("settings.title") || "Settings"}
+    use:trackClick={{
+        category: "Navigation",
+        action: "Click",
+        name: "OpenSettings",
+    }}
+  >
+    {@html icons.settings}
+  </button>
+
+  <div class="h-px w-full bg-[var(--border-color)] my-1"></div>
+
+  <!-- Technicals Toggle -->
+  <button
+    class="control-btn"
+    class:active={settingsState.showTechnicals}
+    onclick={() => (settingsState.showTechnicals = !settingsState.showTechnicals)}
+    title={$_("settings.showTechnicals") || "Toggle Technicals"}
+  >
+    {@html icons.chart}
+  </button>
+
+  <!-- Market Overview Toggle -->
+  <button
+    class="control-btn"
+    class:active={settingsState.showMarketOverview}
+    onclick={() => (settingsState.showMarketOverview = !settingsState.showMarketOverview)}
+    title="Toggle Market Tiles"
+  >
+    {@html ICONS.overview}
+  </button>
+
+  <!-- Sentiment Toggle -->
+  <button
+    class="control-btn"
+    class:active={settingsState.showMarketSentiment}
+    onclick={() => (settingsState.showMarketSentiment = !settingsState.showMarketSentiment)}
+    title="Toggle Market Sentiment"
+  >
+    {@html ICONS.sentiment}
+  </button>
+</aside>
+
+<style>
+  .control-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 0.5rem;
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+  }
+
+  .control-btn:hover {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    transform: scale(1.05);
+  }
+
+  .control-btn.active {
+    background-color: var(--bg-tertiary);
+    color: var(--accent-color);
+  }
+
+  .control-btn :global(svg) {
+    width: 20px;
+    height: 20px;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,15 +47,14 @@
   import Tooltip from "../components/shared/Tooltip.svelte";
   import CachyIcon from "../components/shared/CachyIcon.svelte";
   import ModalFrame from "../components/shared/ModalFrame.svelte";
-  import SettingsButton from "../components/settings/SettingsButton.svelte";
   import MarketOverview from "../components/shared/MarketOverview.svelte";
   import PositionsSidebar from "../components/shared/PositionsSidebar.svelte";
   import TechnicalsPanel from "../components/shared/TechnicalsPanel.svelte"; // Import TechnicalsPanel
   import ConnectionStatus from "../components/shared/ConnectionStatus.svelte"; // Import ConnectionStatus
   import SidePanel from "../components/shared/SidePanel.svelte";
+  import LeftControlPanel from "../components/shared/LeftControlPanel.svelte";
   import FloatingIframeButton from "../components/shared/FloatingIframeButton.svelte";
   import NewsSentimentPanel from "../components/shared/NewsSentimentPanel.svelte";
-  import AnalyticsButton from "../components/shared/AnalyticsButton.svelte";
   import PowerToggle from "../components/shared/PowerToggle.svelte";
   import { handleGlobalKeydown } from "../services/hotkeyService";
 
@@ -235,6 +234,7 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <SidePanel />
+<LeftControlPanel />
 
 <!-- Global Layout Wrapper -->
 <div
@@ -649,8 +649,6 @@
           <LanguageSwitcher />
           <div class="flex items-center gap-2">
             <FloatingIframeButton />
-            <AnalyticsButton />
-            <SettingsButton />
           </div>
           <div class="flex items-center gap-2">
             <PowerToggle />
@@ -671,16 +669,18 @@
           <NewsSentimentPanel symbol={tradeState.symbol} variant="sidebar" />
         {/if}
 
-        <MarketOverview
-          onToggleTechnicals={toggleTechnicals}
-          {isTechnicalsVisible}
-        />
+        {#if settingsState.showMarketOverview}
+          <MarketOverview
+            onToggleTechnicals={toggleTechnicals}
+            {isTechnicalsVisible}
+          />
+        {/if}
 
         {#if settingsState.showTechnicals && isTechnicalsVisible}
           <TechnicalsPanel isVisible={isTechnicalsVisible} />
         {/if}
 
-        {#if favoritesState.items.length > 0}
+        {#if favoritesState.items.length > 0 && settingsState.showMarketOverview}
           <div
             class="text-[var(--text-secondary)] text-xs font-bold uppercase tracking-widest px-1"
           >
@@ -702,10 +702,12 @@
       class="hidden xl:flex flex-col gap-3 w-56 shrink-0 sticky top-8 transition-all duration-300 z-40"
     >
       <!-- Main current symbol -->
-      <MarketOverview
-        onToggleTechnicals={toggleTechnicals}
-        {isTechnicalsVisible}
-      />
+      {#if settingsState.showMarketOverview}
+        <MarketOverview
+          onToggleTechnicals={toggleTechnicals}
+          {isTechnicalsVisible}
+        />
+      {/if}
 
       <!-- Technicals Panel (Absolute positioned next to MarketOverview) -->
       {#if settingsState.showTechnicals}
@@ -721,18 +723,20 @@
       {/if}
 
       <!-- Favorites list -->
-      {#if favoritesState.items.length > 0}
-        <div
-          class="text-[var(--text-secondary)] text-xs font-bold uppercase tracking-widest mt-2 px-1"
-        >
-          {$_("dashboard.favorites") || "Favorites"}
-        </div>
-      {/if}
-      {#each favoritesState.items as fav (fav)}
-        {#if fav.toUpperCase() !== (tradeState.symbol || "").toUpperCase()}
-          <MarketOverview customSymbol={fav} isFavoriteTile={true} />
+      {#if settingsState.showMarketOverview}
+        {#if favoritesState.items.length > 0}
+          <div
+            class="text-[var(--text-secondary)] text-xs font-bold uppercase tracking-widest mt-2 px-1"
+          >
+            {$_("dashboard.favorites") || "Favorites"}
+          </div>
         {/if}
-      {/each}
+        {#each favoritesState.items as fav (fav)}
+          {#if fav.toUpperCase() !== (tradeState.symbol || "").toUpperCase()}
+            <MarketOverview customSymbol={fav} isFavoriteTile={true} />
+          {/if}
+        {/each}
+      {/if}
     </div>
   {/if}
 </div>

--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -167,6 +167,7 @@ export interface Settings {
   cmcApiKey?: string;
   enableCmcContext: boolean;
   showMarketOverviewLinks: boolean;
+  showMarketOverview: boolean; // Toggle for tile visibility
   showMarketActivity: boolean;
   marketAnalysisInterval: number;
   pauseAnalysisOnBlur: boolean;
@@ -324,6 +325,7 @@ const defaultSettings: Settings = {
   cmcApiKey: "",
   enableCmcContext: false,
   showMarketOverviewLinks: true,
+  showMarketOverview: true,
   showMarketActivity: true,
   showMarketSentiment: true,
   showSidebarActivity: false,
@@ -528,6 +530,7 @@ export class SettingsManager {
   showMarketOverviewLinks = $state<boolean>(
     defaultSettings.showMarketOverviewLinks,
   );
+  showMarketOverview = $state<boolean>(defaultSettings.showMarketOverview);
   showMarketActivity = $state<boolean>(defaultSettings.showMarketActivity);
   marketAnalysisInterval = $state<number>(defaultSettings.marketAnalysisInterval);
   pauseAnalysisOnBlur = $state<boolean>(defaultSettings.pauseAnalysisOnBlur);
@@ -952,6 +955,7 @@ export class SettingsManager {
       this.cmcApiKey = merged.cmcApiKey;
       this.enableCmcContext = merged.enableCmcContext;
       this.showMarketOverviewLinks = merged.showMarketOverviewLinks;
+      this.showMarketOverview = merged.showMarketOverview ?? defaultSettings.showMarketOverview;
       this.showMarketActivity = merged.showMarketActivity;
       this.showSidebarActivity =
         merged.showSidebarActivity ?? defaultSettings.showSidebarActivity;
@@ -1147,6 +1151,7 @@ export class SettingsManager {
       cmcApiKey: this.cmcApiKey,
       enableCmcContext: this.enableCmcContext,
       showMarketOverviewLinks: this.showMarketOverviewLinks,
+      showMarketOverview: this.showMarketOverview,
       showMarketActivity: this.showMarketActivity,
       showSidebarActivity: this.showSidebarActivity,
       showMarketSentiment: this.showMarketSentiment,


### PR DESCRIPTION
This PR restructures the main UI by moving the Dashboard and Settings buttons from the footer to a new fixed "Left Control Panel". This panel also includes new toggle switches for visibility of Technicals, Market Overview Tiles, and Market Sentiment. The settings store and modal were updated to support these granular visibility controls.

---
*PR created automatically by Jules for task [4596329729711354265](https://jules.google.com/task/4596329729711354265) started by @mydcc*