### PR TITLE
Performance: News Cache Optimization

### DIFF
--- a/src/routes/api/external/news/+server.ts
+++ b/src/routes/api/external/news/+server.ts
@@ -16,9 +16,20 @@ interface CachedResponse {
   timestamp: number;
 }
 
-const newsCache = new Map<string, CachedResponse>();
+export const _newsCache = new Map<string, CachedResponse>();
 const pendingRequests = new Map<string, Promise<any>>();
 const CACHE_TTL = 60 * 60 * 1000; // 60 Minuten (erh\u00f6ht f\u00fcr Quota-Schonung)
+const MAX_CACHE_SIZE = 50;
+
+function setCache(key: string, data: any) {
+  if (_newsCache.has(key)) {
+    _newsCache.delete(key);
+  } else if (_newsCache.size >= MAX_CACHE_SIZE) {
+    const oldest = _newsCache.keys().next().value;
+    if (oldest !== undefined) _newsCache.delete(oldest);
+  }
+  _newsCache.set(key, { data, timestamp: Date.now() });
+}
 
 export const POST: RequestHandler = async ({ request, fetch }) => {
   let cacheKey = ""; // Scope erweitern für catch-Block
@@ -34,8 +45,11 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
     const now = Date.now();
 
     // Check Cache
-    const cached = newsCache.get(cacheKey);
+    const cached = _newsCache.get(cacheKey);
     if (cached && (now - cached.timestamp < CACHE_TTL)) {
+      // Refresh LRU position
+      _newsCache.delete(cacheKey);
+      _newsCache.set(cacheKey, cached);
       return json(cached.data);
     }
 
@@ -71,7 +85,7 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
             const response = await fetch(url);
             if (response.ok) {
               const data = await response.json();
-              newsCache.set(cacheKey, { data, timestamp: Date.now() });
+              setCache(cacheKey, data);
               return data;
             }
             if (response.status === 429) {
@@ -102,7 +116,7 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
           throw new Error(`Upstream error (NewsAPI): ${response.status} - ${errorText}`);
         }
         const data = await response.json();
-        newsCache.set(cacheKey, { data, timestamp: Date.now() });
+        setCache(cacheKey, data);
         return data;
       } else {
         throw new Error("Invalid source");
@@ -128,7 +142,7 @@ export const POST: RequestHandler = async ({ request, fetch }) => {
 
     // 429-Error → Nutze stale cache falls vorhanden
     if (errorMsg.includes("429") || errorMsg.includes("quota")) {
-      const staleCache = newsCache.get(cacheKey);
+      const staleCache = _newsCache.get(cacheKey);
       if (staleCache) {
         console.warn("[NewsProxy] Using stale cache due to quota exhaustion");
         return json(staleCache.data);

--- a/src/routes/api/external/news/news_service_memory.test.ts
+++ b/src/routes/api/external/news/news_service_memory.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST, _newsCache } from './+server';
+
+describe('News Service Cache Memory', () => {
+    beforeEach(() => {
+        _newsCache.clear();
+        vi.clearAllMocks();
+    });
+
+    it('should limit cache size to 50 items (optimization)', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ articles: [] }),
+            text: async () => "",
+        });
+
+        // Insert 100 items
+        for (let i = 0; i < 100; i++) {
+            const request = {
+                json: async () => ({
+                    source: 'newsapi',
+                    apiKey: 'test-key',
+                    params: { q: `test-${i}` }
+                })
+            } as any;
+
+            await POST({ request, fetch: fetchMock } as any);
+        }
+
+        // Optimization: Cache size should be capped at 50
+        expect(_newsCache.size).toBe(50);
+
+        // Verify LRU: The last item (99) should exist, the first (0) should not
+        const cacheKeyLast = `newsapi:{"q":"test-99"}:default`;
+        expect(_newsCache.has(cacheKeyLast)).toBe(true);
+
+        const cacheKeyFirst = `newsapi:{"q":"test-0"}:default`;
+        expect(_newsCache.has(cacheKeyFirst)).toBe(false);
+    });
+});


### PR DESCRIPTION
⚡ Performance: Implement LRU Cache for News Service to prevent memory leaks

💡 **What:**
- Replaced the unbounded `Map` cache in `src/routes/api/external/news/+server.ts` with an LRU-style cache bounded at 50 items.
- Implemented cache eviction (oldest first) when the limit is reached.
- Updated cache hits to refresh the item's position (delete/set).
- Exported the cache as `_newsCache` to enable white-box testing.
- Added `news_service_memory.test.ts` to verify the fix.

🎯 **Why:**
- The previous implementation used a global `Map` that grew indefinitely with every unique request (cache key includes query params).
- This would eventually lead to `OutOfMemoryError` on the server under load or over time.

📊 **Measured Improvement:**
- **Baseline:** A reproduction test showed the cache size growing to 100 items after 100 unique requests.
- **Optimized:** The same test confirms the cache size is strictly capped at 50 items, with the oldest entries being evicted.
- **Impact:** Memory usage is now deterministic and bounded for this service.

---
*PR created automatically by Jules for task [17277128817849124703](https://jules.google.com/task/17277128817849124703) started by @mydcc*