### PR TITLE
fix(test): update flash close expectation to assert cancel call presence

### DIFF
--- a/change_test.py
+++ b/change_test.py
@@ -1,0 +1,40 @@
+import sys
+
+with open('src/tests/flash-close.test.ts', 'r') as f:
+    content = f.read()
+
+search_str = """        // This expectation confirms the vulnerability (missing cancel call)
+        // Since we want to reproduce the bug (i.e., demonstrate it's missing),
+        // we assert that it IS MISSING for now, then we will flip it to expect PRESENCE after fix.
+        // OR better: assert it IS PRESENT, and let the test fail.
+        // The prompt says "Create reproduction test...". A failing test is the reproduction.
+
+        expect(cancelCall).toBeDefined();
+
+        // Ensure Cancel happens BEFORE Close if both exist
+        if (cancelCall) {
+            const closeCall = calls.find((call: any) => call[2].side === 'SELL');
+            const cancelIndex = calls.indexOf(cancelCall);
+            const closeIndex = calls.indexOf(closeCall);
+            expect(cancelIndex).toBeLessThan(closeIndex);
+        }"""
+
+replace_str = """        // Expect the Cancel All call to be present (Hardening Fix)
+        expect(cancelCall).toBeDefined();
+
+        // Ensure Close call is also present
+        const closeCall = calls.find((call: any) => call[2] && call[2].side === 'SELL');
+        expect(closeCall).toBeDefined();
+
+        // Ensure Cancel happens BEFORE Close
+        const cancelIndex = calls.indexOf(cancelCall);
+        const closeIndex = calls.indexOf(closeCall);
+        expect(cancelIndex).toBeLessThan(closeIndex);"""
+
+if search_str in content:
+    new_content = content.replace(search_str, replace_str)
+    with open('src/tests/flash-close.test.ts', 'w') as f:
+        f.write(new_content)
+    print("Successfully updated test.")
+else:
+    print("Search string not found.")

--- a/src/tests/flash-close.test.ts
+++ b/src/tests/flash-close.test.ts
@@ -214,20 +214,16 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
             call[2].type === 'cancel-all'
         );
 
-        // This expectation confirms the vulnerability (missing cancel call)
-        // Since we want to reproduce the bug (i.e., demonstrate it's missing),
-        // we assert that it IS MISSING for now, then we will flip it to expect PRESENCE after fix.
-        // OR better: assert it IS PRESENT, and let the test fail.
-        // The prompt says "Create reproduction test...". A failing test is the reproduction.
-
+        // Expect the Cancel All call to be present (Hardening Fix)
         expect(cancelCall).toBeDefined();
 
-        // Ensure Cancel happens BEFORE Close if both exist
-        if (cancelCall) {
-            const closeCall = calls.find((call: any) => call[2].side === 'SELL');
-            const cancelIndex = calls.indexOf(cancelCall);
-            const closeIndex = calls.indexOf(closeCall);
-            expect(cancelIndex).toBeLessThan(closeIndex);
-        }
+        // Ensure Close call is also present
+        const closeCall = calls.find((call: any) => call[2] && call[2].side === 'SELL');
+        expect(closeCall).toBeDefined();
+
+        // Ensure Cancel happens BEFORE Close
+        const cancelIndex = calls.indexOf(cancelCall);
+        const closeIndex = calls.indexOf(closeCall);
+        expect(cancelIndex).toBeLessThan(closeIndex);
     });
 });


### PR DESCRIPTION
Updated `src/tests/flash-close.test.ts` to reflect the fixed implementation in `tradeService.ts`. The test now correctly asserts that `cancelAllOrders` is called before the position is closed, removing outdated comments about reproducing a bug.

Test Verification:
- `npm test src/tests/flash-close.test.ts` passed.
- `svelte-check` passed with 0 errors.

Adheres to AGENT.md Phase 4 & 5.

---
*PR created automatically by Jules for task [18414186536461427802](https://jules.google.com/task/18414186536461427802) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
