### PR TITLE
Add Gamified Flashcard Quiz

### DIFF
--- a/src/components/shared/FlashCard.svelte
+++ b/src/components/shared/FlashCard.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import { quizState } from "../../stores/quiz.svelte";
+  import { fade, scale } from "svelte/transition";
+  import { quintOut } from "svelte/easing";
+
+  let isFlipped = $state(false);
+
+  // Reset flip when active question changes (new card)
+  $effect(() => {
+    if (quizState.activeQuestion) {
+      isFlipped = false;
+    }
+  });
+
+  function handleFlip() {
+    isFlipped = !isFlipped;
+  }
+
+  function handleKnown() {
+    quizState.markKnown();
+  }
+
+  function handleUnknown() {
+    quizState.markUnknown();
+  }
+</script>
+
+{#if quizState.isQuizActive && quizState.activeQuestion}
+  <!-- Backdrop -->
+  <div
+    class="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+    transition:fade={{ duration: 200 }}
+    onclick={() => quizState.closeQuiz()}
+    role="button"
+    tabindex="0"
+    onkeydown={(e) => e.key === "Escape" && quizState.closeQuiz()}
+  >
+    <!-- Card Container -->
+    <div
+      class="relative w-full max-w-md aspect-[4/3] perspective-1000 cursor-pointer group"
+      onclick={(e) => {
+        e.stopPropagation();
+        if (!isFlipped) handleFlip();
+      }}
+      transition:scale={{ duration: 300, easing: quintOut, start: 0.8 }}
+      role="button"
+      tabindex="0"
+      onkeydown={(e) => e.key === "Enter" && handleFlip()}
+    >
+      <!-- Card Inner -->
+      <div
+        class="relative w-full h-full duration-500 preserve-3d transition-transform {isFlipped
+          ? 'rotate-y-180'
+          : ''}"
+      >
+        <!-- Front -->
+        <div
+          class="absolute inset-0 backface-hidden flex flex-col items-center justify-center p-8 text-center bg-[var(--bg-secondary)] border border-[var(--border-color)] rounded-2xl shadow-2xl glass-panel"
+        >
+          <div
+            class="text-[var(--text-secondary)] text-sm uppercase tracking-widest font-bold mb-4"
+          >
+            Frage
+          </div>
+          <h3
+            class="text-xl md:text-2xl font-bold text-[var(--text-primary)] leading-relaxed select-none"
+          >
+            {quizState.activeQuestion.question}
+          </h3>
+          <div
+            class="absolute bottom-6 text-xs text-[var(--text-tertiary)] animate-pulse select-none"
+          >
+            Klicken zum Aufdecken
+          </div>
+        </div>
+
+        <!-- Back -->
+        <div
+          class="absolute inset-0 backface-hidden rotate-y-180 flex flex-col items-center justify-center p-8 text-center bg-[var(--bg-secondary)] border border-[var(--border-color)] rounded-2xl shadow-2xl glass-panel"
+        >
+          <div class="flex-1 flex flex-col items-center justify-center w-full">
+            <div
+              class="text-[var(--text-secondary)] text-sm uppercase tracking-widest font-bold mb-2"
+            >
+              Antwort
+            </div>
+            <p
+              class="text-lg text-[var(--text-primary)] leading-relaxed overflow-y-auto max-h-[60%] w-full scrollbar-hide"
+            >
+              {quizState.activeQuestion.answer}
+            </p>
+          </div>
+
+          <div class="flex gap-4 w-full mt-4 shrink-0">
+            <button
+              class="flex-1 py-3 px-4 rounded-xl font-bold text-white bg-red-500 hover:bg-red-600 transition-colors shadow-lg hover:shadow-red-500/20 active:scale-95 transform duration-100"
+              onclick={(e) => {
+                e.stopPropagation();
+                handleUnknown();
+              }}
+            >
+              Noch üben
+            </button>
+            <button
+              class="flex-1 py-3 px-4 rounded-xl font-bold text-white bg-green-500 hover:bg-green-600 transition-colors shadow-lg hover:shadow-green-500/20 active:scale-95 transform duration-100"
+              onclick={(e) => {
+                e.stopPropagation();
+                handleKnown();
+              }}
+            >
+              Gewusst
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .perspective-1000 {
+    perspective: 1000px;
+  }
+  .preserve-3d {
+    transform-style: preserve-3d;
+  }
+  .backface-hidden {
+    backface-visibility: hidden;
+  }
+  .rotate-y-180 {
+    transform: rotateY(180deg);
+  }
+</style>

--- a/src/components/shared/LeftControlPanel.svelte
+++ b/src/components/shared/LeftControlPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { settingsState } from "../../stores/settings.svelte";
   import { uiState } from "../../stores/ui.svelte";
+  import { quizState } from "../../stores/quiz.svelte";
   import { _ } from "../../locales/i18n";
   import { icons } from "../../lib/constants";
   import Tooltip from "./Tooltip.svelte";
@@ -49,18 +50,29 @@
   </button>
 
   <!-- Academy Button -->
-  <button
-    class="control-btn"
-    onclick={() => uiState.toggleAcademyModal(true)}
-    title={$_("academy.title") || "Trading Academy"}
-    use:trackClick={{
+  <div class="relative w-full flex justify-center">
+    <button
+      class="control-btn"
+      onclick={() => uiState.toggleAcademyModal(true)}
+      title={$_("academy.title") || "Trading Academy"}
+      use:trackClick={{
         category: "Navigation",
         action: "Click",
         name: "OpenAcademy",
-    }}
-  >
-    {@html ICONS.academy}
-  </button>
+      }}
+    >
+      {@html ICONS.academy}
+    </button>
+    <!-- Quiz Progress Bar -->
+    {#if quizState.questions.length > 0}
+      <div
+        class="absolute left-[2px] bottom-1 w-[2px] bg-[var(--success-color)] rounded-full transition-all duration-500"
+        style:height="{(quizState.knownQuestionIds.size /
+          quizState.questions.length) *
+          28}px"
+      ></div>
+    {/if}
+  </div>
 
   <div class="h-px w-full bg-[var(--border-color)] my-1"></div>
 

--- a/src/components/shared/QuizButton.svelte
+++ b/src/components/shared/QuizButton.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { quizState } from "../../stores/quiz.svelte";
+  import { trackClick } from "../../lib/actions";
+</script>
+
+<button
+  class="btn-icon-accent"
+  class:active={quizState.isQuizActive}
+  onclick={() => quizState.startQuiz()}
+  use:trackClick={{
+    category: "Quiz",
+    action: "Click",
+    name: "StartQuiz",
+  }}
+  aria-label="Start Quiz"
+  title="Quick Quiz"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    stroke-width="2"
+    class="w-5 h-5"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+    />
+  </svg>
+</button>
+
+<style>
+  .btn-icon-accent {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    transition: all 0.2s;
+    color: var(--text-secondary);
+  }
+  .btn-icon-accent:hover {
+    color: var(--text-primary);
+    background-color: var(--bg-tertiary);
+  }
+  .btn-icon-accent.active {
+    color: var(--accent-color);
+    background: rgba(var(--accent-color-rgb), 0.1);
+  }
+</style>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,6 +22,8 @@ export const CONSTANTS = {
   LOCAL_STORAGE_JOURNAL_KEY: "tradeJournal",
   LOCAL_STORAGE_PRESETS_KEY: "cryptoCalculatorPresets",
   LOCAL_STORAGE_THEME_KEY: "cachy_theme",
+  LOCAL_STORAGE_QUIZ_KEY: "cachy_quiz_state",
+  FLASHCARDS_CSV_PATH: "/quiz/flashcards.csv",
   STATUS_INVALID: "INVALID",
   STATUS_INCOMPLETE: "INCOMPLETE",
   STATUS_VALID: "VALID",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,6 +57,8 @@
   import NewsSentimentPanel from "../components/shared/NewsSentimentPanel.svelte";
   import AcademyModal from "../components/shared/AcademyModal.svelte";
   import PowerToggle from "../components/shared/PowerToggle.svelte";
+  import QuizButton from "../components/shared/QuizButton.svelte";
+  import FlashCard from "../components/shared/FlashCard.svelte";
   import { handleGlobalKeydown } from "../services/hotkeyService";
 
   let changelogContent = $state("");
@@ -661,6 +663,7 @@
         <div class="mt-4 flex justify-between items-center">
           <LanguageSwitcher />
           <div class="flex items-center gap-2">
+            <QuizButton />
             <FloatingIframeButton />
           </div>
           <div class="flex items-center gap-2">
@@ -864,3 +867,4 @@
 </ModalFrame>
 
 <AcademyModal />
+<FlashCard />

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -29,6 +29,7 @@ interface BackupData {
   journal: string | null; // Stored as a raw string from localStorage
   tradeState: string | null; // Stored as a raw string from localStorage
   theme: string | null; // Stored as a raw string from localStorage
+  quizState: string | null; // Stored as a raw string from localStorage
 }
 
 // The overall structure of the backup file
@@ -83,6 +84,7 @@ export async function createBackup(password?: string) {
       CONSTANTS.LOCAL_STORAGE_TRADE_KEY || "cachy_trade_store",
     ),
     theme: getDataFromLocalStorage("theme"), // Theme is often just a string ("dark"|"light"), not JSON
+    quizState: getValidatedData(CONSTANTS.LOCAL_STORAGE_QUIZ_KEY),
   };
 
   const backupFile: BackupFile = {
@@ -230,6 +232,9 @@ export async function restoreFromBackup(
     }
     if (data.theme) {
       localStorage.setItem("theme", data.theme);
+    }
+    if (data.quizState) {
+      localStorage.setItem(CONSTANTS.LOCAL_STORAGE_QUIZ_KEY, data.quizState);
     }
 
     return {

--- a/src/stores/quiz.svelte.ts
+++ b/src/stores/quiz.svelte.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { browser } from "$app/environment";
+import { CONSTANTS } from "../lib/constants";
+
+export interface FlashCard {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+class QuizStore {
+  questions = $state<FlashCard[]>([]);
+  knownQuestionIds = $state<Set<string>>(new Set());
+  activeQuestion = $state<FlashCard | null>(null);
+  isQuizActive = $state(false);
+  isLoading = $state(false);
+
+  constructor() {
+    if (browser) {
+      this.loadProgress();
+      this.loadQuestions();
+    }
+  }
+
+  loadProgress() {
+    try {
+      const stored = localStorage.getItem(CONSTANTS.LOCAL_STORAGE_QUIZ_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          this.knownQuestionIds = new Set(parsed);
+        }
+      }
+    } catch (e) {
+      console.warn("Failed to load quiz progress", e);
+    }
+  }
+
+  saveProgress() {
+    if (!browser) return;
+    try {
+      localStorage.setItem(
+        CONSTANTS.LOCAL_STORAGE_QUIZ_KEY,
+        JSON.stringify(Array.from(this.knownQuestionIds))
+      );
+    } catch (e) {
+      console.error("Failed to save quiz progress", e);
+    }
+  }
+
+  async loadQuestions() {
+    try {
+      this.isLoading = true;
+      const response = await fetch(CONSTANTS.FLASHCARDS_CSV_PATH);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const text = await response.text();
+      this.questions = this.parseCSV(text);
+    } catch (e) {
+      console.error("Failed to load flashcards", e);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  parseCSV(text: string): FlashCard[] {
+    const lines = text.split("\n").filter((l) => l.trim().length > 0);
+    const cards: FlashCard[] = [];
+
+    // Simple regex for CSV splitting: matches comma only if followed by even number of quotes
+    const regex = /,(?=(?:(?:[^"]*"){2})*[^"]*$)/;
+
+    lines.forEach((line) => {
+      const parts = line.split(regex);
+
+      if (parts.length >= 2) {
+        let question = parts[0].trim();
+        let answer = parts[1].trim();
+
+        // Unquote
+        if (question.startsWith('"') && question.endsWith('"')) {
+          question = question.slice(1, -1).replace(/""/g, '"');
+        }
+        if (answer.startsWith('"') && answer.endsWith('"')) {
+          answer = answer.slice(1, -1).replace(/""/g, '"');
+        }
+
+        // Simple ID generation
+        const id = btoa(unescape(encodeURIComponent(question))).slice(0, 16);
+
+        cards.push({ id, question, answer });
+      }
+    });
+    return cards;
+  }
+
+  startQuiz() {
+    if (this.questions.length === 0) return;
+
+    // Filter unknown questions
+    const unknownQuestions = this.questions.filter(
+      (q) => !this.knownQuestionIds.has(q.id)
+    );
+
+    if (unknownQuestions.length === 0) {
+      // All known! Maybe show a specific "Mastered" card?
+      // For now, we might reset or just pick one at random from all
+      // But user wanted "Stack of un-known questions".
+      // If empty, let's just pick any random one to keep playing, or handle "Done" UI.
+      // I'll pick a random one from ALL to allow replay, but user knows they finished.
+      // Or better: Show nothing and return? No, better to replay.
+      const randomIndex = Math.floor(Math.random() * this.questions.length);
+      this.activeQuestion = this.questions[randomIndex];
+    } else {
+      const randomIndex = Math.floor(Math.random() * unknownQuestions.length);
+      this.activeQuestion = unknownQuestions[randomIndex];
+    }
+
+    this.isQuizActive = true;
+  }
+
+  closeQuiz() {
+    this.isQuizActive = false;
+    // Delay clearing active question for animation if needed, but for now immediate
+    setTimeout(() => {
+        this.activeQuestion = null;
+    }, 300);
+  }
+
+  markKnown() {
+    if (this.activeQuestion) {
+      this.knownQuestionIds.add(this.activeQuestion.id);
+      // Reactivity hack for Sets in Svelte 5 (reassign)
+      this.knownQuestionIds = new Set(this.knownQuestionIds);
+      this.saveProgress();
+    }
+    this.closeQuiz();
+  }
+
+  markUnknown() {
+    // Just close, remains in pool
+    this.closeQuiz();
+  }
+
+  resetProgress() {
+    this.knownQuestionIds = new Set();
+    this.saveProgress();
+  }
+
+  exportState(): string {
+     return JSON.stringify(Array.from(this.knownQuestionIds));
+  }
+
+  importState(json: string) {
+    try {
+        const parsed = JSON.parse(json);
+        if (Array.isArray(parsed)) {
+            this.knownQuestionIds = new Set(parsed);
+            this.saveProgress();
+        }
+    } catch (e) {
+        console.error("Failed to import quiz state", e);
+    }
+  }
+}
+
+export const quizState = new QuizStore();


### PR DESCRIPTION
Implemented a flashcard quiz system using data from 'static/quiz/flashcards.csv'. Includes a new 'QuizState' store (Svelte 5 runes) for managing questions and progress (persisted to localStorage and backups). Added 'FlashCard.svelte' for the interactive 3D flip card UI, 'QuizButton.svelte' in the footer to trigger the quiz, and a progress bar in 'LeftControlPanel.svelte'. Localization set to German as requested.

---
*PR created automatically by Jules for task [9895007730328042697](https://jules.google.com/task/9895007730328042697) started by @mydcc*