### PR TITLE
🔒 Fix path traversal vulnerability in CMC proxy

### DIFF
--- a/src/routes/api/external/cmc/+server.ts
+++ b/src/routes/api/external/cmc/+server.ts
@@ -41,7 +41,7 @@ export const GET: RequestHandler = async ({ url, request }) => {
     "/v1/cryptocurrency/category",
   ];
 
-  if (!ALLOWED_ENDPOINTS.some((ep) => endpoint.startsWith(ep))) {
+  if (!ALLOWED_ENDPOINTS.includes(endpoint)) {
     return json({ error: "Endpoint not allowed" }, { status: 403 });
   }
 

--- a/src/tests/security/cmc_proxy.test.ts
+++ b/src/tests/security/cmc_proxy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// @ts-ignore
+import { GET } from '../../routes/api/external/cmc/+server';
+
+describe('CMC Proxy Security', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    // Mock console to reduce noise
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should allow whitelisted endpoints', async () => {
+    const url = new URL('http://localhost/api/external/cmc?endpoint=/v1/global-metrics/quotes/latest');
+    const request = new Request(url, {
+      headers: { 'x-cmc-api-key': 'test-key' }
+    });
+
+    (global.fetch as any).mockResolvedValue(new Response(JSON.stringify({ data: 'ok' })));
+
+    const response = await GET({ request, url } as any);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ data: 'ok' });
+  });
+
+  it('should block non-whitelisted endpoints', async () => {
+    const url = new URL('http://localhost/api/external/cmc?endpoint=/v1/unknown');
+    const request = new Request(url, {
+      headers: { 'x-cmc-api-key': 'test-key' }
+    });
+
+    const response = await GET({ request, url } as any);
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe('Endpoint not allowed');
+  });
+
+  it('should prevent path traversal', async () => {
+    const exploitEndpoint = '/v1/global-metrics/quotes/latest/../sensitive';
+    const url = new URL(`http://localhost/api/external/cmc?endpoint=${encodeURIComponent(exploitEndpoint)}`);
+    const request = new Request(url, {
+      headers: { 'x-cmc-api-key': 'test-key' }
+    });
+
+    // Mock successful fetch to simulate successful exploitation if passed through
+    (global.fetch as any).mockResolvedValue(new Response(JSON.stringify({ secret: 'exposed' })));
+
+    const response = await GET({ request, url } as any);
+
+    // If vulnerable, this will be 200. We want 403.
+    expect(response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `src/routes/api/external/cmc/+server.ts`.
⚠️ **Risk:** The previous validation used `startsWith` to check the endpoint, allowing attackers to append `..` (e.g., `/v1/global-metrics/quotes/latest/../../sensitive`) to access unauthorized endpoints on the CMC API via the proxy.
🛡️ **Solution:** Changed the validation to use `ALLOWED_ENDPOINTS.includes(endpoint)` to enforce an exact match against the whitelist. Added a security regression test `src/tests/security/cmc_proxy.test.ts`.

---
*PR created automatically by Jules for task [11898127733178171363](https://jules.google.com/task/11898127733178171363) started by @mydcc*