### PR TITLE
Fix type errors in flash-close test and i18n schema

### DIFF
--- a/src/locales/schema.d.ts
+++ b/src/locales/schema.d.ts
@@ -554,6 +554,7 @@ export type TranslationKey =
   | "settings.spinButtonsAlways"
   | "settings.spinButtonsHover"
   | "settings.spinButtonsHidden"
+  | "settings.hotkeys.conflictWarning"
   | "settings.tabs.general"
   | "settings.tabs.api"
   | "settings.tabs.ai"

--- a/src/tests/flash-close.test.ts
+++ b/src/tests/flash-close.test.ts
@@ -86,7 +86,7 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
                 leverage: 10,
                 liquidationPrice: new Decimal('45000'),
                 unrealizedPnl: new Decimal('0'),
-                timestamp: Date.now()
+                marginMode: 'cross'
             }
         ]);
 


### PR DESCRIPTION
This PR fixes two type errors reported by `npm run check`.
1.  In `src/tests/flash-close.test.ts`, the `OMSPosition` mock object contained a `timestamp` property which is not present in the interface, and was missing the required `marginMode` property. This has been corrected.
2.  In `src/components/settings/HotkeySettings.svelte`, the translation key `settings.hotkeys.conflictWarning` was flagged as invalid because it was missing from the generated `TranslationKey` type in `src/locales/schema.d.ts`. The schema has been regenerated to include this key.

---
*PR created automatically by Jules for task [4998847119611436395](https://jules.google.com/task/4998847119611436395) started by @mydcc*