### PR TITLE
Fix Bitunix API Rate Limiting

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -51,9 +51,9 @@ class RateLimiter {
   private readonly capacity: number;
   private readonly refillRateMs: number;
 
-  constructor(tokensPerSecond: number) {
-    this.capacity = tokensPerSecond;
-    this.tokens = tokensPerSecond;
+  constructor(tokensPerSecond: number, capacity?: number) {
+    this.capacity = capacity ?? tokensPerSecond;
+    this.tokens = this.capacity;
     this.lastRefill = Date.now();
     this.refillRateMs = tokensPerSecond / 1000;
   }
@@ -118,8 +118,8 @@ class RequestManager {
     }
 
     // Initialize Rate Limiters
-    // Bitunix: Conservative 10 req/s to avoid 500 "frequent request" error
-    this.rateLimiters.set("BITUNIX", new RateLimiter(10));
+    // Bitunix: Conservative 5 req/s with no burst to avoid 500 "frequent request" error
+    this.rateLimiters.set("BITUNIX", new RateLimiter(5, 1));
     // Bitget: Usually 20 req/s
     this.rateLimiters.set("BITGET", new RateLimiter(20));
   }

--- a/src/services/marketWatcher.ts
+++ b/src/services/marketWatcher.ts
@@ -41,7 +41,7 @@ class MarketWatcher {
   private unlockTimeouts = new Map<string, any>(); // Track lock release timers to prevent race conditions
   private proactiveLockTimeouts = new Map<string, any>(); // Safety valve for stuck locks
   private staggerTimeouts = new Set<any>(); // Track staggered requests to prevent zombie calls
-  private maxConcurrentPolls = 12; // Reduced to mitigate rate limits (worked with RateLimiter)
+  private maxConcurrentPolls = 6; // Reduced to mitigate rate limits (aligned with strict token bucket)
   private inFlight = 0;
   private lastErrorLog = 0;
   private readonly errorLogIntervalMs = 30000;


### PR DESCRIPTION
- Updated `RateLimiter` in `src/services/apiService.ts` to support configurable burst `capacity`.
- Configured Bitunix rate limiter to 5 requests per second with a burst capacity of 1 (effectively strictly sequential with 200ms spacing).
- Reduced `maxConcurrentPolls` in `src/services/marketWatcher.ts` from 12 to 6 to align with stricter rate limits and prevent backlog.
- Updated `src/services/apiService_rateLimit.test.ts` to verify the new rate limiting behavior.

---
*PR created automatically by Jules for task [906987554804999845](https://jules.google.com/task/906987554804999845) started by @mydcc*