### PR TITLE
Fix RSI Decimal Type Crash in Market Overview

### DIFF
--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -171,14 +171,14 @@
     const tech = wsData?.technicals?.[effectiveRsiTimeframe];
     if (!tech?.oscillators) return null;
     const rsi = tech.oscillators.find((o) => o.name === "RSI");
-    return rsi ? rsi.value : null;
+    return rsi ? new Decimal(rsi.value) : null;
   });
 
   let signalValue = $derived.by(() => {
     const tech = wsData?.technicals?.[effectiveRsiTimeframe];
     if (!tech?.oscillators) return null;
     const rsi = tech.oscillators.find((o) => o.name === "RSI");
-    return rsi ? rsi.signal : null; // Signal might be undefined on IndicatorResult, check type
+    return rsi && rsi.signal !== undefined ? new Decimal(rsi.signal) : null;
   });
 
   // Funding Rate & Countdown


### PR DESCRIPTION
Fixed a runtime crash in the Market Overview component caused by treating native number RSI values as Decimal objects. 

The technicals calculator returns native numbers for performance, but the UI template expects Decimal objects for comparison logic (`.gte()`). I added explicit `new Decimal()` casting in the `$derived` blocks for both `rsiValue` and `signalValue`.

Verified by running `npm run check` to confirm type safety in the modified file.

---
*PR created automatically by Jules for task [12883517221042807545](https://jules.google.com/task/12883517221042807545) started by @mydcc*