### PR TITLE
🔒 Add HTTP Security Headers

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -122,11 +122,15 @@ const themeHandler: Handle = async ({ event, resolve }) => {
   return response;
 };
 
-const headersHandler: Handle = async ({ event, resolve }) => {
+export const headersHandler: Handle = async ({ event, resolve }) => {
   const response = await resolve(event);
   // Enable Cross-Origin-Opener-Policy to allow interaction with popups (like TradingView)
   // that also set this header. This helps in maintaining window references for named targets.
   response.headers.set("Cross-Origin-Opener-Policy", "same-origin-allow-popups");
+  response.headers.set("X-Frame-Options", "SAMEORIGIN");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
   return response;
 };
 

--- a/src/tests/security/headers.test.ts
+++ b/src/tests/security/headers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { headersHandler } from '../../hooks.server';
+import type { RequestEvent } from '@sveltejs/kit';
+
+describe('Security Headers', () => {
+  it('should set security headers', async () => {
+    // Mock the resolve function to return a basic response
+    const resolve = vi.fn().mockResolvedValue(new Response('ok'));
+
+    // Mock the event object
+    const event = {
+      request: new Request('http://localhost/'),
+      url: new URL('http://localhost/'),
+      cookies: {
+        get: () => null,
+      },
+    } as unknown as RequestEvent;
+
+    // Call the headersHandler function
+    const response = await headersHandler({ event, resolve });
+
+    // Verify headers
+    const headers = response.headers;
+
+    // Existing header
+    expect(headers.get('Cross-Origin-Opener-Policy')).toBe('same-origin-allow-popups');
+
+    // Missing headers (these should fail initially)
+    expect(headers.get('X-Frame-Options')).toBe('SAMEORIGIN');
+    expect(headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(headers.get('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=()');
+  });
+});


### PR DESCRIPTION
* 🎯 **What:** Added missing HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) to `src/hooks.server.ts`.
* ⚠️ **Risk:** Without these headers, the application is vulnerable to clickjacking, MIME type sniffing, and potential privacy leaks via referrer or feature usage.
* 🛡️ **Solution:** Implemented a `headersHandler` that sets these standard hardening headers. Added a regression test to verify their presence.

---
*PR created automatically by Jules for task [10184434643683153969](https://jules.google.com/task/10184434643683153969) started by @mydcc*