### PR TITLE
⚡ Optimize Trade Store Reset with structuredClone

### DIFF
--- a/src/stores/trade.svelte.ts
+++ b/src/stores/trade.svelte.ts
@@ -299,7 +299,7 @@ class TradeManager {
     this.atrTimeframe = INITIAL_TRADE_STATE.atrTimeframe;
     this.tradeNotes = INITIAL_TRADE_STATE.tradeNotes;
     this.tags = [...INITIAL_TRADE_STATE.tags];
-    this.targets = JSON.parse(JSON.stringify(INITIAL_TRADE_STATE.targets));
+    this.targets = structuredClone(INITIAL_TRADE_STATE.targets);
     this.isPositionSizeLocked = INITIAL_TRADE_STATE.isPositionSizeLocked;
     this.lockedPositionSize = INITIAL_TRADE_STATE.lockedPositionSize;
     this.isRiskAmountLocked = INITIAL_TRADE_STATE.isRiskAmountLocked;
@@ -375,7 +375,7 @@ class TradeManager {
     const currentTradeType = this.tradeType;
 
     // Reset everything to deep copy of initial state to prevent reference issues
-    const defaults = JSON.parse(JSON.stringify(INITIAL_TRADE_STATE));
+    const defaults = structuredClone(INITIAL_TRADE_STATE);
     Object.assign(this, defaults);
 
     // Restore preserved values


### PR DESCRIPTION
💡 **What:**
Replaced the legacy deep cloning pattern `JSON.parse(JSON.stringify(...))` with the modern `structuredClone(...)` in `src/stores/trade.svelte.ts` (specifically in `resetToDefaults` and `resetInputs`).

🎯 **Why:**
1.  **Correctness:** `JSON.stringify` removes keys with `undefined` values. This meant that optional fields in `INITIAL_TRADE_STATE` (like `remoteLeverage`, `remoteMakerFee`, etc.) were missing from the clone. Consequently, `Object.assign(this, defaults)` failed to reset these fields if they held values, leaving stale data in the store. `structuredClone` preserves `undefined`, ensuring a true full reset.
2.  **Modernization:** `structuredClone` is the standard, native API for this purpose.

📊 **Measured Improvement:**
A benchmark was run in the Node.js v22 environment comparing the two methods on the `INITIAL_TRADE_STATE` structure.
*   **Result:** `structuredClone` was slightly slower (~0.007ms vs ~0.005ms per op) than the highly optimized V8 `JSON` implementation for this specific simple object structure.
*   **Conclusion:** The performance difference is in the *microseconds* range and is negligible for this use case (UI state reset). The functional improvement (handling `undefined` correctly) and code cleanliness justify the change despite the lack of raw throughput gain in this specific runtime environment.

---
*PR created automatically by Jules for task [1510761371104917601](https://jules.google.com/task/1510761371104917601) started by @mydcc*