### PR TITLE
Improve Set reactivity in QuizStore

### DIFF
--- a/src/stores/quiz.svelte.ts
+++ b/src/stores/quiz.svelte.ts
@@ -164,8 +164,6 @@ class QuizStore {
   markKnown() {
     if (this.activeQuestion) {
       this.knownQuestionIds.add(this.activeQuestion.id);
-      // Reactivity hack for Sets in Svelte 5 (reassign)
-      this.knownQuestionIds = new Set(this.knownQuestionIds);
       this.saveProgress();
     }
     this.closeQuiz();


### PR DESCRIPTION
The previous implementation used a reassignment hack (`this.knownQuestionIds = new Set(this.knownQuestionIds)`) to trigger reactivity for `knownQuestionIds`.
Since Svelte 5's `$state` proxy natively supports `Set` reactivity (mutations like `.add()` trigger updates), this hack is redundant.
This change removes the hack and the associated comment, relying on standard Svelte 5 reactivity patterns.

Verification:
- Manually reviewed `src/stores/quiz.svelte.ts` to ensure logical correctness.
- Verified that `knownQuestionIds` is initialized as a reactive `$state` proxy.
- Attempted to run tests but encountered environment limitations (missing dependencies).
- Confirmed no other usage of this pattern in the codebase via `grep`.

---
*PR created automatically by Jules for task [2862167992830188359](https://jules.google.com/task/2862167992830188359) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
