### PR TITLE
Fix dashboard layout regression by preventing result items from wrapping

### DIFF
--- a/src/themes.css
+++ b/src/themes.css
@@ -1846,7 +1846,6 @@ select {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  flex-wrap: wrap;
   padding: 0.75rem 0;
   border-bottom: 1px solid var(--bg-tertiary);
 }
@@ -1861,6 +1860,7 @@ select {
   align-items: center;
   gap: 0.5rem;
   margin-right: 1rem;
+  flex-shrink: 0;
 }
 
 .input-label {


### PR DESCRIPTION
- Modified `src/themes.css` to remove `flex-wrap: wrap` from `.result-item`.
- Added `flex-shrink: 0` to `.result-label` to ensure labels don't collapse.
- This ensures values (e.g. Position Size, Net Loss) stay on the same line as their labels, fixing the visual regression reported by the user.