### PR TITLE
Implement Technicals Panel Docking Logic

### DIFF
--- a/src/components/shared/TechnicalsPanel.svelte
+++ b/src/components/shared/TechnicalsPanel.svelte
@@ -19,9 +19,10 @@
 
   interface Props {
     isVisible?: boolean;
+    fluidWidth?: boolean;
   }
 
-  let { isVisible = false }: Props = $props();
+  let { isVisible = false, fluidWidth = false }: Props = $props();
 
   // Local UI state
   let showTimeframePopup = $state(false);
@@ -155,8 +156,8 @@
 {#if showPanel}
   <div
     class="technicals-panel p-3 flex flex-col gap-2 w-full transition-all relative"
-    class:md:w-72={!settingsState.showIndicatorParams}
-    class:md:w-[22rem]={settingsState.showIndicatorParams}
+    class:md:w-72={!fluidWidth && !settingsState.showIndicatorParams}
+    class:md:w-[22rem]={!fluidWidth && settingsState.showIndicatorParams}
   >
     <!-- Top Header -->
     <div

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -229,6 +229,17 @@
   function toggleTechnicals() {
     isTechnicalsVisible = !isTechnicalsVisible;
   }
+
+  let isTechnicalsDocked = $derived(
+    !settingsState.showMarketOverview && settingsState.showTechnicals,
+  );
+  let sidebarWidthClass = $derived(
+    isTechnicalsDocked
+      ? settingsState.showIndicatorParams
+        ? "w-[22rem]"
+        : "w-72"
+      : "w-56",
+  );
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -677,7 +688,7 @@
         {/if}
 
         {#if settingsState.showTechnicals && isTechnicalsVisible}
-          <TechnicalsPanel isVisible={isTechnicalsVisible} />
+          <TechnicalsPanel isVisible={isTechnicalsVisible} fluidWidth={true} />
         {/if}
 
         {#if favoritesState.items.length > 0 && settingsState.showMarketOverview}
@@ -699,7 +710,7 @@
   {#if settingsState.showSidebars}
     <!-- Right Sidebar: Market Data & Favorites (Sticky) -->
     <div
-      class="hidden xl:flex flex-col gap-3 w-56 shrink-0 sticky top-8 transition-all duration-300 z-40"
+      class="hidden xl:flex flex-col gap-3 shrink-0 sticky top-8 transition-all duration-300 z-40 {sidebarWidthClass}"
     >
       <!-- Main current symbol -->
       {#if settingsState.showMarketOverview}
@@ -707,10 +718,12 @@
           onToggleTechnicals={toggleTechnicals}
           {isTechnicalsVisible}
         />
+      {:else if isTechnicalsDocked}
+        <TechnicalsPanel isVisible={isTechnicalsVisible} fluidWidth={true} />
       {/if}
 
       <!-- Technicals Panel (Absolute positioned next to MarketOverview) -->
-      {#if settingsState.showTechnicals}
+      {#if settingsState.showTechnicals && !isTechnicalsDocked}
         <div
           class="absolute top-0 left-full ml-8 transition-all duration-300 transform origin-left z-40"
           class:scale-0={!isTechnicalsVisible}


### PR DESCRIPTION
Implemented logic to optimize screen space by docking the Technicals Panel into the right sidebar when the Market Overview is toggled off.

Changes:
- `src/components/shared/TechnicalsPanel.svelte`: Added `fluidWidth` prop to override fixed width classes with `w-full` when needed.
- `src/routes/+page.svelte`: Added `isTechnicalsDocked` derived state to control layout. If Docked, Technicals renders inside the sticky sidebar. If Floating, it renders in the absolute container. Adjusted sidebar width classes to accommodate the wider Technicals panel when docked.


---
*PR created automatically by Jules for task [13277777632221919021](https://jules.google.com/task/13277777632221919021) started by @mydcc*