### PR TITLE
Fix WebGL shader error and sentiment analysis missing key handling

### DIFF
--- a/src/components/shared/backgrounds/TradeFlowBackground.svelte
+++ b/src/components/shared/backgrounds/TradeFlowBackground.svelte
@@ -296,7 +296,8 @@
       fragmentShader: fragmentShader,
       transparent: true,
       depthWrite: false, // For better transparency if needed
-      blending: THREE.AdditiveBlending
+      blending: THREE.AdditiveBlending,
+      vertexColors: true
     });
 
     resources.points = new THREE.Points(resources.geometry, resources.material);

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -465,7 +465,12 @@ export const newsService = {
 
         return analysis;
       } catch (e: any) {
-        logger.error("ai", "Sentiment Analysis Failed", e);
+        const msg = e?.message || String(e);
+        if (msg.includes("NO_GEMINI_KEY") || msg.includes("NO_OPENAI_KEY")) {
+          logger.warn("ai", "Sentiment analysis skipped: Missing API Key");
+        } else {
+          logger.error("ai", "Sentiment Analysis Failed", e);
+        }
         return {
           score: 0,
           regime: "UNCERTAIN",


### PR DESCRIPTION
- Added `vertexColors: true` to `TradeFlowBackground.svelte` ShaderMaterial to fix 'undeclared identifier color' WebGL error.
- Updated `newsService.ts` to log warnings instead of errors when API keys are missing for sentiment analysis.

---
*PR created automatically by Jules for task [9059401668128901252](https://jules.google.com/task/9059401668128901252) started by @mydcc*