### PR TITLE
🔒 Fix Weak Randomness in ID Generation

### DIFF
--- a/src/stores/notes.svelte.ts
+++ b/src/stores/notes.svelte.ts
@@ -19,7 +19,7 @@ export interface NoteMessage {
 
 const LOCAL_STORAGE_KEY = "cachy_notes_history";
 
-class NotesManager {
+export class NotesManager {
   messages = $state<NoteMessage[]>([]);
 
   constructor() {
@@ -70,7 +70,7 @@ class NotesManager {
     const limit = settingsState.maxPrivateNotes || 50;
 
     const newNote: NoteMessage = {
-      id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
+      id: crypto.randomUUID(),
       text,
       timestamp: Date.now(),
     };

--- a/src/stores/notesStore.test.ts
+++ b/src/stores/notesStore.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("$app/environment", () => ({
+  browser: true,
+  dev: true
+}));
+
+vi.mock("./settings.svelte", () => ({
+  settingsState: {
+    maxPrivateNotes: 10
+  }
+}));
+
+import { NotesManager } from "./notes.svelte";
+
+describe("NotesManager Security", () => {
+  let notesManager: NotesManager;
+
+  beforeEach(() => {
+    // Mock localStorage
+    const storage: Record<string, string> = {};
+    global.localStorage = {
+      getItem: (key: string) => storage[key] || null,
+      setItem: (key: string, value: string) => { storage[key] = value; },
+      removeItem: (key: string) => { delete storage[key]; },
+      clear: () => { },
+      length: 0,
+      key: (index: number) => null,
+    };
+    notesManager = new NotesManager();
+  });
+
+  it("should generate a secure UUID for note ID", () => {
+    notesManager.addNote("Test secure note");
+    const note = notesManager.messages[0];
+
+    expect(note).toBeDefined();
+    expect(note.text).toBe("Test secure note");
+
+    // UUID v4 regex
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    expect(note.id).toMatch(uuidRegex);
+  });
+});


### PR DESCRIPTION
Fixed security vulnerability in `src/stores/notes.svelte.ts` where note IDs were generated using insecure `Math.random()`.
Replaced with `crypto.randomUUID()` for cryptographically secure UUID generation.
Exported `NotesManager` for better testing.
Added `src/stores/notesStore.test.ts` to verify ID generation and security.

---
*PR created automatically by Jules for task [13495499814130414749](https://jules.google.com/task/13495499814130414749) started by @mydcc*