### PR TITLE
Implement proper position reset in omsService

### DIFF
--- a/src/services/omsService.ts
+++ b/src/services/omsService.ts
@@ -50,6 +50,12 @@ class OrderManagementSystem {
         }
     }
 
+    public reset() {
+        this.orders.clear();
+        this.positions.clear();
+        logger.log("market", "[OMS] State Reset");
+    }
+
     public updateOrder(order: OMSOrder) {
         const isKnown = this.orders.has(order.id);
 

--- a/src/services/tradeService_safety.test.ts
+++ b/src/services/tradeService_safety.test.ts
@@ -27,11 +27,7 @@ vi.mock("./logger", () => ({
 describe("TradeService Safety - Flash Close", () => {
     beforeEach(() => {
         // Reset OMS
-        const orders = omsService.getAllOrders();
-        orders.forEach(o => omsService.removeOrder(o.id));
-        // Reset Positions (Hack: access private map via public update or just assume we start fresh)
-        // omsService has no clear method, but we can overwrite.
-        // Since we can't easily clear positions map without 'destroy', we'll rely on unique symbols.
+        omsService.reset();
     });
 
     afterEach(() => {


### PR DESCRIPTION
Added a `reset()` method to `omsService` to properly clear orders and positions. Updated `tradeService_safety.test.ts` to use this method, replacing a manual cleanup hack.

---
*PR created automatically by Jules for task [1076844794704177709](https://jules.google.com/task/1076844794704177709) started by @mydcc*