### PR TITLE
Refactor tracking to use Data Layer and add global context

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -17,6 +17,8 @@
 
 // src/lib/actions.ts
 
+import { trackCustomEvent } from "../services/trackingService";
+
 interface TrackClickParams {
   category: string;
   action: string;
@@ -24,13 +26,30 @@ interface TrackClickParams {
 }
 
 export function trackClick(node: HTMLElement, params: TrackClickParams) {
-  node.setAttribute("data-mtm-category", params.category);
-  node.setAttribute("data-mtm-action", params.action);
-  node.setAttribute("data-mtm-name", params.name);
+  // Legacy attributes for reference (optional, but cleaner to remove to force migration to Data Layer)
+  // node.setAttribute("data-mtm-category", params.category);
+  // node.setAttribute("data-mtm-action", params.action);
+  // node.setAttribute("data-mtm-name", params.name);
+
+  let currentParams = params;
+
+  function handleClick() {
+    trackCustomEvent(
+      currentParams.category,
+      currentParams.action,
+      currentParams.name,
+    );
+  }
+
+  // Use event bubbling to capture clicks on child elements (like SVG icons)
+  node.addEventListener("click", handleClick);
 
   return {
+    update(newParams: TrackClickParams) {
+      currentParams = newParams;
+    },
     destroy() {
-      // No cleanup needed for this action
+      node.removeEventListener("click", handleClick);
     },
   };
 }

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -38,7 +38,7 @@ import type {
 } from "../stores/types";
 import { Decimal } from "decimal.js";
 import { browser } from "$app/environment";
-import { trackCustomEvent } from "./trackingService";
+import { trackCustomEvent, addContextProvider } from "./trackingService";
 import { onboardingService } from "./onboardingService";
 import { storageUtils } from "../utils/storageUtils";
 import { marketWatcher } from "./marketWatcher";
@@ -62,6 +62,20 @@ export const app = {
     if (browser) {
       if (isInitialized) return;
       isInitialized = true;
+
+      // 0. Setup Tracking Context
+      addContextProvider(() => {
+        return {
+          app_theme: uiState.currentTheme,
+          app_symbol: tradeState.symbol,
+          app_provider: settingsState.apiProvider,
+          app_background: settingsState.backgroundType,
+          app_modals: uiState.windows.map((w) => w.id).join(","),
+          app_viewport: `${window.innerWidth}x${window.innerHeight}`,
+          app_zoom: window.devicePixelRatio,
+          app_version: import.meta.env.VITE_APP_VERSION,
+        };
+      });
 
       // 1. Initialise core logic
       app.populatePresetLoader();

--- a/src/services/trackingService.ts
+++ b/src/services/trackingService.ts
@@ -17,10 +17,28 @@
 
 // src/services/trackingService.ts
 
+type ContextProvider = () => Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+const contextProviders: ContextProvider[] = [];
+
+/**
+ * Registers a function that provides additional context (dimensions)
+ * for every tracked event.
+ * @param provider Function returning an object of key-value pairs
+ */
+export function addContextProvider(provider: ContextProvider) {
+  contextProviders.push(provider);
+}
+
 /**
  * Pushes a custom event to the Matomo Tag Manager data layer.
  * This can be used to track events that are not simple clicks,
  * such as successful calculations or API calls.
+ *
+ * Automatically includes context from registered providers.
  *
  * @param category The category of the event (e.g., 'Calculation').
  * @param action The action of the event (e.g., 'Success').
@@ -33,14 +51,18 @@ export function trackCustomEvent(
   name?: string,
   value?: number,
 ) {
-  if (!window._mtm) {
+  // Check if window exists (SSR guard) and if _mtm is available
+  if (typeof window === "undefined" || !window._mtm) {
     // Matomo Tag Manager is not available, do nothing.
     // This can happen if it's blocked or not yet loaded.
-    console.warn("Matomo Tag Manager not available. Skipping custom event.");
+    // Only log in dev mode to reduce noise
+    if (import.meta.env.DEV) {
+      console.warn("Matomo Tag Manager not available. Skipping custom event.");
+    }
     return;
   }
 
-  const eventData: { [key: string]: string | number } = {
+  const eventData: { [key: string]: any } = {
     event: "customEvent",
     "custom-event-category": category,
     "custom-event-action": action,
@@ -52,6 +74,16 @@ export function trackCustomEvent(
 
   if (value !== undefined) {
     eventData["custom-event-value"] = value;
+  }
+
+  // Inject Context
+  try {
+    contextProviders.forEach((provider) => {
+      const ctx = provider();
+      Object.assign(eventData, ctx);
+    });
+  } catch (e) {
+    console.warn("Error gathering tracking context", e);
   }
 
   window._mtm.push(eventData);

--- a/src/stores/ui.svelte.ts
+++ b/src/stores/ui.svelte.ts
@@ -271,14 +271,12 @@ class UiManager {
       ).toUTCString();
       document.cookie = `${CONSTANTS.LOCAL_STORAGE_THEME_KEY}=${themeName}; expires=${expires}; path=/; SameSite=Lax`;
 
-      if (typeof window !== "undefined" && (window as any)._mtm) {
-        (window as any)._mtm.push({
-          event: "customEvent",
-          "custom-event-category": "Settings",
-          "custom-event-action": "ChangeTheme",
-          "custom-event-name": themeName,
-        });
-      }
+      // Dynamic import to avoid circular dependency
+      import("../services/trackingService")
+        .then(({ trackCustomEvent }) => {
+          trackCustomEvent("Settings", "ChangeTheme", themeName);
+        })
+        .catch(() => {});
     } catch (e) {
       console.warn("Could not save theme.", e);
     }


### PR DESCRIPTION
This PR refactors the analytics tracking to be more robust and data-rich. It replaces the fragile DOM attribute scanning method (`data-mtm-*`) with direct Data Layer events (`window._mtm.push`).

Key changes:
1.  **Robust Click Tracking:** The `trackClick` action now adds a real `click` event listener. This ensures clicks on child elements (like icons inside buttons) are correctly captured, solving a major issue where Matomo missed interactions.
2.  **Rich Context:** Every tracked event now automatically includes global application state:
    *   `app_theme`: Current theme (e.g., 'dark', 'solarized-light').
    *   `app_symbol`: Active trading symbol (e.g., 'BTCUSDT').
    *   `app_provider`: Current API provider (e.g., 'bitunix').
    *   `app_background`: Background type.
    *   `app_modals`: List of open window IDs.
    *   `app_viewport` & `app_zoom`: Screen dimensions and pixel ratio.
    *   `app_version`: App version.
3.  **Architecture:** Implemented a "Context Provider" registry in `trackingService.ts` to allow `app.ts` to inject store data without creating circular dependencies.
4.  **Consistency:** Unified all tracking (clicks and custom events) to use the same `trackCustomEvent` pipeline.

---
*PR created automatically by Jules for task [17026623148904491921](https://jules.google.com/task/17026623148904491921) started by @mydcc*