### PR TITLE
Fix: Move tsx to dependencies for Render deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "svelte-i18n": "^4.0.1",
         "tailwindcss": "^4.1.18",
         "three": "^0.182.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "undici": "^6.23.0",
         "vite": "^7.3.1",
@@ -50,7 +51,6 @@
         "@vitest/ui": "^4.0.18",
         "happy-dom": "^20.3.9",
         "puppeteer": "^24.36.1",
-        "tsx": "^4.21.0",
         "vitest": "^4.0.18"
       }
     },
@@ -3113,7 +3113,6 @@
       "version": "4.13.5",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.5.tgz",
       "integrity": "sha512-v4/4xAEpBRp6SvCkWhnGCaLkJf9IwWzrsygJPxD/+p2/xPE3C5m2fA9FD0Ry9tG+Rqqq3gBzHSl6y1/T9V/tMQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -4312,7 +4311,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -4965,7 +4963,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -5353,7 +5350,6 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@vitest/ui": "^4.0.18",
     "happy-dom": "^20.3.9",
     "puppeteer": "^24.36.1",
-    "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
   "dependencies": {
@@ -54,6 +53,7 @@
     "svelte-i18n": "^4.0.1",
     "tailwindcss": "^4.1.18",
     "three": "^0.182.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "undici": "^6.23.0",
     "vite": "^7.3.1",


### PR DESCRIPTION
* Moved `tsx` from devDependencies to dependencies in `package.json`
* Updated `package-lock.json`
* This resolves potential "tsx not found" errors during Render build/runtime where NODE_ENV=production prunes dev dependencies.