### PR TITLE
fix(bitunixWs): rename variable to resolve CI shadowing issue

### DIFF
--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -930,6 +930,7 @@ class BitunixWebSocketService {
       // BitunixWSMessageSchema in types/bitunixValidation.ts uses z.object({...}) which allows extra fields.
       const validationResult = BitunixWSMessageSchema.safeParse(message);
       if (!validationResult.success) {
+        const validationIssues = validationResult.error.issues;
         
         // Check if it's a critical structure failure vs minor field mismatch
         // If 'event', 'op' or 'ch' are missing/wrong type, it's critical.
@@ -938,7 +939,7 @@ class BitunixWebSocketService {
         // Critical if:
         // 1. Root level structure error (path is empty)
         // 2. Critical field error (path[0] is in criticalFields)
-        const isCritical = issues.some(i =>
+        const isCritical = validationIssues.some(i =>
           i.path.length === 0 ||
           (i.path.length > 0 && criticalFields.includes(String(i.path[0])))
         );


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
