### PR TITLE
Fix technical indicators by correcting Bitunix volume mapping

### DIFF
--- a/src/routes/api/klines/+server.ts
+++ b/src/routes/api/klines/+server.ts
@@ -141,7 +141,7 @@ async function fetchBitunixKlines(
       high: new Decimal(k.high || k.h || 0).toString(),
       low: new Decimal(k.low || k.l || 0).toString(),
       close: new Decimal(k.close || k.c || 0).toString(),
-      volume: new Decimal(k.vol || k.v || 0).toString(),
+      volume: new Decimal(k.volume || k.vol || k.v || k.amount || 0).toString(),
       timestamp: k.id || k.ts || k.time || 0,
     }))
     .sort((a: any, b: any) => a.timestamp - b.timestamp);

--- a/src/utils/indicators.ts
+++ b/src/utils/indicators.ts
@@ -289,7 +289,9 @@ export const JSIndicators = {
         sumNeg += negFlow[i - j];
       }
 
-      if (sumNeg === 0) {
+      if (sumPos + sumNeg === 0) {
+        result[i] = 50;
+      } else if (sumNeg === 0) {
         result[i] = 100;
       } else {
         const mfr = sumPos / sumNeg;


### PR DESCRIPTION
Fixed "Unrealistic Indicators" (VWAP=0, OBV=0, MFI=100) by correctly mapping the `volume` field from Bitunix Kline API (fallback to `k.volume`, `k.vol`, `k.amount`).
Updated MFI calculation to return 50 (Neutral) instead of 100 (Sell) when volume data is zero or missing, ensuring safer signals.

---
*PR created automatically by Jules for task [974684814518818028](https://jules.google.com/task/974684814518818028) started by @mydcc*