### PR TITLE
Add New Relic Browser Agent and update CSP

### DIFF
--- a/static/js/newrelic.js
+++ b/static/js/newrelic.js
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2026 MYDCT
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
 
 ;window.NREUM||(NREUM={});NREUM.init={distributed_tracing:{enabled:true},performance:{capture_measures:true},browser_consent_mode:{enabled:false},privacy:{cookies_enabled:true},ajax:{deny_list:["bam.eu01.nr-data.net"]}};
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -37,6 +37,7 @@ const config = {
           "unsafe-inline",
           "unsafe-eval",
           "https://s.cachy.app",
+          "https://js-agent.newrelic.com",
           "blob:",
         ],
       },


### PR DESCRIPTION
- Added New Relic snippet to static/js/newrelic.js (without license header).
- Imported script in src/app.html.
- Updated svelte.config.js to allow https://js-agent.newrelic.com in script-src CSP.