### PR TITLE
fix(api): correct bitunix kline volume mapping

### DIFF
--- a/src/routes/api/klines/+server.ts
+++ b/src/routes/api/klines/+server.ts
@@ -141,7 +141,10 @@ async function fetchBitunixKlines(
       high: new Decimal(k.high || k.h || 0).toString(),
       low: new Decimal(k.low || k.l || 0).toString(),
       close: new Decimal(k.close || k.c || 0).toString(),
-      volume: new Decimal(k.volume || k.vol || k.v || k.amount || 0).toString(),
+      // Bitunix Kline API returns 'quoteVol' as the Quantity (BTC) and 'baseVol' as Turnover (USDT).
+      // This is swapped compared to standard conventions and their own Ticker API.
+      // We map k.quoteVol (Quantity) to our internal volume field.
+      volume: new Decimal(k.quoteVol || k.q || k.volume || k.vol || k.v || k.amount || 0).toString(),
       timestamp: k.id || k.ts || k.time || 0,
     }))
     .sort((a: any, b: any) => a.timestamp - b.timestamp);

--- a/src/services/mdaService.ts
+++ b/src/services/mdaService.ts
@@ -72,7 +72,10 @@ export const mdaService = {
                     low: k.low || k.l || "0",
                     close: k.close || k.c || "0",
                     // Extended volume checks for Klines: v=vol, q=quote (if base missing), vol
-                    volume: k.volume || k.v || k.vol || k.amount || "0"
+                    // IMPORTANT: Bitunix Kline API (REST & WS) swaps Base/Quote volume compared to standard.
+                    // 'quoteVol' (q) is often the Quantity (BTC), while 'baseVol' is Turnover (USDT).
+                    // We prioritize quoteVol/q here to ensure indicators get the correct quantity.
+                    volume: k.quoteVol || k.q || k.volume || k.v || k.vol || k.amount || "0"
                 };
             }
             // Generic / Bitget


### PR DESCRIPTION
This PR addresses a data mapping issue with the Bitunix Kline API where `quoteVol` and `baseVol` fields are swapped relative to standard conventions (and even their own Ticker API).

**The Issue:**
- Bitunix Klines return quantity (BTC amount) in `quoteVol` and turnover (USDT amount) in `baseVol`.
- Our application expects `volume` (quantity) to be present.
- Previously, the mapping defaulted to 0 because it looked for `volume`, `vol`, or `v`, which were missing or incorrect.
- This caused volume-dependent indicators like VWAP, OBV, and MFI to return 0 or default values (e.g., MFI=50).

**The Fix:**
- Updated `src/routes/api/klines/+server.ts` to explicitly map `k.quoteVol` to `volume`.
- Updated `src/services/mdaService.ts` (WebSocket adapter) to prioritize `k.quoteVol` and `k.q` when normalizing kline data for live updates.

**Verification:**
- Verified via `curl` output analysis that `quoteVol` indeed corresponds to the asset quantity (BTC) and `baseVol` matches the USDT turnover math (Price * Qty).
- Code review confirmed the scope is limited to Bitunix data handling.

---
*PR created automatically by Jules for task [5202158789359210967](https://jules.google.com/task/5202158789359210967) started by @mydcc*