### PR TITLE
fix: add AI service domains to CSP connect-src

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -48,6 +48,8 @@ const config = {
           "wss://fapi.bitunix.com",
           "wss://stream.bitunix.com",
           "https://api.imgbb.com",
+          "https://generativelanguage.googleapis.com",
+          "https://api.openai.com",
         ],
       },
     },


### PR DESCRIPTION
Erweitert die `connect-src` CSP-Direktive in `svelte.config.js` um `https://generativelanguage.googleapis.com` (Google Gemini) und `https://api.openai.com` (OpenAI), um die Sentiment-Analyse im Frontend zu ermöglichen und API-Blockaden zu beheben.

---
*PR created automatically by Jules for task [14603876596073782191](https://jules.google.com/task/14603876596073782191) started by @mydcc*