### PR TITLE
feat: finalize heatmap popout logic

### DIFF
--- a/src/components/settings/tabs/TradingTab.svelte
+++ b/src/components/settings/tabs/TradingTab.svelte
@@ -311,9 +311,9 @@
                                                     bind:value={settingsState.heatmapMode}
                                                     class="input-field py-1.5 text-xs w-full"
                                                 >
-                                                    <option value="coinglass_link">Coinglass (Link)</option>
+                                                    <option value="coinglass_new_tab">Coinglass (New Tab)</option>
                                                     <option value="coinglass_popup">Coinglass (Popup Window)</option>
-                                                    <option value="coinank_link">Coinank (Link)</option>
+                                                    <option value="coinank_new_tab">Coinank (New Tab)</option>
                                                     <option value="coinank_popup">Coinank (ProChart Popup)</option>
                                                 </select>
                                                 <p class="text-[10px] text-[var(--text-secondary)] opacity-80">

--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -311,12 +311,12 @@
     // Use effective RSI timeframe as proxy for "active strategy timeframe"
     const tf = effectiveRsiTimeframe || "1d";
 
-    if (mode === "coinank_link") {
+    if (mode === "coinank_new_tab") {
       return getCoinankUrl(symbol, tf, currentProvider, "link");
     } else if (mode === "coinank_popup") {
       return getCoinankUrl(symbol, tf, currentProvider, "iframe");
     } else {
-      // Coinglass (link or popup)
+      // Coinglass (new tab or popup)
       return getCoinglassUrl(symbol);
     }
   });
@@ -328,14 +328,18 @@
     const tf = effectiveRsiTimeframe || "1d";
 
     if (mode === "coinglass_popup") {
-      // Open Popup Window (solves CORS image issue by just showing the page in a dedicated window)
+      // Open Popup Window
       externalLinkService.openPopout(cgHeatmapLink, cgTarget, 1200, 800);
     } else if (mode === "coinank_popup") {
-      // Open Popup Window (solves Iframe Login issue by sharing session with main window)
+      // Open ProChart Popup
       const url = getCoinankUrl(symbol, tf, currentProvider, "iframe");
       externalLinkService.openPopout(url, `coinank_${symbol}_${tf}`, 1400, 900);
+    } else if (mode === "coinank_new_tab") {
+      // Coinank Standard Link (New Tab)
+      const url = getCoinankUrl(symbol, tf, currentProvider, "link");
+      externalLinkService.openOrFocus(url, `coinank_heat_${symbol}`);
     } else {
-      // Direct Link
+      // Coinglass Standard Link (New Tab) - Default
       externalLinkService.openOrFocus(cgHeatmapLink, cgTarget);
     }
   }

--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -32,7 +32,7 @@ export type AnalysisDepth = "quick" | "standard" | "deep";
 
 export type MarketMode = "performance" | "balanced" | "pro" | "custom";
 export type TechnicalsUpdateMode = "realtime" | "fast" | "balanced" | "conservative";
-export type HeatmapMode = "coinglass_link" | "coinglass_popup" | "coinank_link" | "coinank_popup";
+export type HeatmapMode = "coinglass_new_tab" | "coinglass_popup" | "coinank_new_tab" | "coinank_popup";
 
 export const TECHNICALS_UPDATE_PRESETS = {
   realtime: {
@@ -362,7 +362,7 @@ const defaultSettings: Settings = {
   showTechnicalsPivots: true,
   showTvLink: true,
   showCgHeatLink: true,
-  heatmapMode: "coinglass_link",
+  heatmapMode: "coinglass_new_tab",
   showBrokerLink: true,
   rssPresets: ["coindesk", "cointelegraph"],
   customRssFeeds: [],


### PR DESCRIPTION
- Updated `heatmapMode` types in `Settings` to explicitly distinguish between "New Tab" and "Popup Window" modes (`coinglass_new_tab`, `coinglass_popup`, `coinank_new_tab`, `coinank_popup`).
- Updated `MarketOverview` to use `externalLinkService.openPopout` for popup modes (resolving Auth/CORS issues) and `openOrFocus` for new tab modes.
- Added `openPopout` to `ExternalLinkService` to handle detached window creation.
- Removed unused `ImageModal` component and dead translation keys.
- Updated Settings UI to reflect the refined options.