### PR TITLE
fix: cast divergence scanner results to number in technicals calculator

### DIFF
--- a/src/utils/technicalsCalculator.ts
+++ b/src/utils/technicalsCalculator.ts
@@ -368,10 +368,10 @@ export function calculateIndicatorsFromArrays(
           side: res.side,
           startIdx: res.startIdx,
           endIdx: res.endIdx,
-          priceStart: res.priceStart,
-          priceEnd: res.priceEnd,
-          indStart: res.indStart,
-          indEnd: res.indEnd,
+          priceStart: res.priceStart.toNumber(),
+          priceEnd: res.priceEnd.toNumber(),
+          indStart: res.indStart.toNumber(),
+          indEnd: res.indEnd.toNumber(),
         });
       });
     });


### PR DESCRIPTION
Resolves TypeScript errors where `Decimal` values from `DivergenceScanner` were being assigned to properties in `TechnicalsData` that expect `number`.

This change ensures that `priceStart`, `priceEnd`, `indStart`, and `indEnd` from `DivergenceResult` are explicitly converted to primitive numbers using `.toNumber()` before being included in the technical analysis results. This aligns with the interface definition and prevents build failures during type checking.