### PR TITLE
fix(a11y): Add aria-label to gyroscope toggle button

### DIFF
--- a/src/components/settings/tabs/VisualsTab.svelte
+++ b/src/components/settings/tabs/VisualsTab.svelte
@@ -547,6 +547,7 @@
                             <button
                                 class="w-12 h-6 rounded-full relative transition-colors {settingsState.galaxySettings.enableGyroscope ? 'bg-[var(--accent-color)]' : 'bg-[var(--border-color)]'}"
                                 onclick={toggleGyro}
+                                aria-label="Toggle Gyroscope Control"
                             >
                                 <span class="absolute top-1 left-1 bg-white w-4 h-4 rounded-full transition-transform {settingsState.galaxySettings.enableGyroscope ? 'translate-x-6' : 'translate-x-0'}"></span>
                             </button>


### PR DESCRIPTION
- Resolved accessibility warning for button missing label in VisualsTab.
- Added `aria-label="Toggle Gyroscope Control"`.