### PR TITLE
Analysis Report: 2000 Candles in TradingView Chart

### DIFF
--- a/src/services/marketWatcher.ts
+++ b/src/services/marketWatcher.ts
@@ -316,6 +316,8 @@ class MarketWatcher {
             const currentData = marketState.data[symbol]?.klines[tf] || [];
 
             // Fetch part 2: Backfill if needed
+            // If the requested limit (e.g. 2000) exceeds the API max (1000), we perform a second fetch
+            // using the oldest timestamp from the first batch to retrieve the preceding history.
             if (limit > 1000 && klines1.length >= 1000 && currentData.length < limit) {
                 const oldestTime = klines1[0].time;
                 const klines2 = await apiService.fetchBitunixKlines(symbol, tf, 1000, undefined, oldestTime);


### PR DESCRIPTION
Analysebericht: 2000 Kerzen im TradingView Chart

Ich habe den Datenfluss im Code untersucht, um sicherzustellen, dass das Ziel von 2000 Kerzen erreicht wird.

1.  **Datenquelle (`MarketWatcher`)**:
    Der `MarketWatcher` Service (`src/services/marketWatcher.ts`) implementiert eine intelligente Backfill-Logik.
    Da die API oft ein Limit von 1000 Kerzen pro Anfrage hat, prüft `ensureHistory`, ob das gewünschte Limit (Standard 2000) höher ist als das API-Limit.
    Falls ja, wird nach dem Laden der ersten 1000 Kerzen eine zweite Anfrage gestellt, die das Zeitstempel-Ende der ersten Batch als Referenz nutzt, um die davor liegenden historischen Daten zu laden.

2.  **Datenspeicherung (`MarketState`)**:
    Im `MarketStore` (`src/stores/market.svelte.ts`) werden die empfangenen Kerzen gespeichert. Die `updateSymbolKlines` Methode respektiert strikt das `settingsState.chartHistoryLimit`. Wenn dieses auf 2000 gesetzt ist (Standard), behält der Store bis zu 2000 Kerzen im Speicher und schneidet ältere Daten ab, um Speicherlecks zu vermeiden.

3.  **Anzeige (`CandleChartView`)**:
    Die Komponente `CandleChartView.svelte` abonniert reaktiv die Daten aus dem `MarketState`. Sobald der Store durch den Backfill-Prozess aktualisiert wird (also 2000 Kerzen enthält), werden diese vollständig an die `lightweight-charts` Instanz übergeben (`candleSeries.setData`).

4.  **Konfiguration**:
    In `src/stores/settings.svelte.ts` ist `chartHistoryLimit` standardmäßig auf 2000 gesetzt.

**Fazit**:
Das System ist korrekt implementiert, um 2000 Kerzen zu laden und anzuzeigen. Ich habe zur Verdeutlichung Kommentare in `src/services/marketWatcher.ts` hinzugefügt, die diese Backfill-Logik dokumentieren.

---
*PR created automatically by Jules for task [3059613852891678809](https://jules.google.com/task/3059613852891678809) started by @mydcc*