### PR TITLE
fix: allow New Relic JS agent domain in CSP and fix type errors

### DIFF
--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -451,7 +451,7 @@
               ? "var(--danger-color)"
               : "var(--accent-color)",
         intensity:
-          rsiValue && (rsiValue > 70 || rsiValue < 30) ? 1.8 : 1.0,
+          rsiValue && (rsiValue.gt(70) || rsiValue.lt(30)) ? 1.8 : 1.0,
         layer: "tiles",
       }
     : undefined}
@@ -613,10 +613,10 @@
             >
             <span
               class="font-medium transition-colors duration-300 cursor-help"
-              class:text-[var(--danger-color)]={rsiValue && rsiValue >= 70}
-              class:text-[var(--success-color)]={rsiValue && rsiValue <= 30}
+              class:text-[var(--danger-color)]={rsiValue && rsiValue.gte(70)}
+              class:text-[var(--success-color)]={rsiValue && rsiValue.lte(30)}
               class:text-[var(--text-primary)]={!rsiValue ||
-                (rsiValue > 30 && rsiValue < 70)}
+                (rsiValue.gt(30) && rsiValue.lt(70))}
             >
               {formatValue(rsiValue, 2)}
             </span>

--- a/src/utils/technicalsCalculator.ts
+++ b/src/utils/technicalsCalculator.ts
@@ -387,10 +387,10 @@ export function calculateIndicatorsFromArrays(
           side: res.side,
           startIdx: res.startIdx,
           endIdx: res.endIdx,
-          priceStart: res.priceStart.toNumber(),
-          priceEnd: res.priceEnd.toNumber(),
-          indStart: res.indStart.toNumber(),
-          indEnd: res.indEnd.toNumber(),
+          priceStart: res.priceStart,
+          priceEnd: res.priceEnd,
+          indStart: res.indStart,
+          indEnd: res.indEnd,
         });
       });
     });

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -37,6 +37,7 @@ const config = {
           "unsafe-inline",
           "unsafe-eval",
           "https://s.cachy.app",
+          "https://js-agent.newrelic.com",
           "blob:",
         ],
         "connect-src": [


### PR DESCRIPTION
This PR addresses a `ChunkLoadError` caused by a missing domain in the Content Security Policy for the New Relic integration. Additionally, it fixes unrelated type errors in the technicals calculator and market overview component that were blocking the `npm run check` verification process.

**Changes:**
- **`svelte.config.js`:** Added `https://js-agent.newrelic.com` to the `script-src` directive.
- **`src/utils/technicalsCalculator.ts`:** Removed redundant `.toNumber()` calls on `DivergenceResult` properties which are already typed as numbers.
- **`src/components/shared/MarketOverview.svelte`:** Updated `Decimal` comparisons in the template to use proper `.gt()`, `.lt()`, etc., methods instead of standard operators.

---
*PR created automatically by Jules for task [3944141551056907499](https://jules.google.com/task/3944141551056907499) started by @mydcc*