### PR TITLE
Fix: Enable COOP header to allow TradingView tab reuse

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -122,4 +122,12 @@ const themeHandler: Handle = async ({ event, resolve }) => {
   return response;
 };
 
-export const handle = sequence(loggingHandler, themeHandler);
+const headersHandler: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+  // Enable Cross-Origin-Opener-Policy to allow interaction with popups (like TradingView)
+  // that also set this header. This helps in maintaining window references for named targets.
+  response.headers.set("Cross-Origin-Opener-Policy", "same-origin-allow-popups");
+  return response;
+};
+
+export const handle = sequence(loggingHandler, headersHandler, themeHandler);


### PR DESCRIPTION
- Added `Cross-Origin-Opener-Policy: same-origin-allow-popups` to `src/hooks.server.ts`.
- This matches TradingView's security policy, preventing the browser from severing the window opener relationship due to Site Isolation.
- Allows `window.open(url, name)` to successfully find and reuse existing TradingView tabs instead of opening new ones.
- Works in conjunction with the new `ExternalLinkService` and named targets implemented in previous steps.