### PR TITLE
Fix Galaxy 3D background visibility issue

### DIFF
--- a/src/components/shared/BackgroundRenderer.svelte
+++ b/src/components/shared/BackgroundRenderer.svelte
@@ -62,13 +62,16 @@
 
   $effect(() => {
     if (typeof document !== "undefined") {
-      document.documentElement.style.setProperty(
-        "--bg-blur",
-        `${settingsState.backgroundBlur}px`,
-      );
+      // Force full visibility for ThreeJS to prevent "covering" by background color
+      // due to default blur/opacity settings meant for images
+      const isThree = settingsState.backgroundType === "threejs";
+      const blur = isThree ? 0 : settingsState.backgroundBlur;
+      const opacity = isThree ? 1 : settingsState.backgroundOpacity;
+
+      document.documentElement.style.setProperty("--bg-blur", `${blur}px`);
       document.documentElement.style.setProperty(
         "--bg-opacity",
-        settingsState.backgroundOpacity.toString(),
+        opacity.toString(),
       );
     }
   });


### PR DESCRIPTION
The Galaxy 3D background was "flashing" briefly on load and then disappearing or appearing "covered". This was caused by `BackgroundRenderer` applying global background blur (default 5px) and opacity (default 0.3) settings to the ThreeJS canvas container. These defaults are suitable for background images to improve text readability but render a starfield invisible. The fix conditionally overrides these CSS variables to ensure the 3D scene is fully visible and crisp when active.

---
*PR created automatically by Jules for task [7266917106299586072](https://jules.google.com/task/7266917106299586072) started by @mydcc*