### PR TITLE
Fix unsanitized error logging in account API

### DIFF
--- a/src/tests/hardening/account_logging.test.ts
+++ b/src/tests/hardening/account_logging.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { POST } from "../../routes/api/account/+server";
+
+// Mock @sveltejs/kit
+vi.mock("@sveltejs/kit", () => ({
+  json: (data: any, init?: any) => ({ ...init, body: JSON.stringify(data) }),
+}));
+
+describe("Account API Logging Security", () => {
+  let consoleErrorSpy: any;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Mock fetch to return a failure with sensitive data
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () =>
+        Promise.resolve("Error with key: MY_SECRET_KEY_1234567890_LEAKED"),
+      json: () => Promise.resolve({}),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should not log sensitive data in error messages", async () => {
+    const request = {
+      json: async () => ({
+        exchange: "bitunix",
+        apiKey: "valid_api_key_12345",
+        apiSecret: "valid_api_secret_12345",
+      }),
+    };
+
+    // Execute POST
+    await POST({ request: request as any } as any);
+
+    // Check logs
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const loggedArgs = consoleErrorSpy.mock.calls[0];
+    const logOutput = loggedArgs.join(" ");
+
+    console.log("Test captured log:", logOutput);
+
+    // The sensitive key should be redacted
+    expect(logOutput).not.toContain("MY_SECRET_KEY_1234567890_LEAKED");
+    expect(logOutput).toContain("[REDACTED]");
+  });
+});


### PR DESCRIPTION
Sanitize exchange parameter and redact sensitive data from error logs. Added regression test.

---
*PR created automatically by Jules for task [5412908337456425342](https://jules.google.com/task/5412908337456425342) started by @mydcc*