### PR TITLE
Fix Matomo tracking for SvelteKit navigation

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,6 +16,13 @@
 -->
 
 <script lang="ts">
+  import { afterNavigate } from "$app/navigation";
+  import { page } from "$app/stores";
+  import { trackPageView } from "../services/trackingService";
+
+  afterNavigate(() => {
+    trackPageView($page.url.href, document.title);
+  });
   import favicon from "../assets/favicon.svg";
   import { uiState } from "../stores/ui.svelte";
   import { settingsState } from "../stores/settings.svelte";

--- a/src/services/trackingService.ts
+++ b/src/services/trackingService.ts
@@ -133,3 +133,27 @@ export function trackInteraction(
 
   pushToDataLayer(eventData);
 }
+
+/**
+ * Tracks a page view event in Matomo.
+ * Pushes the standard 'mtm.PageView' event with URL and title.
+ *
+ * @param url The current full URL (e.g. from page.url.href)
+ * @param title The document title
+ */
+export function trackPageView(url: string, title?: string) {
+  // Check if window exists (SSR guard) and if _mtm is available
+  if (typeof window === "undefined" || !window._mtm) {
+    if (import.meta.env.DEV) {
+      console.warn("Matomo Tag Manager not available. Skipping PageView:", url);
+    }
+    return;
+  }
+
+  window._mtm.push({
+    event: "mtm.PageView",
+    pageUrl: url,
+    pageTitle: title,
+    mtm: { startTime: new Date().getTime() },
+  });
+}


### PR DESCRIPTION
- Added `trackPageView` helper in `src/services/trackingService.ts` strictly typed and compliant with Matomo structure.
- Added `afterNavigate` hook in `src/routes/+layout.svelte` to trigger page views on route changes.
- Verified type safety with `npm run check`.
- Verified tests pass with `npm test`.

---
*PR created automatically by Jules for task [7586254428370830590](https://jules.google.com/task/7586254428370830590) started by @mydcc*