### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive data leak in server logs

### DIFF
--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -192,7 +192,7 @@ class ServerLogger extends EventEmitter {
     const entry: LogEntry = {
       timestamp: new Date().toISOString(),
       level,
-      message,
+      message: this.sanitizeString(message),
       data: this.sanitize(data),
     };
 

--- a/tests/unit/logger_security.test.ts
+++ b/tests/unit/logger_security.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * Logger Security Tests
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { logger } from '../../src/lib/server/logger';
+
+describe('ServerLogger Security', () => {
+    it('should redact sensitive information from log message', () => {
+        const spy = vi.spyOn(logger, 'emit');
+
+        // Simulate a sensitive log message (e.g. from console.log)
+        const sensitiveKey = "sk_live_12345secret";
+        const message = `User config: {"apiKey":"${sensitiveKey}"}`;
+
+        logger.info(message);
+
+        // Verify that emit was called
+        expect(spy).toHaveBeenCalled();
+
+        // Get the arguments of the first call
+        const [event, entry] = spy.mock.calls[0];
+
+        expect(event).toBe('log');
+
+        // The message should be redacted
+        expect(entry.message).toContain('***REDACTED***');
+        expect(entry.message).not.toContain(sensitiveKey);
+
+        spy.mockRestore();
+    });
+
+    it('should redact sensitive information from data object', () => {
+        const spy = vi.spyOn(logger, 'emit');
+        const sensitiveData = { apiKey: "sk_live_98765secret" };
+
+        logger.info("User login", sensitiveData);
+
+        const [event, entry] = spy.mock.calls[0];
+
+        // The data object should be redacted (this was already working)
+        expect(entry.data.apiKey).toBe('***REDACTED***');
+
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Sensitive data (like API keys) passed to `console.log` was being leaked in plaintext to the log stream because the `message` field was not being sanitized.
🎯 Impact: Attackers with access to the log stream could extract secrets.
🔧 Fix: Sanitized the `message` field in `emitLog` using `sanitizeString`.
✅ Verification: Added unit tests (`tests/unit/logger_security.test.ts`) which verify that sensitive patterns in log messages are redacted.
Tested with `npm run test tests/unit/logger_security.test.ts` and full `npm run test`.

---
*PR created automatically by Jules for task [13661103390300460255](https://jules.google.com/task/13661103390300460255) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
