### PR TITLE
Stabilize Stateful Worker (Phase 1.5)

### DIFF
--- a/src/services/technicalsService.ts
+++ b/src/services/technicalsService.ts
@@ -425,6 +425,36 @@ export const technicalsService = {
     return result;
   },
 
+  async shiftTechnicals(
+    symbol: string,
+    timeframe: string,
+    kline: {
+      time: number;
+      open: number | string | Decimal;
+      high: number | string | Decimal;
+      low: number | string | Decimal;
+      close: number | string | Decimal;
+      volume?: number | string | Decimal;
+    }
+  ): Promise<TechnicalsData> {
+    const { data: result } = await workerManager.postMessage({
+        type: "SHIFT",
+        payload: {
+            symbol,
+            timeframe,
+            kline: {
+                ...kline,
+                open: kline.open.toString(),
+                high: kline.high.toString(),
+                low: kline.low.toString(),
+                close: kline.close.toString(),
+                volume: kline.volume?.toString() || "0"
+            }
+        }
+    });
+    return result;
+  },
+
   async updateTechnicals(
     symbol: string,
     timeframe: string,

--- a/src/services/technicalsTypes.ts
+++ b/src/services/technicalsTypes.ts
@@ -191,7 +191,7 @@ export interface WorkerCalculatePayloadSoA {
   enabledIndicators?: Partial<Record<string, boolean>>;
 }
 
-export type WorkerMessageType = "CALCULATE" | "RESULT" | "ERROR" | "INITIALIZE" | "UPDATE";
+export type WorkerMessageType = "CALCULATE" | "RESULT" | "ERROR" | "INITIALIZE" | "UPDATE" | "SHIFT";
 
 export interface WorkerMessage {
   type: WorkerMessageType;
@@ -229,6 +229,7 @@ export interface TechnicalsState {
 
   // Indicator States
   ema?: Record<string, EmaState>; // Keyed by length
+  sma?: Record<string, SmaState>;
   rsi?: Record<string, RsiState>;
 
   // Last calculated result (to update incrementally)

--- a/src/utils/statefulTechnicalsCalculator.ts
+++ b/src/utils/statefulTechnicalsCalculator.ts
@@ -21,8 +21,11 @@ export class StatefulTechnicalsCalculator {
   private settings: any;
   private enabledIndicators: Partial<Record<string, boolean>> | undefined;
 
-  // We keep a small history buffer for indicators that need "Old Value" removal (like SMA)
-  // For this MVP (EMA/RSI focus), we mainly need the previous calculated values.
+  // History Buffers for SMA/Bollinger (Sliding Window)
+  // Key: "close", "high", "low" -> Ring Buffer
+  private historyBuffers: Record<string, Float64Array> = {};
+  private historyIndex: number = 0;
+  private historySize: number = 200; // Sufficient for standard MAs. Can be dynamic.
 
   constructor() {}
 
@@ -47,6 +50,7 @@ export class StatefulTechnicalsCalculator {
     // Since we want minimal intrusion, we will reconstruct state for supported incremental indicators.
 
     this.reconstructState(history, result);
+    this.initHistoryBuffers(history);
 
     return result;
   }
@@ -80,6 +84,17 @@ export class StatefulTechnicalsCalculator {
        this.updateRsiGroup(newResult, currentPrice, prevPrice);
     }
 
+    // 3. Update SMA
+    // For SMA, we need the value falling out of the window.
+    // The current window ends at 'lastCandle'. The value dropping out is at (index - period).
+    // In our ring buffer, we store historical closes.
+    // 'historyIndex' points to the NEXT write slot (which corresponds to 'lastCandle' position in abstract).
+    // Actually, let's keep it simple: RingBuffer stores CLOSED candles.
+    // 'currentPrice' is the forming candle.
+    if (this.state.sma && this.enabled("sma")) {
+        this.updateSmaGroup(newResult, currentPrice);
+    }
+
     // Update other non-incremental fields simply by carrying over or re-running light logic?
     // For MVP, we only increment supported ones. Others remain "stale" or we re-run them if cheap.
     // Actually, if we don't update them, they show the value from the last candle close.
@@ -94,6 +109,56 @@ export class StatefulTechnicalsCalculator {
     // If a new candle opens, 'initialize' (or a new 'shift' method) should be called.
 
     return newResult;
+  }
+
+  public shift(newCandle: Kline) {
+      if (!this.state.lastResult || !this.state.lastCandle) return;
+
+      // 1. Finalize State for the CLOSED candle (this.state.lastCandle)
+      // This is crucial. 'state.ema' currently holds the value from the *previous* close (T-1).
+      // We need to advance it to the current close (T) before starting T+1.
+
+      const lastClose = this.state.lastCandle.close.toNumber();
+
+      // Advance EMA State
+      if (this.state.ema && this.enabled("ema")) {
+          Object.keys(this.state.ema).forEach(k => {
+              const len = parseInt(k);
+              const state = this.state.ema![len];
+              // Calculate final EMA for the closed candle
+              const finalEma = JSIndicators.updateEma(state.prevEma, lastClose, len);
+              // Update state to this new finalized value
+              state.prevEma = finalEma;
+          });
+      }
+
+      // Advance RSI State
+      if (this.state.rsi && this.enabled("rsi")) {
+          Object.keys(this.state.rsi).forEach(k => {
+              const len = parseInt(k);
+              const state = this.state.rsi![len];
+              // Update with the finalized close of the candle being shifted out
+              const { avgGain, avgLoss } = JSIndicators.updateRsi(
+                  state.avgGain, state.avgLoss,
+                  lastClose, state.prevPrice, len
+              );
+              state.avgGain = avgGain;
+              state.avgLoss = avgLoss;
+              state.prevPrice = lastClose;
+          });
+      }
+
+      // 2. Shift History
+      // Push the finalized lastClose to ring buffer
+      if (this.historyBuffers["close"]) {
+          this.historyBuffers["close"][this.historyIndex] = lastClose;
+          this.historyIndex = (this.historyIndex + 1) % this.historySize;
+      }
+
+      this.state.lastCandle = newCandle;
+
+      // Note: 'lastResult' is not updated here.
+      // The first 'update()' call on the new candle will generate the new result based on this shifted state.
   }
 
   private enabled(key: string): boolean {
@@ -157,6 +222,47 @@ export class StatefulTechnicalsCalculator {
               prevPrice: closes[closes.length - 1]
           };
       }
+
+      // Reconstruct SMA State
+      // We need 'prevSum'. SMA = Sum / N. So prevSum = SMA * N.
+      this.state.sma = {};
+      // Iterate MAs, if SMA found
+      // Actually SMA is not in default MAs list (only EMA 1/2/3).
+      // But user can config. Let's support it if it appears.
+      // Currently `technicalsCalculator` outputs EMAs primarily.
+      // If we add SMA support to the app later, this logic is ready.
+      // For now, let's enable it if we see "SMA".
+      // But typically standard MAs in this app are EMAs.
+      // Bollinger Bands use SMA.
+
+      // Bollinger Support
+      if (this.enabled("bb") && result.volatility?.bb) {
+          // BB uses SMA(20).
+          // We need to store the SUM of the last 20 closes.
+          // result.volatility.bb.middle is the SMA value.
+          const len = this.settings?.bb?.length || 20;
+          const smaVal = result.volatility.bb.middle;
+          // State: Sum = SMA * len
+          // We store it under a specific key "BB" or generic "SMA:20"?
+          // Let's use generic "SMA:length".
+          // We need to know which indicator uses it during update.
+          // For now, let's just store it for BB.
+          this.state.sma[len] = { prevSum: smaVal * len };
+      }
+  }
+
+  private initHistoryBuffers(history: Kline[]) {
+      // Fill ring buffer with last N closes
+      const len = history.length;
+      this.historyBuffers["close"] = new Float64Array(this.historySize);
+
+      const start = Math.max(0, len - this.historySize);
+      let writeIdx = 0;
+      for(let i=start; i<len; i++) {
+          this.historyBuffers["close"][writeIdx] = history[i].close.toNumber();
+          writeIdx++;
+      }
+      this.historyIndex = writeIdx % this.historySize;
   }
 
   private updateEmaGroup(result: TechnicalsData, price: number) {
@@ -207,6 +313,66 @@ export class StatefulTechnicalsCalculator {
               rsiInd.value = rsi;
               // Action logic could be duplicated here or extracted.
               // For now, minimal update.
+          }
+      }
+  }
+
+  private updateSmaGroup(result: TechnicalsData, price: number) {
+      // Bollinger Bands Update
+      if (this.state.sma && this.enabled("bb") && result.volatility?.bb) {
+          const len = this.settings?.bb?.length || 20;
+          const stdDev = this.settings?.bb?.stdDev || 2;
+          const state = this.state.sma[len];
+
+          if (state && this.historyBuffers["close"]) {
+              // Retrieve the OLD value that is falling out of the window.
+              // The window is length 'len'.
+              // The 'current' window includes 'price'.
+              // So we need the value at index (now - len).
+              // 'historyIndex' points to next write (which is effectively T).
+              // So T-1 is at historyIndex-1.
+              // T-len is at historyIndex - len.
+
+              let oldIdx = this.historyIndex - len;
+              if (oldIdx < 0) oldIdx += this.historySize;
+
+              const oldVal = this.historyBuffers["close"][oldIdx];
+
+              // Calc new SMA
+              // SMA_new = (Sum_prev - Old + New) / N
+              // Wait, 'state.prevSum' is sum of [T-N .. T-1].
+              // New Sum = prevSum - Val[T-N] + Price.
+              // This is correct.
+
+              const newSum = state.prevSum - oldVal + price;
+              const newSma = newSum / len;
+
+              // Update BB
+              // We need StdDev for BB.
+              // Incremental StdDev is hard (requires sum of squares).
+              // For now, we can iterate the ring buffer for StdDev (O(N) but small N=20).
+              // This is much faster than iterating 1000 candles.
+
+              let sumSqDiff = 0;
+              // Iterate window to calc Variance
+              for(let i=0; i<len-1; i++) {
+                  // Reconstruct index
+                  let idx = this.historyIndex - 1 - i;
+                  if (idx < 0) idx += this.historySize;
+                  const val = this.historyBuffers["close"][idx];
+                  sumSqDiff += Math.pow(val - newSma, 2);
+              }
+              // Add current price
+              sumSqDiff += Math.pow(price - newSma, 2);
+
+              const std = Math.sqrt(sumSqDiff / len);
+
+              result.volatility.bb = {
+                  middle: newSma,
+                  upper: newSma + std * stdDev,
+                  lower: newSma - std * stdDev,
+                  percentP: (result.volatility.bb.upper - result.volatility.bb.lower) === 0 ? 0.5 : (price - (newSma - std*stdDev)) / ((newSma + std*stdDev) - (newSma - std*stdDev))
+              };
           }
       }
   }


### PR DESCRIPTION
- Implemented `shift(newCandle)` logic in `StatefulTechnicalsCalculator` to handle new candles incrementally (finalizing previous candle state).
- Added `SHIFT` message type to worker and service to trigger seamless candle transitions.
- Extended incremental support to SMA (used by Bollinger Bands) by introducing a `historyBuffer` (Ring Buffer) in the calculator.
- Updated `TechnicalsState` type to include `sma` state.