### PR TITLE
feat(security): enhance Content Security Policy (CSP)

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -32,14 +32,34 @@ const config = {
     csp: {
       mode: "auto",
       directives: {
+        "default-src": ["self"],
         "script-src": [
           "self",
           "unsafe-inline",
-          "unsafe-eval",
           "https://s.cachy.app",
           "https://js-agent.newrelic.com",
           "blob:",
         ],
+        "style-src": [
+          "self",
+          "unsafe-inline",
+        ],
+        "img-src": [
+          "self",
+          "data:",
+          "https://s.cachy.app",
+          "https://*.imgbb.com",
+          "https://avatars.githubusercontent.com",
+          "https://cdn.discordapp.com",
+          "https://*.githubusercontent.com",
+        ],
+        "font-src": [
+          "self",
+          "data:",
+        ],
+        "object-src": ["none"],
+        "base-uri": ["self"],
+        "frame-ancestors": ["self"],
         "connect-src": [
           "self",
           "https://s.cachy.app",
@@ -48,7 +68,9 @@ const config = {
           "https://bam.eu01.nr-data.net",
           "wss://fapi.bitunix.com",
           "wss://stream.bitunix.com",
+          "wss://ws.bitget.com",
           "https://api.imgbb.com",
+          "https://discord.com",
           "https://generativelanguage.googleapis.com",
           "https://api.openai.com",
         ],


### PR DESCRIPTION
Implements strict CSP in svelte.config.js to mitigate XSS and other attacks.

- Adds default-src: 'self'
- Removes 'unsafe-eval' from script-src
- Adds object-src: 'none' and base-uri: 'self'
- Adds frame-ancestors: 'self' to prevent clickjacking
- Explicitly lists allowed domains for img-src and connect-src (Bitget, Bitunix, Discord, Cachy, ImgBB, etc.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
