### PR TITLE
Fix chart history limit and realtime updates via REST fallback

### DIFF
--- a/src/stores/market.svelte.ts
+++ b/src/stores/market.svelte.ts
@@ -336,7 +336,8 @@ export class MarketManager {
     // PROTECTION: Single Source of Truth for Live Candle (WebSocket)
     // If source is REST, we must NEVER overwrite the latest live candle (Head)
     // because REST snapshots lag behind the WebSocket stream.
-    if (source === "rest" && history.length > 0) {
+    // EXCEPTION: If WebSocket is disconnected, we MUST accept REST updates for the live candle.
+    if (source === "rest" && history.length > 0 && this.connectionStatus === "connected") {
       const lastKnownTime = history[history.length - 1].time;
       // Filter out any incoming REST candle that matches the current live candle's time
       newKlines = newKlines.filter(k => k.time !== lastKnownTime);


### PR DESCRIPTION
This PR addresses two issues reported by the user:
1.  **Missing Candle History**: The chart was limited to ~2000 candles. I updated `ensureHistory` in `src/services/marketWatcher.ts` to fetch historical data in batches until the user's `chartHistoryLimit` (default 20,000) is satisfied.
2.  **No Real-Time Prices**: The chart appeared frozen when WebSocket was disconnected because the REST fallback logic explicitly discarded updates to the current live candle. I updated `src/stores/market.svelte.ts` to permit REST updates to the live candle when the connection status is not "connected".

Verified with unit tests for `market.svelte.ts` and mock tests for `marketWatcher.ts`.

---
*PR created automatically by Jules for task [17346274833733811235](https://jules.google.com/task/17346274833733811235) started by @mydcc*