### PR TITLE
Hardening Phase 2: API Safety & Code Cleanup

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -455,6 +455,7 @@ export const apiService = {
           const res = await apiService.safeJson(response);
 
           if (!Array.isArray(res)) {
+            logger.error("network", `[Bitget] Invalid kline response type: ${typeof res}`, res);
             throw new Error("apiErrors.invalidResponse");
           }
 
@@ -572,7 +573,8 @@ export const apiService = {
 
           // Backend returns the mapped array directly
           if (!Array.isArray(res)) {
-            if (res.error) throw new Error("apiErrors.klineError");
+            if (res && res.error) throw new Error("apiErrors.klineError");
+            logger.error("network", `[Bitunix] Invalid kline response type: ${typeof res}`, res);
             throw new Error("apiErrors.invalidResponse");
           }
 

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -997,7 +997,6 @@ class BitunixWebSocketService {
       if (validatedChannel === "price") {
         const rawSymbol = validatedMessage.symbol || "";
         const symbol = normalizeSymbol(rawSymbol, "bitunix");
-        // const normalized = mdaService.normalizeTicker(validatedMessage, "bitunix");
 
         if (!this.shouldThrottle(`${symbol}:price`)) {
           marketState.updateSymbol(symbol, {


### PR DESCRIPTION
Enhanced `apiService.ts` to strictly validate API response types (kline endpoints) before processing, preventing crashes on unexpected payloads (e.g. rate limit errors returned as objects instead of arrays). Cleaned up commented-out code in `bitunixWs.ts`.
Verified `apiService` changes with unit tests.