### PR TITLE
Fix: Use HTML target for unique external link tabs

### DIFF
--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -479,13 +479,13 @@
       {#if settingsState.showMarketOverviewLinks && symbol}
         <div class="flex items-center gap-4 mt-3 pt-2 border-t border-[var(--border-color)]">
           {#if settingsState.showTvLink}
-            <a href={tvLink} target={tvTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--accent-color)] transition-colors" title="TradingView Chart" onclick={(e) => { e.preventDefault(); window.open(tvLink, tvTarget)?.focus(); }}>TV</a>
+            <a href={tvLink} target={tvTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--accent-color)] transition-colors" title="TradingView Chart">TV</a>
           {/if}
           {#if settingsState.showCgHeatLink}
-            <a href={cgHeatmapLink} target={cgTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--danger-color)] transition-colors" title="Liquidation Heatmap" onclick={(e) => { e.preventDefault(); window.open(cgHeatmapLink, cgTarget)?.focus(); }}>CG Heat</a>
+            <a href={cgHeatmapLink} target={cgTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--danger-color)] transition-colors" title="Liquidation Heatmap">CG Heat</a>
           {/if}
           {#if settingsState.showBrokerLink}
-            <a href={brokerLink} target={brokerTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--success-color)] transition-colors" title="Open on {provider}" onclick={(e) => { e.preventDefault(); window.open(brokerLink, brokerTarget)?.focus(); }}>{provider.toUpperCase()}</a>
+            <a href={brokerLink} target={brokerTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--success-color)] transition-colors" title="Open on {provider}">{provider.toUpperCase()}</a>
           {/if}
           {#if CHANNEL_CONFIG[baseAsset] && settingsState.isPro}
             {@const config = CHANNEL_CONFIG[baseAsset]}


### PR DESCRIPTION
- Replaced `window.open` JS handler with native HTML `target` attribute on Market Overview links.
- Uses dynamic target names (e.g., `cachy_tv_BTCUSDT`) to ensure one tab per symbol/provider.
- This resolves the issue where `window.open` would lose reference to cross-origin tabs (like TradingView) and spawn duplicate tabs instead of reusing the existing one.
- Native browser behavior automatically focuses the reused tab.