### PR TITLE
Fix: Prevent null values in EMA series data causing chart crash

### DIFF
--- a/src/lib/windows/implementations/CandleChartView.svelte
+++ b/src/lib/windows/implementations/CandleChartView.svelte
@@ -358,11 +358,21 @@
 
                             const mapToSeries = (arr: number[]) =>
                                 arr
-                                    .map((val: number, i: number) => ({
-                                        time: unique[i].time,
-                                        value: val,
-                                    }))
-                                    .filter((d) => !isNaN(d.value));
+                                    .map((val: number, i: number) => {
+                                        if (!unique[i]) return null;
+                                        return {
+                                            time: unique[i].time,
+                                            value: val,
+                                        };
+                                    })
+                                    .filter(
+                                        (d): d is { time: Time; value: number } =>
+                                            d !== null &&
+                                            d.value !== null &&
+                                            d.value !== undefined &&
+                                            typeof d.value === "number" &&
+                                            !isNaN(d.value),
+                                    );
 
                             ema1Series.setData(mapToSeries(ema1));
                             ema2Series.setData(mapToSeries(ema2));


### PR DESCRIPTION
Updated `src/lib/windows/implementations/CandleChartView.svelte` to implement stricter filtering in `mapToSeries` function. 

This change ensures that `null` or `undefined` values are explicitly removed from the data passed to Lightweight Charts `LineSeries`. The previous check `!isNaN(d.value)` was insufficient as `!isNaN(null)` evaluates to `true` in JavaScript. Passing `null` as a value to `LineSeries` in Lightweight Charts v5.x causes a runtime crash ("Value is null").

Also added a boundary check for `unique[i]` to prevent accessing properties of undefined indices.

---
*PR created automatically by Jules for task [8975513393576448484](https://jules.google.com/task/8975513393576448484) started by @mydcc*