### PR TITLE
Refactor dialogs to use WindowManager and fix Svelte warnings.

### DIFF
--- a/src/lib/windows/implementations/DialogView.svelte
+++ b/src/lib/windows/implementations/DialogView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { untrack } from "svelte";
     import { _ } from "../../../locales/i18n";
     import { windowManager } from "../WindowManager.svelte";
     import type { DialogWindow } from "./DialogWindow.svelte";
@@ -11,7 +12,7 @@
 
     let { window: win }: Props = $props();
 
-    let inputValue = $state(win.defaultValue || "");
+    let inputValue = $state(untrack(() => win.defaultValue) || "");
 
     function handleConfirm(result: boolean | string) {
         win.closeWith(result);
@@ -39,6 +40,7 @@
 
     {#if win.type === "prompt"}
         <div class="mb-6">
+            <!-- svelte-ignore a11y_autofocus -->
             <input
                 type="text"
                 class="w-full px-4 py-3 rounded-lg bg-[var(--bg-tertiary)] border border-[var(--border-color)] focus:border-[var(--accent-color)] outline-none transition-colors"


### PR DESCRIPTION
- Replaced CustomModal and SymbolPickerModal with DialogWindow and SymbolPickerWindow.
- Updated modalState.show() to instantiate windows via WindowManager.
- Added isResponsive and edgeToEdgeBreakpoint to WindowBase for mobile optimization.
- Added destroy() method to WindowBase for cleanup.
- Fixed Svelte 5 state initialization warnings in DialogView.
- Removed legacy modal components from +layout.svelte.