### PR TITLE
Restore Take Profit Row Layout

### DIFF
--- a/src/components/shared/TakeProfitRow.svelte
+++ b/src/components/shared/TakeProfitRow.svelte
@@ -161,7 +161,7 @@
   </div>
 
   <!-- Inputs -->
-  <div class="flex items-center gap-2 mb-1">
+  <div class="flex items-center justify-between gap-4 mb-1">
     <!-- TP Price Input -->
     <div class="relative flex-grow">
       <input
@@ -177,60 +177,62 @@
       />
     </div>
 
-    <!-- TP Percent Input -->
-    <div class="relative w-20 flex-shrink-0">
-      <input
-        id="tp-percent-{index}"
-        name="tpPercent-{index}"
-        type="text"
-        use:numberInput={{
-          noDecimals: true,
-          isPercentage: true,
-          minValue: 0,
-          maxValue: 100,
-        }}
-        use:enhancedInput={{
-          step: 1,
-          min: 0,
-          max: 100,
-          noDecimals: true,
-          rightOffset: "2px",
-        }}
-        value={format(percent)}
-        oninput={handlePercentInput}
-        class="tp-percent input-field w-full px-2 py-1.5 rounded-md text-sm"
-        class:locked-input={isLocked}
-        disabled={isLocked}
-        placeholder="%"
-      />
-    </div>
+    <div class="flex items-center gap-2 flex-shrink-0">
+      <!-- TP Percent Input -->
+      <div class="relative w-20">
+        <input
+          id="tp-percent-{index}"
+          name="tpPercent-{index}"
+          type="text"
+          use:numberInput={{
+            noDecimals: true,
+            isPercentage: true,
+            minValue: 0,
+            maxValue: 100,
+          }}
+          use:enhancedInput={{
+            step: 1,
+            min: 0,
+            max: 100,
+            noDecimals: true,
+            rightOffset: "2px",
+          }}
+          value={format(percent)}
+          oninput={handlePercentInput}
+          class="tp-percent input-field w-full px-2 py-1.5 rounded-md text-sm"
+          class:locked-input={isLocked}
+          disabled={isLocked}
+          placeholder="%"
+        />
+      </div>
 
-    <button
-      class="remove-tp-btn text-[var(--danger-color)] hover:opacity-80 p-1 flex-shrink-0"
-      title={$_("dashboard.takeProfitRow.removeButtonTitle")}
-      tabindex="-1"
-      onclick={removeRow}
-      use:trackClick={{
-        category: "TakeProfitRow",
-        action: "Click",
-        name: "RemoveRow",
-      }}
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        fill="currentColor"
-        class="pointer-events-none"
-        viewBox="0 0 16 16"
-        ><path
-          d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"
-        /><path
-          fill-rule="evenodd"
-          d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"
-        /></svg
+      <button
+        class="remove-tp-btn text-[var(--danger-color)] hover:opacity-80 p-1 flex-shrink-0"
+        title={$_("dashboard.takeProfitRow.removeButtonTitle")}
+        tabindex="-1"
+        onclick={removeRow}
+        use:trackClick={{
+          category: "TakeProfitRow",
+          action: "Click",
+          name: "RemoveRow",
+        }}
       >
-    </button>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="currentColor"
+          class="pointer-events-none"
+          viewBox="0 0 16 16"
+          ><path
+            d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"
+          /><path
+            fill-rule="evenodd"
+            d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"
+          /></svg
+        >
+      </button>
+    </div>
   </div>
 
   <!-- Stats: Win / RR (Footer) -->


### PR DESCRIPTION
Restores the layout of `TakeProfitRow` to match the design shown in `image.png`.
- Groups percent input and trash button in a right-aligned container.
- Uses `justify-between` to separate the price input (left) from the controls (right).
- Verified visually via Playwright screenshot.

---
*PR created automatically by Jules for task [5410382544543057350](https://jules.google.com/task/5410382544543057350) started by @mydcc*