### PR TITLE
Sanitize API keys in positions-history logs and errors

### DIFF
--- a/src/routes/api/sync/positions-history/positions_history_security.test.ts
+++ b/src/routes/api/sync/positions-history/positions_history_security.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './+server';
+
+// Mock fetch globally
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+// Import the real signature function to mock if needed, or just let it run
+// Since the refactor uses generateBitunixSignature, we might need to mock crypto or ensure it works.
+// Node's crypto is available in vitest environment usually.
+
+describe('POST /api/sync/positions-history - Security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should sanitize API key in logs and response on error', async () => {
+    const apiKey = 'SENSITIVE_API_KEY_12345';
+    const apiSecret = 'SENSITIVE_API_SECRET_67890';
+    const errorMsg = `Invalid API Key: ${apiKey}`; // Simulate upstream error leaking key
+
+    // Mock fetch to fail with sensitive info in the body
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      text: async () => errorMsg,
+      status: 400,
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const request = {
+      json: async () => ({ apiKey, apiSecret, limit: 10 }),
+    } as Request;
+
+    const response = await POST({ request } as any);
+    const body = await response.json();
+
+    // Verify fetch was called
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Verify console.error was called
+    expect(consoleSpy).toHaveBeenCalled();
+    const loggedArgs = consoleSpy.mock.calls[0];
+    const loggedMessage = loggedArgs.join(' ');
+
+    // Vulnerability Check: Ideally, we want these to NOT contain the key.
+    expect(loggedMessage).not.toContain(apiKey);
+    expect(loggedMessage).toContain('***'); // Check for mask
+    expect(body.error).not.toContain(apiKey);
+    expect(body.error).toContain('***');
+  });
+
+  it('should work correctly with valid credentials', async () => {
+     fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ code: 0, data: { positionList: [] } }),
+    });
+
+    const request = {
+      json: async () => ({ apiKey: 'validApiKey', apiSecret: 'validSecret', limit: 10 }),
+    } as Request;
+
+    const response = await POST({ request } as any);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual([]);
+  });
+});


### PR DESCRIPTION
Refactor `src/routes/api/sync/positions-history/+server.ts` to prevent information leakage in server logs and client error responses.
Previously, API keys and secrets could be logged in plain text or returned to the client if the upstream API returned an error message containing them.
The refactor:
1.  Uses the shared `generateBitunixSignature` utility for consistent crypto operations.
2.  Explicitly sanitizes `console.error` arguments by masking API keys and secrets.
3.  Sanitizes the error message returned in the JSON response to avoid leaking upstream error details.
4.  Adds a regression test to verify sanitization.

---
*PR created automatically by Jules for task [15123148335979238714](https://jules.google.com/task/15123148335979238714) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
