### PR TITLE
Fix: Enforce single tab per symbol using JS window references

### DIFF
--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -17,6 +17,7 @@
   import { marketState } from "../../stores/market.svelte";
   import { marketWatcher } from "../../services/marketWatcher";
   import { activeTechnicalsManager } from "../../services/activeTechnicalsManager.svelte";
+  import { externalLinkService } from "../../services/externalLinkService";
   import { icons } from "../../lib/constants";
   import { _ } from "../../locales/i18n";
   import { formatDynamicDecimal } from "../../utils/utils";
@@ -479,13 +480,13 @@
       {#if settingsState.showMarketOverviewLinks && symbol}
         <div class="flex items-center gap-4 mt-3 pt-2 border-t border-[var(--border-color)]">
           {#if settingsState.showTvLink}
-            <a href={tvLink} target={tvTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--accent-color)] transition-colors" title="TradingView Chart">TV</a>
+            <a href={tvLink} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--accent-color)] transition-colors" title="TradingView Chart" onclick={(e) => { e.preventDefault(); externalLinkService.openOrFocus(tvLink, tvTarget); }}>TV</a>
           {/if}
           {#if settingsState.showCgHeatLink}
-            <a href={cgHeatmapLink} target={cgTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--danger-color)] transition-colors" title="Liquidation Heatmap">CG Heat</a>
+            <a href={cgHeatmapLink} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--danger-color)] transition-colors" title="Liquidation Heatmap" onclick={(e) => { e.preventDefault(); externalLinkService.openOrFocus(cgHeatmapLink, cgTarget); }}>CG Heat</a>
           {/if}
           {#if settingsState.showBrokerLink}
-            <a href={brokerLink} target={brokerTarget} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--success-color)] transition-colors" title="Open on {provider}">{provider.toUpperCase()}</a>
+            <a href={brokerLink} class="text-[10px] uppercase font-bold text-[var(--text-secondary)] hover:text-[var(--success-color)] transition-colors" title="Open on {provider}" onclick={(e) => { e.preventDefault(); externalLinkService.openOrFocus(brokerLink, brokerTarget); }}>{provider.toUpperCase()}</a>
           {/if}
           {#if CHANNEL_CONFIG[baseAsset] && settingsState.isPro}
             {@const config = CHANNEL_CONFIG[baseAsset]}

--- a/src/services/externalLinkService.ts
+++ b/src/services/externalLinkService.ts
@@ -1,0 +1,35 @@
+export class ExternalLinkService {
+  private static instance: ExternalLinkService;
+  private windows: Map<string, Window> = new Map();
+
+  private constructor() {}
+
+  public static getInstance(): ExternalLinkService {
+    if (!ExternalLinkService.instance) {
+      ExternalLinkService.instance = new ExternalLinkService();
+    }
+    return ExternalLinkService.instance;
+  }
+
+  /**
+   * Opens a URL in a new window or focuses the existing window if it's already open.
+   * @param url The URL to open.
+   * @param key A unique key to identify the window context (e.g., "tv_BTCUSDT").
+   */
+  public openOrFocus(url: string, key: string): void {
+    const existingWindow = this.windows.get(key);
+
+    if (existingWindow && !existingWindow.closed) {
+      existingWindow.focus();
+    } else {
+      // Open new window. We use 'key' as the window name as well,
+      // though we primarily rely on the JS reference.
+      const newWindow = window.open(url, key);
+      if (newWindow) {
+        this.windows.set(key, newWindow);
+      }
+    }
+  }
+}
+
+export const externalLinkService = ExternalLinkService.getInstance();


### PR DESCRIPTION
- Introduced `ExternalLinkService` to manage window references for external links (TradingView, Coinglass, Broker).
- Implemented `openOrFocus` logic: tracks opened windows in a Map; focuses the existing window if open, or creates a new one if closed/missing.
- Updated `MarketOverview.svelte` to use this service instead of HTML `target` attributes.
- Solves the issue where browsers (especially with COOP/COEP) fail to reuse tabs by name when navigating cross-origin, ensuring robust tab reuse within the app session.