### PR TITLE
fix(SidePanel): suppress a11y warning for mouse interaction

### DIFF
--- a/src/components/shared/SidePanel.svelte
+++ b/src/components/shared/SidePanel.svelte
@@ -486,6 +486,7 @@
 
     <!-- MAIN PANEL CONTENT -->
     {#if isOpen}
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
       <div
         bind:this={panelEl}
         onmousedown={bringToFront}


### PR DESCRIPTION
- Add `svelte-ignore a11y_no_noninteractive_element_interactions` to the main SidePanel container.
- The `onmousedown` listener is used strictly for z-index management (bringing the window to the front), which is a visual behavior.
- The panel already has `role="region"` and `aria-label` for accessibility structure.
- This resolves the build warning reported by the user.