### PR TITLE
Fix: Integrate Matomo PageView tracking

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,6 +25,9 @@
   import OrderDetailsTooltip from "../components/shared/OrderDetailsTooltip.svelte";
   import OfflineBanner from "../components/shared/OfflineBanner.svelte";
   import { onMount } from "svelte";
+import { afterNavigate } from "$app/navigation";
+  import { page } from "$app/stores";
+  import { trackPageView } from "../services/trackingService";
   import { initZoomPlugin } from "../lib/chartSetup";
   import BackgroundRenderer from "../components/shared/BackgroundRenderer.svelte";
 
@@ -127,6 +130,10 @@
         evtSource.close();
       }
     };
+  });
+
+  afterNavigate(() => {
+    trackPageView($page.url.href, document.title);
   });
 
   onMount(() => {
@@ -265,6 +272,7 @@
   });
 
   // Start Market Analyst
+
   onMount(() => {
     import("../services/marketAnalyst").then(({ marketAnalyst }) => {
       marketAnalyst.start();

--- a/src/services/trackingService.ts
+++ b/src/services/trackingService.ts
@@ -133,3 +133,24 @@ export function trackInteraction(
 
   pushToDataLayer(eventData);
 }
+
+/**
+ * Tracks a page view event explicitly for Matomo.
+ * Ensures the 'mtm.PageView' event is sent with the correct structure.
+ *
+ * @param url The current page URL
+ * @param title The page title (optional)
+ */
+export function trackPageView(url: string, title?: string) {
+  // SSR Guard
+  if (typeof window === "undefined" || !window._mtm) {
+    return;
+  }
+
+  window._mtm.push({
+    event: 'mtm.PageView',
+    pageUrl: url,
+    pageTitle: title,
+    mtm: { startTime: new Date().getTime() }
+  });
+}


### PR DESCRIPTION
Connects existing Matomo container to SvelteKit router events using afterNavigate. Added trackPageView in trackingService and hook in layout.

---
*PR created automatically by Jules for task [5268724002983404213](https://jules.google.com/task/5268724002983404213) started by @mydcc*