### PR TITLE
Systematic hardening of TradeService, MarketWatcher, and Data Integrity

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -602,6 +602,12 @@ export const apiService = {
                   logger.warn("network", "[Bitunix] Dropping invalid kline (Time=0)", d);
                   return null;
               }
+
+              // HARDENING: Check for missing or zero prices
+              if (!d.open || !d.close || d.open === "0" || d.close === "0") {
+                  return null;
+              }
+
               return {
                 open: d.open,
                 high: d.high,

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -604,7 +604,8 @@ export const apiService = {
               }
 
               // HARDENING: Check for missing or zero prices
-              if (!d.open || !d.close || d.open === "0" || d.close === "0") {
+              // d.open/close are Decimals (from BitunixKlineSchema)
+              if (!d.open || !d.close || d.open.isZero() || d.close.isZero()) {
                   return null;
               }
 

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -823,7 +823,7 @@ class BitunixWebSocketService {
                     const safeMessage = { ...message, data: safeData };
                     const normalized = mdaService.normalizeTicker(safeMessage, "bitunix");
 
-                    if (!this.shouldThrottle(`${symbol}:ticker`)) {
+                    if (normalized && !this.shouldThrottle(`${symbol}:ticker`)) {
                       marketState.updateSymbol(symbol, {
                         lastPrice: normalized.lastPrice,
                         highPrice: normalized.high,
@@ -1012,7 +1012,7 @@ class BitunixWebSocketService {
         const symbol = normalizeSymbol(rawSymbol, "bitunix");
         const normalized = mdaService.normalizeTicker(validatedMessage, "bitunix");
 
-        if (!this.shouldThrottle(`${symbol}:ticker`)) {
+        if (normalized && !this.shouldThrottle(`${symbol}:ticker`)) {
           marketState.updateSymbol(symbol, {
             lastPrice: normalized.lastPrice,
             highPrice: normalized.high,

--- a/src/services/mdaService.test.ts
+++ b/src/services/mdaService.test.ts
@@ -57,8 +57,8 @@ describe('mdaService Data Hardening', () => {
   it('should handle null/undefined safely', () => {
      const raw = { symbol: 'BTCUSDT', data: {} };
      const normalized = mdaService.normalizeTicker(raw, 'bitunix');
-     expect(normalized.lastPrice).toBe('0');
-     expect(normalized.volume).toBe('0');
+     // Changed behavior: Invalid/Empty data returns null to prevent zero-price pollution
+     expect(normalized).toBeNull();
   });
 
   it('should handle fast-path flat objects', () => {

--- a/src/services/mdaService.test.ts
+++ b/src/services/mdaService.test.ts
@@ -34,10 +34,11 @@ describe('mdaService Data Hardening', () => {
     const normalized = mdaService.normalizeTicker(raw, 'bitunix');
 
     // Assert strict string type
-    expect(typeof normalized.lastPrice).toBe('string');
-    expect(normalized.lastPrice).toBe('50000.5'); // JS default stringification
-    expect(typeof normalized.volume).toBe('string');
-    expect(normalized.volume).toBe('1000.123');
+    expect(normalized).not.toBeNull();
+    expect(typeof normalized!.lastPrice).toBe('string');
+    expect(normalized!.lastPrice).toBe('50000.5'); // JS default stringification
+    expect(typeof normalized!.volume).toBe('string');
+    expect(normalized!.volume).toBe('1000.123');
   });
 
   it('should handle string inputs correctly (preserving precision)', () => {
@@ -50,8 +51,9 @@ describe('mdaService Data Hardening', () => {
     };
     const normalized = mdaService.normalizeTicker(raw, 'bitunix');
 
-    expect(typeof normalized.lastPrice).toBe('string');
-    expect(normalized.lastPrice).toBe('50000.500000001'); // Should not round
+    expect(normalized).not.toBeNull();
+    expect(typeof normalized!.lastPrice).toBe('string');
+    expect(normalized!.lastPrice).toBe('50000.500000001'); // Should not round
   });
 
   it('should handle null/undefined safely', () => {
@@ -69,7 +71,8 @@ describe('mdaService Data Hardening', () => {
       };
 
       const normalized = mdaService.normalizeTicker(raw, 'bitunix');
-      expect(normalized.lastPrice).toBe('3000.55');
-      expect(typeof normalized.lastPrice).toBe('string');
+      expect(normalized).not.toBeNull();
+      expect(normalized!.lastPrice).toBe('3000.55');
+      expect(typeof normalized!.lastPrice).toBe('string');
   });
 });

--- a/src/services/tradeService_flashClose.test.ts
+++ b/src/services/tradeService_flashClose.test.ts
@@ -1,0 +1,111 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tradeService } from './tradeService';
+import { omsService } from './omsService';
+import { Decimal } from 'decimal.js';
+import { marketState } from '../stores/market.svelte';
+
+// Mock dependencies
+vi.mock('./omsService', () => ({
+  omsService: {
+    getPositions: vi.fn(),
+    updatePosition: vi.fn(),
+    addOptimisticOrder: vi.fn(),
+    removeOrder: vi.fn(),
+    getOrder: vi.fn(),
+    updateOrder: vi.fn(),
+  }
+}));
+
+vi.mock('../stores/settings.svelte', () => ({
+  settingsState: {
+    apiProvider: 'bitunix',
+    apiKeys: {
+      bitunix: { key: 'test', secret: 'test' }
+    }
+  }
+}));
+
+vi.mock('../stores/market.svelte', async (importOriginal) => {
+    const { Decimal } = await import('decimal.js');
+    return {
+        marketState: {
+            data: {
+                'BTCUSDT': { lastPrice: new Decimal(50000) }
+            }
+        }
+    };
+});
+
+vi.mock('./logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+  }
+}));
+
+describe('TradeService Flash Close Reproduction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('flashClosePosition crashes if cancelAllOrders fails', async () => {
+    const symbol = 'BTCUSDT';
+    const side = 'long';
+
+    // Fresh position
+    const freshPos = {
+      symbol,
+      side,
+      amount: new Decimal(1),
+      lastUpdated: Date.now(),
+    };
+
+    (omsService.getPositions as any).mockReturnValue([freshPos]);
+
+    // Mock fetch to simulate cancelAllOrders failure
+    // The first call will be "cancel-all"
+    (global.fetch as any).mockImplementation(async (url: string, options: any) => {
+        const body = JSON.parse(options.body);
+
+        if (body.type === 'cancel-all') {
+            return {
+                ok: false,
+                status: 504,
+                text: () => Promise.resolve('Gateway Timeout')
+            };
+        }
+
+        if (body.type === 'place-order' || body.side === 'SELL' || body.side === 'BUY') {
+             return {
+                ok: true,
+                text: () => Promise.resolve(JSON.stringify({ code: 0, msg: 'success' }))
+             };
+        }
+
+        return {
+            ok: false,
+            text: () => Promise.resolve('Unknown')
+        };
+    });
+
+    // Expect flashClosePosition to resolve (Best Effort)
+    await expect(tradeService.flashClosePosition(symbol, side)).resolves.toEqual({ code: 0, msg: 'success' });
+
+    // Verify that the CLOSE order WAS sent despite cancel failure
+    // We expect 2 calls (cancel-all, then place-order)
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    const firstCallArgs = (global.fetch as any).mock.calls[0];
+    expect(JSON.parse(firstCallArgs[1].body).type).toBe('cancel-all');
+
+    const secondCallArgs = (global.fetch as any).mock.calls[1];
+    const secondBody = JSON.parse(secondCallArgs[1].body);
+    // It is a POST /api/orders
+    expect(secondCallArgs[0]).toBe('/api/orders');
+    // For closePosition, we check side or other params
+    expect(secondBody.reduceOnly).toBe(true);
+  });
+});


### PR DESCRIPTION
Implemented systematic maintenance and hardening fixes:
1.  **Trade Stability**: `flashClosePosition` no longer crashes if `cancelAllOrders` times out. It logs the error and proceeds to close the position (Best Effort).
2.  **Data Integrity**: `mdaService` now validates critical fields (price, volume) and returns `null` if missing, preventing "0.00" price artifacts in the UI. `BitunixWs` and `ApiService` consume this safely.
3.  **Performance**: `MarketWatcher` polling loop refactored to recursive `setTimeout` to handle variable network latency gracefully without stacking requests.
4.  **Verified**: Added unit test `src/services/tradeService_flashClose.test.ts` ensuring the fix works. Verified `mdaService` with updated tests.

---
*PR created automatically by Jules for task [8200876167577493930](https://jules.google.com/task/8200876167577493930) started by @mydcc*