### PR TITLE
refactor: simplify MarketWatcher locking mechanism (Phase 3)

### DIFF
--- a/src/services/marketWatcher.test.ts
+++ b/src/services/marketWatcher.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { marketWatcher } from './marketWatcher';
+import { apiService } from './apiService';
+import { marketState } from '../stores/market.svelte';
+
+// Mock dependencies
+vi.mock('./apiService', () => ({
+    apiService: {
+        fetchTicker24h: vi.fn(),
+        fetchBitunixKlines: vi.fn(),
+        fetchBitgetKlines: vi.fn()
+    }
+}));
+
+vi.mock('../stores/market.svelte', () => ({
+    marketState: {
+        updateSymbol: vi.fn(),
+        updateSymbolKlines: vi.fn(),
+        data: {},
+        connectionStatus: 'disconnected'
+    }
+}));
+
+vi.mock('../stores/settings.svelte', () => ({
+    settingsState: {
+        apiProvider: 'bitunix',
+        capabilities: { marketData: true },
+        marketDataInterval: 1 // Short interval for testing
+    }
+}));
+
+// We need to access private methods/properties for some tests, or test via public API
+// casting to any for test access
+const watcher = marketWatcher as any;
+
+describe('MarketWatcher Locking & Deduplication', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset internal state if possible or assume clean state due to module reloading in some envs
+        // In this env, singleton might persist, so we manually clear
+        if (watcher.pendingRequests) watcher.pendingRequests.clear();
+        if (watcher.requests) watcher.requests.clear();
+    });
+
+    it('should deduplicate concurrent requests for the same symbol/channel', async () => {
+        // Setup a slow API response
+        let resolveApi: (value: any) => void;
+        const delayedPromise = new Promise(resolve => { resolveApi = resolve; });
+
+        vi.mocked(apiService.fetchTicker24h).mockReturnValue(delayedPromise as any);
+
+        // Trigger two polls effectively simultaneously
+        const p1 = watcher.pollSymbolChannel('BTCUSDT', 'price', 'bitunix');
+        const p2 = watcher.pollSymbolChannel('BTCUSDT', 'price', 'bitunix');
+
+        // Verify API was called ONLY ONCE
+        expect(apiService.fetchTicker24h).toHaveBeenCalledTimes(1);
+
+        // Resolve the API
+        resolveApi!({ lastPrice: '50000' });
+
+        await Promise.all([p1, p2]);
+
+        // Verify update was called
+        expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', expect.objectContaining({ lastPrice: '50000' }));
+    });
+
+    it('should allow new request after previous one finishes', async () => {
+        vi.mocked(apiService.fetchTicker24h).mockResolvedValue({ lastPrice: '50000' } as any);
+
+        // First call
+        await watcher.pollSymbolChannel('BTCUSDT', 'price', 'bitunix');
+        expect(apiService.fetchTicker24h).toHaveBeenCalledTimes(1);
+
+        // Second call (sequential)
+        await watcher.pollSymbolChannel('BTCUSDT', 'price', 'bitunix');
+        expect(apiService.fetchTicker24h).toHaveBeenCalledTimes(2);
+    });
+
+    it('should release lock even if API fails', async () => {
+        vi.mocked(apiService.fetchTicker24h).mockRejectedValue(new Error('API Error'));
+
+        // Call that fails
+        try {
+            await watcher.pollSymbolChannel('BTCUSDT', 'price', 'bitunix');
+        } catch (e) {
+            // Expected
+        }
+
+        // Next call should proceed (lock released)
+        vi.mocked(apiService.fetchTicker24h).mockResolvedValue({ lastPrice: '50000' } as any);
+        await watcher.pollSymbolChannel('BTCUSDT', 'price', 'bitunix');
+
+        expect(apiService.fetchTicker24h).toHaveBeenCalledTimes(2); // 1 fail + 1 success
+    });
+});

--- a/src/services/marketWatcher.ts
+++ b/src/services/marketWatcher.ts
@@ -35,11 +35,13 @@ class MarketWatcher {
   private requests = new Map<string, Map<string, number>>(); // symbol -> { channel -> count }
   private pollingInterval: any = null;
   private startTimeout: any = null; // Track startup delay
-  // private currentIntervalSeconds: number = 10; // Deprecated: Use settingsState
-  private fetchLocks = new Set<string>(); // "symbol:channel"
-  private historyLocks = new Set<string>(); // "symbol:tf" for ensuring history
-  private unlockTimeouts = new Map<string, any>(); // Track lock release timers to prevent race conditions
-  private proactiveLockTimeouts = new Map<string, any>(); // Safety valve for stuck locks
+
+  // Phase 3 Hardening: Replaced Boolean Set locks with Promise Map for deduplication
+  private pendingRequests = new Map<string, Promise<void>>();
+
+  // Helper to store subscriptions intent
+  private historyLocks = new Set<string>();
+
   private staggerTimeouts = new Set<any>(); // Track staggered requests to prevent zombie calls
   private maxConcurrentPolls = 6; // Reduced to mitigate rate limits (aligned with strict token bucket)
   private inFlight = 0;
@@ -212,16 +214,8 @@ class MarketWatcher {
     this.staggerTimeouts.forEach((t) => clearTimeout(t));
     this.staggerTimeouts.clear();
 
-    // Clear pending unlock timeouts to prevent race conditions on restart
-    this.unlockTimeouts.forEach((t) => clearTimeout(t));
-    this.unlockTimeouts.clear();
-
-    // Clear proactive safety timeouts
-    this.proactiveLockTimeouts.forEach((t) => clearTimeout(t));
-    this.proactiveLockTimeouts.clear();
-
-    // Clear pending fetch locks to prevent memory leaks
-    this.fetchLocks.clear();
+    // Clear locks
+    this.pendingRequests.clear();
   }
 
   public resumePolling() {
@@ -230,23 +224,9 @@ class MarketWatcher {
     }
   }
 
-  // Removed isPollingPaused() as part of Hybrid Architecture.
-  // Polling is now governed by "Gap Detection" inside performPollingCycle.
-
-
   private async performPollingCycle() {
     const settings = settingsState;
     const provider = settings.apiProvider;
-
-    // Safety: If fetchLocks grows too large (stale locks), prune it
-    // This handles edge cases where `finally` block might not have cleared a lock
-    // or if component logic caused orphan keys.
-    if (this.fetchLocks.size > 200) {
-      // Emergency cleanup
-      logger.warn("market", `[MarketWatcher] Pruning stale locks (${this.fetchLocks.size})`);
-      this.fetchLocks.clear();
-      this.inFlight = 0;
-    }
 
     const allowed = Math.max(this.maxConcurrentPolls - this.inFlight, 0);
     if (allowed <= 0) return;
@@ -270,7 +250,8 @@ class MarketWatcher {
 
       channels.forEach((_, channel) => {
         const lockKey = `${symbol}:${channel}`;
-        if (this.fetchLocks.has(lockKey)) return;
+        // Skip if already in flight (Deduplication)
+        if (this.pendingRequests.has(lockKey)) return;
         tasks.push({ symbol, channel, lockKey });
       });
     });
@@ -282,7 +263,7 @@ class MarketWatcher {
     // Spread out requests over the first cycle to avoid burst
     let stagger = 0;
     for (let i = 0; i < scheduleCount; i++) {
-      const { symbol, channel, lockKey } = tasks[i];
+      const { symbol, channel } = tasks[i];
       const currentStagger = stagger;
       stagger += Math.floor(Math.random() * 150) + 50; // Random 50-200ms increments
 
@@ -290,7 +271,10 @@ class MarketWatcher {
         this.staggerTimeouts.delete(timeoutId);
         if (!this.pollingInterval) return; // Zombie Guard
         if (this.inFlight >= this.maxConcurrentPolls) return;
-        if (!this.fetchLocks.has(lockKey)) {
+
+        // Final dedupe check inside timeout
+        const lockKey = `${symbol}:${channel}`;
+        if (!this.pendingRequests.has(lockKey)) {
           this.pollSymbolChannel(symbol, channel, provider);
         }
       }, currentStagger);
@@ -300,11 +284,10 @@ class MarketWatcher {
 
   public async ensureHistory(symbol: string, tf: string) {
     const provider = settingsState.apiProvider;
-    if (provider !== "bitunix") return; // Only supporting bitunix history optimization for now
+    if (provider !== "bitunix") return;
 
     const lockKey = `${symbol}:${tf}`;
     if (this.historyLocks.has(lockKey)) {
-        if (import.meta.env.DEV) console.log(`[History] Skipping duplicate ensureHistory for ${lockKey}`);
         return;
     }
     this.historyLocks.add(lockKey);
@@ -313,7 +296,6 @@ class MarketWatcher {
         // 1. Try Load from DB
         const stored = await storageService.getKlines(symbol, tf);
         if (stored && stored.length > 0) {
-            if (import.meta.env.DEV) console.log(`[History] Loaded ${stored.length} candles from DB for ${symbol}`);
             marketState.updateSymbolKlines(symbol, tf, stored, "rest");
         }
 
@@ -321,7 +303,6 @@ class MarketWatcher {
         const limit = settingsState.chartHistoryLimit || 1000;
 
         // Execute Fetch Logic
-        // We await here inside the try block so the lock is held during the operation
         const latestLimit = 1000; // API Max
         const klines1 = await apiService.fetchBitunixKlines(symbol, tf, latestLimit);
 
@@ -335,17 +316,9 @@ class MarketWatcher {
             const MAX_ITERATIONS = 30; // Safety cap (e.g. 30k candles max per session load)
 
             // Backfill Loop
-            // If the requested limit exceeds what we have, we loop backfill requests.
-            // We use the oldest known timestamp as the anchor for the next batch.
             let oldestTime = klines1[0].time;
 
             while (limit > 1000 && currentData.length < limit && iterations < MAX_ITERATIONS) {
-                // If the last fetch was partial (reached end of data), stop.
-                // Note: klines1 is only relevant for the first iteration logic,
-                // but inside the loop we check the result of the new fetch.
-                // Actually, checking klines1.length here is only valid for the first jump.
-                // We'll rely on the loop break conditions.
-
                 iterations++;
 
                 // Fetch older batch (before oldestTime)
@@ -362,7 +335,6 @@ class MarketWatcher {
                 currentData = marketState.data[symbol]?.klines[tf] || [];
                 const newOldest = olderKlines[0].time;
 
-                // Safety: If we get the same time back (API quirk), abort to prevent infinite loop
                 if (newOldest >= oldestTime) {
                     break;
                 }
@@ -399,21 +371,11 @@ class MarketWatcher {
         // Ensure sorted
         const oldestTime = history[0].time;
 
-        if (import.meta.env.DEV) {
-           console.log(`[History] Loading more history for ${symbol} before ${new Date(oldestTime).toISOString()}`);
-        }
-
         // Fetch older batch (Bitunix specific)
         const newKlines = await apiService.fetchBitunixKlines(symbol, tf, 1000, undefined, oldestTime);
 
         if (newKlines && newKlines.length > 0) {
-             // Pass enforceLimit: false to allow growth beyond settings.chartHistoryLimit
-             // (up to the safety cap defined in store)
             marketState.updateSymbolKlines(symbol, tf, newKlines, "rest", false);
-
-            // Persist (optional: might get huge)
-            // storageService.saveKlines(symbol, tf, newKlines);
-
             return true;
         }
         return false;
@@ -432,102 +394,83 @@ class MarketWatcher {
   ) {
     if (!settingsState.capabilities.marketData) return;
     const lockKey = `${symbol}:${channel}`;
-    this.fetchLocks.add(lockKey);
+
+    // Request Deduplication
+    if (this.pendingRequests.has(lockKey)) {
+        return this.pendingRequests.get(lockKey);
+    }
+
     this.inFlight++;
 
-    // Safety: Proactive lock release (TTL) in case of critical failure/hang
-    const safetyTimeout = setTimeout(() => {
-      if (this.fetchLocks.has(lockKey)) {
-        logger.warn("market", `[MarketWatcher] Proactive lock release for ${lockKey} (stuck)`);
-        this.fetchLocks.delete(lockKey);
-        this.proactiveLockTimeouts.delete(lockKey);
-        this.inFlight = Math.max(0, this.inFlight - 1);
-      }
-    }, 15000); // 15s (must be > fetch timeout)
-    this.proactiveLockTimeouts.set(lockKey, safetyTimeout);
+    // Create the Promise wrapper
+    const requestPromise = (async () => {
+        try {
+            // Determine priority: high for the main trading symbol, normal for the rest
+            const isMainSymbol =
+              tradeState.symbol &&
+              normalizeSymbol(tradeState.symbol, "bitunix") === symbol;
+            const priority = isMainSymbol ? "high" : "normal";
 
-    // Determine priority: high for the main trading symbol, normal for the rest
-    const isMainSymbol =
-      tradeState.symbol &&
-      normalizeSymbol(tradeState.symbol, "bitunix") === symbol;
-    const priority = isMainSymbol ? "high" : "normal";
+            // Hardening: Wrap API calls in strict timeout
+            const timeoutMs = 10000;
+            const withTimeout = <T>(promise: Promise<T>): Promise<T> => {
+              return Promise.race([
+                promise,
+                new Promise<T>((_, reject) => setTimeout(() => reject(new Error("Timeout")), timeoutMs))
+              ]);
+            };
 
-    try {
-      // Hardening: Wrap API calls in strict timeout to prevent lock leaks
-      // 10s timeout for REST calls
-      const timeoutMs = 10000;
-      const withTimeout = <T>(promise: Promise<T>): Promise<T> => {
-        return Promise.race([
-          promise,
-          new Promise<T>((_, reject) => setTimeout(() => reject(new Error("Timeout")), timeoutMs))
-        ]);
-      };
+            if (channel === "price" || channel === "ticker") {
+                const data = await withTimeout(apiService.fetchTicker24h(
+                  symbol,
+                  provider,
+                  priority,
+                ));
+                marketState.updateSymbol(symbol, {
+                  lastPrice: data.lastPrice,
+                  highPrice: data.highPrice,
+                  lowPrice: data.lowPrice,
+                  volume: data.volume,
+                  priceChangePercent: data.priceChangePercent,
+                  quoteVolume: data.quoteVolume,
+                });
+            } else if (channel.startsWith("kline_")) {
+                const tf = channel.replace("kline_", "");
+                const klines = await withTimeout(provider === "bitget"
+                  ? apiService.fetchBitgetKlines(symbol, tf, 1000)
+                  : apiService.fetchBitunixKlines(symbol, tf, 1000));
 
-      if (channel === "price" || channel === "ticker") {
-        const data = await withTimeout(apiService.fetchTicker24h(
-          symbol,
-          provider,
-          priority,
-        ));
-        marketState.updateSymbol(symbol, {
-          lastPrice: data.lastPrice,
-          highPrice: data.highPrice,
-          lowPrice: data.lowPrice,
-          volume: data.volume,
-          priceChangePercent: data.priceChangePercent,
-          quoteVolume: data.quoteVolume,
-        });
-      } else if (channel.startsWith("kline_")) {
-        const tf = channel.replace("kline_", "");
-        // Use 1000 limit for routine polling as well, to catch up gaps efficiently
-        const klines = await withTimeout(provider === "bitget"
-          ? apiService.fetchBitgetKlines(symbol, tf, 1000)
-          : apiService.fetchBitunixKlines(symbol, tf, 1000));
-
-        if (klines && klines.length > 0) {
-          marketState.updateSymbolKlines(symbol, tf, klines, "rest");
-          // Persist on routine poll too
-          storageService.saveKlines(symbol, tf, klines);
+                if (klines && klines.length > 0) {
+                  marketState.updateSymbolKlines(symbol, tf, klines, "rest");
+                  storageService.saveKlines(symbol, tf, klines);
+                }
+            }
+        } catch (e) {
+            const now = Date.now();
+            if (now - this.lastErrorLog > this.errorLogIntervalMs) {
+                logger.warn("market", `[MarketWatcher] Polling error for ${symbol}/${channel}`, e);
+                this.lastErrorLog = now;
+            }
+        } finally {
+            // Release lock immediately
+            this.pendingRequests.delete(lockKey);
+            this.inFlight = Math.max(0, this.inFlight - 1);
         }
-      }
-      // Depth not yet polled for Binance (requires specific API we logic)
-    } catch (e) {
-      const now = Date.now();
-      if (now - this.lastErrorLog > this.errorLogIntervalMs) {
-        logger.warn("market", `[MarketWatcher] Polling error for ${symbol}/${channel}`, e);
-        this.lastErrorLog = now;
-      }
-    } finally {
-      // Clear safety timeout as we are handling it normally
-      if (this.proactiveLockTimeouts.has(lockKey)) {
-        clearTimeout(this.proactiveLockTimeouts.get(lockKey));
-        this.proactiveLockTimeouts.delete(lockKey);
-      }
+    })();
 
-      // Re-allow polling after interval
-      // Dynamic interval from settings
-      const interval = Math.max(settingsState.marketDataInterval || 5, 2); // Min 2s safety
-
-      const timeoutId = setTimeout(() => {
-        this.fetchLocks.delete(lockKey);
-        this.unlockTimeouts.delete(lockKey);
-      }, interval * 1000);
-
-      this.unlockTimeouts.set(lockKey, timeoutId);
-      this.inFlight = Math.max(0, this.inFlight - 1);
-    }
+    // Store the promise
+    this.pendingRequests.set(lockKey, requestPromise);
+    return requestPromise;
   }
 
   public getActiveSymbols(): string[] {
     return Array.from(this.requests.keys());
   }
 
-  // Safety valve: Force cleanup if ref-counting gets desynced
+  // Safety valve: Force cleanup
   public forceCleanup() {
     this.requests.clear();
-    this.fetchLocks.clear();
-    this.unlockTimeouts.forEach((t) => clearTimeout(t));
-    this.unlockTimeouts.clear();
+    this.pendingRequests.clear();
     this.inFlight = 0;
     this.syncSubscriptions();
     logger.warn("market", "[MarketWatcher] Forced Cleanup Triggered");


### PR DESCRIPTION
- Replaced complex boolean locks and timeouts with a `pendingRequests` Map storing Promises.
- Implemented robust request deduplication: concurrent calls for the same symbol/channel now return the existing Promise.
- Removed legacy `fetchLocks`, `unlockTimeouts`, and `proactiveLockTimeouts`.
- Added `src/services/marketWatcher.test.ts` to verify deduplication and error handling.