### PR TITLE
Fix Bitunix kline fetch error handling for invalid symbols

### DIFF
--- a/src/services/dataRepairService.ts
+++ b/src/services/dataRepairService.ts
@@ -150,8 +150,14 @@ export const dataRepairService = {
         } else {
           failed++;
         }
-      } catch (e) {
-        logger.error("journal", `[DataRepair] Failed to repair ${trade.symbol}`, e);
+      } catch (e: any) {
+        if (e.message !== "apiErrors.symbolNotFound") {
+          logger.error(
+            "journal",
+            `[DataRepair] Failed to repair ${trade.symbol}`,
+            e,
+          );
+        }
         failed++;
         // Continue with next trade
       }
@@ -288,8 +294,14 @@ export const dataRepairService = {
         } else {
           failed++;
         }
-      } catch (e) {
-        logger.error("journal", `[DataRepair] MFE/MAE Err ${trade.symbol}`, e);
+      } catch (e: any) {
+        if (e.message !== "apiErrors.symbolNotFound") {
+          logger.error(
+            "journal",
+            `[DataRepair] MFE/MAE Err ${trade.symbol}`,
+            e,
+          );
+        }
         failed++;
       }
 


### PR DESCRIPTION
Modified `fetchBitunixKlines` in `src/services/apiService.ts` to inspect error responses for "symbol not found" or "system error" messages and throw `apiErrors.symbolNotFound` instead of the generic `apiErrors.klineError`. Updated `src/services/dataRepairService.ts` to suppress logging when encountering `apiErrors.symbolNotFound`, resolving the issue where invalid symbols caused noisy "[NETWORK]" error logs during background repair tasks. Verified with unit tests.

---
*PR created automatically by Jules for task [7891120033463687944](https://jules.google.com/task/7891120033463687944) started by @mydcc*