### PR TITLE
⚡ Optimize Technical Indicators with BufferPool

### DIFF
--- a/src/utils/bufferPool.ts
+++ b/src/utils/bufferPool.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * Buffer Pool for TypedArray reuse.
+ * Reduces garbage collection overhead by recycling arrays.
+ */
+
+export class BufferPool {
+  private pool: Map<number, Float64Array[]> = new Map();
+
+  /**
+   * Acquire a Float64Array of the specified length.
+   * Returns a recycled array if available, or creates a new one.
+   * The returned array may contain dirty data.
+   */
+  acquire(length: number): Float64Array {
+    const list = this.pool.get(length);
+    if (list && list.length > 0) {
+      return list.pop()!;
+    }
+    return new Float64Array(length);
+  }
+
+  /**
+   * Release a Float64Array back to the pool for reuse.
+   */
+  release(buffer: Float64Array) {
+    const len = buffer.length;
+    let list = this.pool.get(len);
+    if (!list) {
+      list = [];
+      this.pool.set(len, list);
+    }
+    list.push(buffer);
+  }
+
+  /**
+   * Clear all buffers from the pool.
+   */
+  clear() {
+    this.pool.clear();
+  }
+}

--- a/src/utils/slidingWindow.ts
+++ b/src/utils/slidingWindow.ts
@@ -13,9 +13,15 @@ import type { NumberArray } from "./indicators";
  * @param period Window size
  * @returns Array where result[i] is the max of data[i-period+1 ... i]
  */
-export function slidingWindowMax(data: NumberArray, period: number): Float64Array {
+export function slidingWindowMax(
+  data: NumberArray,
+  period: number,
+  out?: Float64Array,
+): Float64Array {
   const len = data.length;
-  const result = new Float64Array(len).fill(NaN);
+  const result = (out && out.length === len) ? out : new Float64Array(len);
+  result.fill(NaN);
+
   const deque: number[] = []; // Stores indices
 
   if (len < period) return result;
@@ -53,9 +59,15 @@ export function slidingWindowMax(data: NumberArray, period: number): Float64Arra
  * @param period Window size
  * @returns Array where result[i] is the min of data[i-period+1 ... i]
  */
-export function slidingWindowMin(data: NumberArray, period: number): Float64Array {
+export function slidingWindowMin(
+  data: NumberArray,
+  period: number,
+  out?: Float64Array,
+): Float64Array {
   const len = data.length;
-  const result = new Float64Array(len).fill(NaN);
+  const result = (out && out.length === len) ? out : new Float64Array(len);
+  result.fill(NaN);
+
   const deque: number[] = []; // Stores indices
 
   if (len < period) return result;

--- a/src/workers/technicals.worker.ts
+++ b/src/workers/technicals.worker.ts
@@ -24,6 +24,7 @@
 
 import { Decimal } from "decimal.js";
 import { calculateAllIndicators } from "../utils/technicalsCalculator";
+import { BufferPool } from "../utils/bufferPool";
 import type { Kline } from "../utils/indicators";
 import type {
   WorkerMessage,
@@ -33,6 +34,7 @@ import type {
 import { calculateIndicatorsFromArrays } from "../utils/technicalsCalculator";
 
 const ctx: Worker = self as any;
+const pool = new BufferPool();
 
 // --- Main Worker Listener ---
 
@@ -55,7 +57,8 @@ ctx.onmessage = async (e: MessageEvent<WorkerMessage>) => {
           soa.closes as any,
           soa.volumes as any,
           soa.settings,
-          soa.enabledIndicators
+          soa.enabledIndicators,
+          pool
         );
       } else {
         // Legacy Path (Object Array)

--- a/tests/benchmarks/technicals.bench.ts
+++ b/tests/benchmarks/technicals.bench.ts
@@ -2,6 +2,7 @@
 import { calculateIndicatorsFromArrays } from '../../src/utils/technicalsCalculator';
 import { JSIndicators } from '../../src/utils/indicators';
 import { DivergenceScanner } from '../../src/utils/divergenceScanner';
+import { BufferPool } from '../../src/utils/bufferPool';
 
 // Setup data
 const LENGTH = 5000; // Increased length to make O(N*K) more visible
@@ -70,7 +71,7 @@ function runBench(name: string, fn: () => void, iterations = 100) {
     console.log(`${name}: ${duration.toFixed(2)}ms for ${iterations} ops (${opsPerSec.toFixed(0)} ops/s) -> ${(duration/iterations).toFixed(3)} ms/op`);
 }
 
-runBench('calculateIndicatorsFromArrays (Full)', () => {
+runBench('calculateIndicatorsFromArrays (Full - No Pool)', () => {
     calculateIndicatorsFromArrays(
         times,
         opens,
@@ -80,6 +81,21 @@ runBench('calculateIndicatorsFromArrays (Full)', () => {
         volumes,
         settings as any,
         enabledIndicators
+    );
+}, 50);
+
+const pool = new BufferPool();
+runBench('calculateIndicatorsFromArrays (Full - With Pool)', () => {
+    calculateIndicatorsFromArrays(
+        times,
+        opens,
+        highs,
+        lows,
+        closes,
+        volumes,
+        settings as any,
+        enabledIndicators,
+        pool
     );
 }, 50);
 


### PR DESCRIPTION
Implemented a `BufferPool` strategy to optimize memory allocation in technical indicator calculations.

**Changes:**
1.  **BufferPool Class**: Created `src/utils/bufferPool.ts` to recycle `Float64Array` instances, keyed by length.
2.  **Indicator Updates**: Modified `JSIndicators` functions (`sma`, `ema`, `rsi`, `stoch`, `bb`, `macd`, `adx`, `cci`) and `slidingWindow` functions to accept optional `out` buffers.
3.  **Calculator Integration**: Updated `calculateIndicatorsFromArrays` in `src/utils/technicalsCalculator.ts` to use the pool for sourcing data (`hl2`, `hlc3`) and for intermediate indicator calculations.
4.  **Worker Optimization**: Instantiated a global `BufferPool` in `src/workers/technicals.worker.ts` to persist buffers across worker messages.

**Performance:**
- Benchmark results show comparable execution time (micro-regression in individual calls due to structure overhead, but negligible in aggregate).
- Primary benefit is reduced GC pressure by reusing buffers instead of allocating ~20+ new `Float64Array`s (40KB each for 5000 candles) per update tick.

**Testing:**
- Verified with `npx tsx tests/benchmarks/technicals.bench.ts`.
- Ran `npm test` to ensure no regressions in logic (unrelated pre-existing failures noted).

---
*PR created automatically by Jules for task [12866312243865599055](https://jules.google.com/task/12866312243865599055) started by @mydcc*