### PR TITLE
fix: Correct MFI calculation and Bitunix volume data mapping

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -490,6 +490,7 @@ export const apiService = {
                 high: string | number;
                 low: string | number;
                 close: string | number;
+                volume?: string | number;
                 vol?: string | number;
                 timestamp?: number;
                 time?: number;
@@ -500,7 +501,8 @@ export const apiService = {
                   const high = new Decimal(kline.high || 0);
                   const low = new Decimal(kline.low || 0);
                   const close = new Decimal(kline.close || 0);
-                  const volume = new Decimal(kline.vol || 0);
+                  // The server endpoint normalizes this to 'volume', but we keep fallback to 'vol' just in case
+                  const volume = new Decimal(kline.volume || kline.vol || 0);
                   const time = parseTimestamp(
                     kline.timestamp || kline.time || kline.ts,
                   );

--- a/src/utils/indicators.ts
+++ b/src/utils/indicators.ts
@@ -288,8 +288,13 @@ export const JSIndicators = {
         sumPos += posFlow[i - j];
         sumNeg += negFlow[i - j];
       }
-      const mfr = sumNeg === 0 ? 100 : sumPos / sumNeg;
-      result[i] = 100 - 100 / (1 + mfr);
+
+      if (sumNeg === 0) {
+        result[i] = 100;
+      } else {
+        const mfr = sumPos / sumNeg;
+        result[i] = 100 - 100 / (1 + mfr);
+      }
     }
 
     return result;


### PR DESCRIPTION
This PR addresses reported issues with technical indicators in the "Advanced Analysis" section.

**Changes:**
1.  **MFI Calculation (`src/utils/indicators.ts`):** Modified the Money Flow Index calculation to explicitly return `100` when `sumNeg` (negative money flow) is 0. Previously, it defaulted the ratio `mfr` to 100, which resulted in `100 - 100/(1+100) = ~99.01`. This fix ensures the indicator correctly reflects maximum buying pressure as 100.
2.  **Volume Data Mapping (`src/services/apiService.ts`):** Updated `fetchBitunixKlines` to prioritize reading the `volume` property from the API response. The server-side proxy (`src/routes/api/klines/+server.ts`) normalizes the Bitunix response to use the key `volume`, but the client-side service was looking for `vol`. This mismatch caused volume-dependent indicators (VWAP, OBV) to receive 0 volume, resulting in flatline/zero values.

**Verification:**
-   Added and ran a temporary unit test (`src/utils/mfi_check.test.ts`) to verify the MFI edge case (0 negative flow -> 100).
-   Ran existing tests `src/services/apiService.test.ts` and `src/services/technicalsService.test.ts` to ensure no regressions.


---
*PR created automatically by Jules for task [9703124184611609831](https://jules.google.com/task/9703124184611609831) started by @mydcc*