### PR TITLE
Fix TypeScript errors and missing translations

### DIFF
--- a/src/components/shared/OrderHistoryList.svelte
+++ b/src/components/shared/OrderHistoryList.svelte
@@ -101,7 +101,7 @@
     </div>
   {:else if error}
     <div class="text-xs text-[var(--danger-color)] p-2 text-center">
-      {(error.startsWith("apiErrors.") || error.startsWith("bitunixErrors.")) && typeof $_ === "function" ? $_(error) : error}
+      {(error.startsWith("apiErrors.") || error.startsWith("bitunixErrors.")) && typeof $_ === "function" ? $_(error as any) : error}
     </div>
   {:else if orders.length === 0}
     <div class="text-xs text-[var(--text-secondary)] text-center p-4">

--- a/src/locales/locales/de.json
+++ b/src/locales/locales/de.json
@@ -1504,5 +1504,8 @@
   },
   "markdownErrors": {
     "fileNotFound": "Markdown-Datei nicht gefunden: {path}"
+  },
+  "academy": {
+    "title": "Trading Academy"
   }
 }

--- a/src/locales/schema.d.ts
+++ b/src/locales/schema.d.ts
@@ -1211,4 +1211,5 @@ export type TranslationKey =
   | "workerErrors.eventError"
   | "workerErrors.notAvailable"
   | "workerErrors.timeout"
-  | "markdownErrors.fileNotFound";
+  | "markdownErrors.fileNotFound"
+  | "academy.title";


### PR DESCRIPTION
Resolved TypeScript errors in LeftControlPanel.svelte and OrderHistoryList.svelte. Added missing translation for "academy.title" in German locale.

---
*PR created automatically by Jules for task [11570582793109967926](https://jules.google.com/task/11570582793109967926) started by @mydcc*