### PR TITLE
🔒 Fix Unauthenticated Server Log Streaming

### DIFF
--- a/src/routes/api/stream-logs/+server.ts
+++ b/src/routes/api/stream-logs/+server.ts
@@ -17,15 +17,15 @@
 
 import { logger } from "$lib/server/logger";
 import { env } from "$env/dynamic/private";
-import { dev } from "$app/environment";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = ({ request, url }) => {
   // Security Check
+  const isDev = process.env.NODE_ENV === "development";
   const secret = env.LOG_STREAM_KEY;
   const token = url.searchParams.get("token");
 
-  if (!dev) {
+  if (!isDev) {
     if (!secret) {
       return new Response("Log streaming is disabled in production (LOG_STREAM_KEY not set)", {
         status: 403,

--- a/src/routes/api/stream-logs/+server.ts
+++ b/src/routes/api/stream-logs/+server.ts
@@ -16,9 +16,26 @@
  */
 
 import { logger } from "$lib/server/logger";
+import { env } from "$env/dynamic/private";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = ({ request }) => {
+export const GET: RequestHandler = ({ request, url }) => {
+  // Security Check
+  const isDev = process.env.NODE_ENV === "development";
+  const secret = env.LOG_STREAM_KEY;
+  const token = url.searchParams.get("token");
+
+  if (!isDev) {
+    if (!secret) {
+      return new Response("Log streaming is disabled in production (LOG_STREAM_KEY not set)", {
+        status: 403,
+      });
+    }
+    if (token !== secret) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  }
+
   // Setze Header für SSE
   const headers = {
     "Content-Type": "text/event-stream",

--- a/src/routes/api/stream-logs/+server.ts
+++ b/src/routes/api/stream-logs/+server.ts
@@ -17,15 +17,15 @@
 
 import { logger } from "$lib/server/logger";
 import { env } from "$env/dynamic/private";
+import { dev } from "$app/environment";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = ({ request, url }) => {
   // Security Check
-  const isDev = process.env.NODE_ENV === "development";
   const secret = env.LOG_STREAM_KEY;
   const token = url.searchParams.get("token");
 
-  if (!isDev) {
+  if (!dev) {
     if (!secret) {
       return new Response("Log streaming is disabled in production (LOG_STREAM_KEY not set)", {
         status: 403,

--- a/src/tests/security/log_stream_auth.test.ts
+++ b/src/tests/security/log_stream_auth.test.ts
@@ -5,24 +5,30 @@ const mockEnv = vi.hoisted(() => ({
   LOG_STREAM_KEY: undefined as string | undefined
 }));
 
+// Mutable mock app environment
+const mockAppEnv = vi.hoisted(() => ({
+  dev: false
+}));
+
 vi.mock("$env/dynamic/private", () => ({
   env: mockEnv
 }));
+
+vi.mock("$app/environment", () => ({
+  get dev() { return mockAppEnv.dev; },
+  building: false,
+  browser: false
+}));
+
 
 // Import the handler
 import { GET } from "../../routes/api/stream-logs/+server";
 
 describe("GET /api/stream-logs Security", () => {
-  const originalNodeEnv = process.env.NODE_ENV;
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnv.LOG_STREAM_KEY = undefined;
-    process.env.NODE_ENV = "test";
-  });
-
-  afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
+    mockAppEnv.dev = true; // Default to dev for safety in tests unless specified
   });
 
   const createRequest = (urlStr: string) => {
@@ -33,7 +39,7 @@ describe("GET /api/stream-logs Security", () => {
   };
 
   it("should allow access in development mode without token", async () => {
-    process.env.NODE_ENV = "development";
+    mockAppEnv.dev = true;
 
     // Simulate Request
     const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
@@ -45,7 +51,7 @@ describe("GET /api/stream-logs Security", () => {
   });
 
   it("should deny access in production if LOG_STREAM_KEY is not set", async () => {
-    process.env.NODE_ENV = "production";
+    mockAppEnv.dev = false;
     mockEnv.LOG_STREAM_KEY = undefined;
 
     const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
@@ -56,7 +62,7 @@ describe("GET /api/stream-logs Security", () => {
   });
 
   it("should deny access in production if token is missing", async () => {
-    process.env.NODE_ENV = "production";
+    mockAppEnv.dev = false;
     mockEnv.LOG_STREAM_KEY = "super-secret";
 
     const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
@@ -66,7 +72,7 @@ describe("GET /api/stream-logs Security", () => {
   });
 
   it("should deny access in production if token is wrong", async () => {
-    process.env.NODE_ENV = "production";
+    mockAppEnv.dev = false;
     mockEnv.LOG_STREAM_KEY = "super-secret";
 
     const event = { request: createRequest("http://localhost/api/stream-logs?token=wrong"), url: new URL("http://localhost/api/stream-logs?token=wrong") } as any;
@@ -76,7 +82,7 @@ describe("GET /api/stream-logs Security", () => {
   });
 
   it("should allow access in production if token is correct", async () => {
-    process.env.NODE_ENV = "production";
+    mockAppEnv.dev = false;
     mockEnv.LOG_STREAM_KEY = "super-secret";
 
     const event = { request: createRequest("http://localhost/api/stream-logs?token=super-secret"), url: new URL("http://localhost/api/stream-logs?token=super-secret") } as any;

--- a/src/tests/security/log_stream_auth.test.ts
+++ b/src/tests/security/log_stream_auth.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mutable mock env using vi.hoisted
+const mockEnv = vi.hoisted(() => ({
+  LOG_STREAM_KEY: undefined as string | undefined
+}));
+
+vi.mock("$env/dynamic/private", () => ({
+  env: mockEnv
+}));
+
+// Import the handler
+import { GET } from "../../routes/api/stream-logs/+server";
+
+describe("GET /api/stream-logs Security", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.LOG_STREAM_KEY = undefined;
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  const createRequest = (urlStr: string) => {
+    return {
+      url: new URL(urlStr, "http://localhost"),
+      signal: new AbortController().signal
+    } as unknown as Request;
+  };
+
+  it("should allow access in development mode without token", async () => {
+    process.env.NODE_ENV = "development";
+
+    // Simulate Request
+    const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
+
+    const response = await GET(event);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+  });
+
+  it("should deny access in production if LOG_STREAM_KEY is not set", async () => {
+    process.env.NODE_ENV = "production";
+    mockEnv.LOG_STREAM_KEY = undefined;
+
+    const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
+    const response = await GET(event);
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain("disabled");
+  });
+
+  it("should deny access in production if token is missing", async () => {
+    process.env.NODE_ENV = "production";
+    mockEnv.LOG_STREAM_KEY = "super-secret";
+
+    const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
+    const response = await GET(event);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should deny access in production if token is wrong", async () => {
+    process.env.NODE_ENV = "production";
+    mockEnv.LOG_STREAM_KEY = "super-secret";
+
+    const event = { request: createRequest("http://localhost/api/stream-logs?token=wrong"), url: new URL("http://localhost/api/stream-logs?token=wrong") } as any;
+    const response = await GET(event);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should allow access in production if token is correct", async () => {
+    process.env.NODE_ENV = "production";
+    mockEnv.LOG_STREAM_KEY = "super-secret";
+
+    const event = { request: createRequest("http://localhost/api/stream-logs?token=super-secret"), url: new URL("http://localhost/api/stream-logs?token=super-secret") } as any;
+    const response = await GET(event);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+  });
+});


### PR DESCRIPTION
Fixed a high-severity security vulnerability where server logs were exposed to unauthenticated users via the `/api/stream-logs` endpoint.

🎯 **What:** The endpoint `/api/stream-logs` was publicly accessible, allowing anyone to connect via SSE and view real-time server logs.
⚠️ **Risk:** Leaking sensitive information (environment details, user actions, internal errors) to attackers.
🛡️ **Solution:**
- Implemented a security check in `src/routes/api/stream-logs/+server.ts`.
- The endpoint now checks `process.env.NODE_ENV`.
- In **Production**:
  - Access is denied (403) if `LOG_STREAM_KEY` env var is not set (Secure by Default).
  - Access is authorized (200) only if `?token=...` matches `LOG_STREAM_KEY`.
  - Access is denied (401) if token is invalid.
- In **Development**: Access is allowed without token for developer convenience.
- Added a new test suite `src/tests/security/log_stream_auth.test.ts` to verify these rules.

---
*PR created automatically by Jules for task [15350702202565494199](https://jules.google.com/task/15350702202565494199) started by @mydcc*