### PR TITLE
Hardening: Fix Naked Stop Loss & WebSocket Mutation & CI

### DIFF
--- a/scripts/lint-i18n.js
+++ b/scripts/lint-i18n.js
@@ -113,6 +113,7 @@ const SAFE_CONTEXTS = [
     /on:click/,                 // Svelte events
     /onclick=/,                 // Svelte 5 events
     /i18n-ignore/,              // Manual Ignore Comment
+    /^\s*\*/,                   // JSDoc/Block comments (lines starting with *)
 ];
 
 let violations = [];


### PR DESCRIPTION
- Modified `TradeService.flashClosePosition` to explicitly call `cancelAllOrders` before closing, preventing "Naked Stop Loss".
- Refactored `BitunixWebSocketService` Fast Path to use immutable mapping for depth data, preventing side-effects.
- Optimized `1M` timeframe calculation in WebSocket to use `Date.UTC`.
- Fixed CI linter failure in `lint-i18n.js` by ignoring JSDoc comments correctly.
- Updated regression tests in `src/tests/flash-close.test.ts`.