### PR TITLE
Fix translation structure for Cloud feature and add missing keys

### DIFF
--- a/src/locales/locales/de.json
+++ b/src/locales/locales/de.json
@@ -899,14 +899,6 @@
       "planFree": "Kostenlos",
       "planPro": "Pro"
     },
-    "cloud": {
-      "title": "Community Cloud (Beta)",
-      "description": "Verbinde dich mit SpacetimeDB, um mit anderen Tradern zu chatten.",
-      "connectButton": "Verbinden",
-      "noMessages": "Noch keine Nachrichten.",
-      "sendButton": "Senden",
-      "placeholder": "Sag Hallo..."
-    },
     "trading": {
       "executionTitle": "Exekution & Gebühren",
       "chartTitle": "Chart & Daten"
@@ -1736,5 +1728,13 @@
   },
   "windows": {
     "smash": "Fenster zerschlagen"
+  },
+  "cloud": {
+    "title": "Community Cloud (Beta)",
+    "description": "Verbinde dich mit SpacetimeDB, um mit anderen Tradern zu chatten.",
+    "connectButton": "Verbinden",
+    "noMessages": "Noch keine Nachrichten.",
+    "sendButton": "Senden",
+    "placeholder": "Sag Hallo..."
   }
 }

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -207,7 +207,8 @@
     "takeProfitTargets": {
       "header": "Take-Profit Targets (Partial)",
       "tooltip": "Here you see calculated metrics for each partial take-profit target.",
-      "addTargetTitle": "Add another target"
+      "addTargetTitle": "Add another target",
+      "emptyState": "No targets defined. Add a target above."
     },
     "summaryResults": {
       "header": "Summary",
@@ -999,14 +1000,6 @@
       "planFree": "Free",
       "planPro": "Pro"
     },
-    "cloud": {
-      "title": "Community Cloud (Beta)",
-      "description": "Connect to SpacetimeDB to chat with other traders.",
-      "connectButton": "Connect to Local Cloud",
-      "noMessages": "No messages yet.",
-      "sendButton": "Send",
-      "placeholder": "Say hello..."
-    },
     "imgbbExpiration": "Expiration Time",
     "integrations": {
       "addFeed": "Add Feed",
@@ -1732,5 +1725,13 @@
   },
   "windows": {
     "smash": "Smash Window"
+  },
+  "cloud": {
+    "title": "Community Cloud (Beta)",
+    "description": "Connect to SpacetimeDB to chat with other traders.",
+    "connectButton": "Connect to Local Cloud",
+    "noMessages": "No messages yet.",
+    "sendButton": "Send",
+    "placeholder": "Say hello..."
   }
 }


### PR DESCRIPTION
Moved 'cloud' translation object from 'settings' to root level in en.json and de.json to match code usage. Added missing 'dashboard.takeProfitTargets.emptyState' key to en.json.