### PR TITLE
Fix TypeScript errors in Technicals and UI

### DIFF
--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -451,7 +451,7 @@
               ? "var(--danger-color)"
               : "var(--accent-color)",
         intensity:
-          rsiValue && (rsiValue > 70 || rsiValue < 30) ? 1.8 : 1.0,
+          rsiValue && (rsiValue.gt(70) || rsiValue.lt(30)) ? 1.8 : 1.0,
         layer: "tiles",
       }
     : undefined}
@@ -613,10 +613,10 @@
             >
             <span
               class="font-medium transition-colors duration-300 cursor-help"
-              class:text-[var(--danger-color)]={rsiValue && rsiValue >= 70}
-              class:text-[var(--success-color)]={rsiValue && rsiValue <= 30}
+              class:text-[var(--danger-color)]={rsiValue && rsiValue.gte(70)}
+              class:text-[var(--success-color)]={rsiValue && rsiValue.lte(30)}
               class:text-[var(--text-primary)]={!rsiValue ||
-                (rsiValue > 30 && rsiValue < 70)}
+                (rsiValue.gt(30) && rsiValue.lt(70))}
             >
               {formatValue(rsiValue, 2)}
             </span>

--- a/src/utils/technicalsCalculator.ts
+++ b/src/utils/technicalsCalculator.ts
@@ -387,10 +387,10 @@ export function calculateIndicatorsFromArrays(
           side: res.side,
           startIdx: res.startIdx,
           endIdx: res.endIdx,
-          priceStart: res.priceStart.toNumber(),
-          priceEnd: res.priceEnd.toNumber(),
-          indStart: res.indStart.toNumber(),
-          indEnd: res.indEnd.toNumber(),
+          priceStart: res.priceStart,
+          priceEnd: res.priceEnd,
+          indStart: res.indStart,
+          indEnd: res.indEnd,
         });
       });
     });


### PR DESCRIPTION
- Removed redundant `.toNumber()` calls in `technicalsCalculator.ts` where values are already numbers.
- Fixed `Decimal` comparison logic in `MarketOverview.svelte` by using `.gt()`, `.lt()`, etc., instead of native operators.
- Resolved CI failure in `TypeScript Type Check` workflow.