### PR TITLE
fix(i18n): add missing settings.errors keys

### DIFF
--- a/src/components/inputs/PortfolioInputs.svelte
+++ b/src/components/inputs/PortfolioInputs.svelte
@@ -29,6 +29,7 @@
   import { settingsState } from "../../stores/settings.svelte";
   import { uiState } from "../../stores/ui.svelte";
   import { safeJsonParse } from "../../utils/safeJson";
+  import { mapApiErrorToLabel } from "../../utils/errorUtils";
 
   interface Props {
     accountSize: string | null;
@@ -136,15 +137,6 @@
     }));
   }
 
-  function mapApiErrorToLabel(error: any): string | null {
-    const msg = error?.message || "";
-    // Map common raw API errors to localized keys
-    if (/api key|apikey/i.test(msg)) return "settings.errors.invalidApiKey"; // Hypothetical key, falls back to text in some systems or needs adding
-    if (/ip not allowed/i.test(msg)) return "settings.errors.ipNotAllowed";
-    if (/signature/i.test(msg)) return "settings.errors.invalidSignature";
-    if (/timestamp/i.test(msg)) return "settings.errors.timestampError";
-    return null;
-  }
 
   async function handleFetchBalance(silent = false) {
     const settings = settingsState;

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -830,6 +830,12 @@
     "marketDataIntervalHelp": "How often market prices are updated",
     "intervalLabel": "Check Frequency (in seconds)",
     "autoUpdatePrice": "Auto-update Price",
+    "errors": {
+      "invalidApiKey": "Invalid API Key",
+      "ipNotAllowed": "IP Not Allowed",
+      "invalidSignature": "Invalid Signature",
+      "timestampError": "Timestamp Error"
+    },
     "showSidebars": "Show Sidebars",
     "enableSidePanel": "Enable Side Panel (Chat/Notes)",
     "sidePanelMode": "Side Panel Mode",

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -45,6 +45,13 @@ import {
   validateSymbol,
 } from "../types/bitunixValidation";
 
+export interface TradeData {
+  p: string; // price
+  v: string; // volume
+  s: string; // side
+  t: number; // timestamp
+}
+
 const WS_PUBLIC_URL =
   CONSTANTS.BITUNIX_WS_PUBLIC_URL || "wss://fapi.bitunix.com/public/";
 const WS_PRIVATE_URL =
@@ -62,7 +69,7 @@ interface Subscription {
 
 class BitunixWebSocketService {
   // Trade Listeners
-  private tradeListeners = new Map<string, Set<(trade: any) => void>>();
+  private tradeListeners = new Map<string, Set<(trade: TradeData) => void>>();
   public static activeInstance: BitunixWebSocketService | null = null;
   private static instanceCount = 0;
   private instanceId = 0;
@@ -1260,7 +1267,7 @@ class BitunixWebSocketService {
     }
   }
 
-  subscribeTrade(symbol: string, callback: (trade: any) => void): () => void {
+  subscribeTrade(symbol: string, callback: (trade: TradeData) => void): () => void {
     if (!symbol) return () => {};
     const normalized = normalizeSymbol(symbol, "bitunix");
 
@@ -1278,7 +1285,7 @@ class BitunixWebSocketService {
     };
   }
 
-  unsubscribeTrade(symbol: string, callback: (trade: any) => void) {
+  unsubscribeTrade(symbol: string, callback: (trade: TradeData) => void) {
     if (!symbol) return;
     const normalized = normalizeSymbol(symbol, "bitunix");
 

--- a/src/services/marketWatcher.ts
+++ b/src/services/marketWatcher.ts
@@ -36,6 +36,9 @@ interface MarketWatchRequest {
 }
 
 class MarketWatcher {
+  // Optimization: Module-level constant to reduce allocation
+  private static readonly ZERO_VOL = new Decimal(0);
+
   private requests = new Map<string, Map<string, number>>(); // symbol -> { channel -> count }
   private isPolling = false;
   private pollingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -449,9 +452,6 @@ class MarketWatcher {
       if (klines.length < 2) return klines;
       const filled = [klines[0]];
 
-      // Optimization: Re-use constant for zero volume to reduce allocation
-      const ZERO_VOL = new Decimal(0);
-
       for (let i = 1; i < klines.length; i++) {
           const prev = filled[filled.length - 1];
           const curr = klines[i];
@@ -475,7 +475,7 @@ class MarketWatcher {
                       high: prev.close,
                       low: prev.close,
                       close: prev.close,
-                      volume: ZERO_VOL
+                      volume: MarketWatcher.ZERO_VOL
                   });
                   nextTime += intervalMs;
                   gapCount++;

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -94,3 +94,16 @@ export function getBitunixErrorKey(code: number | string): string {
   // Fallback if the code is not in our list
   return "apiErrors.generic";
 }
+
+export function mapApiErrorToLabel(error: any): string | null {
+  const msg = error?.message || "";
+  const code = error?.code; // Check specific error codes if available
+
+  // Map common raw API errors to localized keys
+  if (/api key|apikey/i.test(msg) || code === 10003) return "settings.errors.invalidApiKey";
+  if (/ip not allowed/i.test(msg) || code === 10004) return "settings.errors.ipNotAllowed";
+  if (/signature/i.test(msg) || code === 10007) return "settings.errors.invalidSignature";
+  if (/timestamp/i.test(msg)) return "settings.errors.timestampError";
+
+  return null;
+}

--- a/src/utils/safeJson_integers.test.ts
+++ b/src/utils/safeJson_integers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { safeJsonParse } from "./safeJson";
+
+describe("Safe JSON Parsing - Integers", () => {
+
+    it("should handle MAX_SAFE_INTEGER correctly", () => {
+        const input = `{"id": ${Number.MAX_SAFE_INTEGER}}`;
+        const result = safeJsonParse(input);
+        // Expect string because MAX_SAFE_INTEGER (16 digits) triggers the regex protection (15+ digits)
+        expect(result.id).toBe(String(Number.MAX_SAFE_INTEGER));
+    });
+
+    it("should convert integers larger than MAX_SAFE_INTEGER to string", () => {
+        const largeIntStr = "9007199254740993"; // MAX_SAFE + 2
+        const input = `{"id": ${largeIntStr}}`;
+
+        // This is the CRITICAL test.
+        // If native JSON.parse runs, id becomes 9007199254740992 (precision loss).
+        // If regex replacement works, it becomes "9007199254740993".
+
+        const result = safeJsonParse(input);
+        expect(result.id).toBe(largeIntStr);
+        expect(typeof result.id).toBe("string");
+    });
+
+    it("should handle large negative integers", () => {
+        const largeNegInt = "-9007199254740995";
+        const input = `{"loss": ${largeNegInt}}`;
+
+        const result = safeJsonParse(input);
+        expect(result.loss).toBe(largeNegInt);
+    });
+
+    it("should handle multiple large integers in one object", () => {
+        const id1 = "1234567890123456789";
+        const id2 = "9876543210987654321";
+        const input = `{"orderId": ${id1}, "clientId": ${id2}, "status": 1}`;
+
+        const result = safeJsonParse(input);
+        expect(result.orderId).toBe(id1);
+        expect(result.clientId).toBe(id2);
+        expect(result.status).toBe(1);
+    });
+
+    it("should not stringify standard floats or small integers", () => {
+        const input = `{"price": 123.45, "qty": 100}`;
+        const result = safeJsonParse(input);
+        expect(result.price).toBe(123.45);
+        expect(result.qty).toBe(100);
+        expect(typeof result.price).toBe("number");
+        expect(typeof result.qty).toBe("number");
+    });
+});


### PR DESCRIPTION
perf(market): reduce allocations in backfill loop
refactor(error): centralize error mapping logic
test(json): add safeJson integer limit test

- Added missing translation keys for API errors.
- Optimized `MarketWatcher` to reuse `Decimal(0)` constant.
- Hardened `BitunixWs` with strict `TradeData` types.
- Centralized `mapApiErrorToLabel` in `errorUtils.ts`.
- Verified SafeJSON parsing for large integers > MAX_SAFE_INTEGER.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
