### PR TITLE
fix(SidePanel): untrack bringToFront call in effect

### DIFF
--- a/src/components/shared/SidePanel.svelte
+++ b/src/components/shared/SidePanel.svelte
@@ -16,7 +16,7 @@
 -->
 
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
   import { fly, scale } from "svelte/transition";
   import { chatState } from "../../stores/chat.svelte";
   import { notesState } from "../../stores/notes.svelte";
@@ -45,7 +45,7 @@
 
   $effect(() => {
     if (isOpen) {
-      bringToFront();
+      untrack(() => bringToFront());
     }
   });
 


### PR DESCRIPTION
- Wrap the `bringToFront()` call inside the `$effect` with `untrack()` to prevent an infinite reactive loop.
- `bringToFront()` triggers `floatingWindowsStore.requestZIndex()`, which reads and writes `nextZIndex`. Without `untrack()`, the effect subscribes to `nextZIndex`, causing a self-invalidation loop.
- This addresses a critical bug where opening the side panel caused the app to freeze and memory to spike.