### PR TITLE
🧹 Refactor Bitunix trade listeners and fix missing subscribe method

### DIFF
--- a/src/services/bitunixWs.test.ts
+++ b/src/services/bitunixWs.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
 import { bitunixWs } from '../../src/services/bitunixWs';
 import { marketState } from '../../src/stores/market.svelte';
 import { mdaService } from '../../src/services/mdaService';
@@ -69,10 +70,32 @@ describe('BitunixWS Fast Path Fallback', () => {
         wsService.handleMessage(msg, 'public');
 
         // Price channel now updates Index Price and Funding Rate, NOT Last Price (to avoid flickering)
-        expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', expect.objectContaining({
-            fundingRate: '0.01',
-            indexPrice: '50001'
-        }));
+        expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', {
+            fundingRate: new Decimal('0.01'),
+            indexPrice: new Decimal('50001'),
+            nextFundingTime: undefined
+        });
+    });
+
+    it('should execute trade listeners exactly once for each trade', () => {
+        const symbol = 'BTCUSDT';
+        const callback = vi.fn();
+        wsService.subscribeTrade(symbol, callback);
+
+        const msg = {
+            ch: 'trade',
+            symbol: symbol,
+            data: {
+                p: '50000',
+                v: '0.1',
+                t: 1600000000000,
+                s: 'buy'
+            }
+        };
+
+        wsService.handleMessage(msg, 'public');
+
+        expect(callback).toHaveBeenCalledTimes(1);
     });
 
     it('should use Fast Path for valid ticker message (Ticker Channel updates LastPrice)', () => {

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -72,7 +72,25 @@ interface Subscription {
 
 class BitunixWebSocketService {
   // Trade Listeners
+
   private tradeListeners = new Map<string, Set<(trade: TradeData) => void>>();
+
+  public subscribeTrade(symbol: string, callback: (trade: TradeData) => void): () => void {
+    const s = normalizeSymbol(symbol, "bitunix");
+    if (!this.tradeListeners.has(s)) {
+      this.tradeListeners.set(s, new Set());
+    }
+    this.tradeListeners.get(s)!.add(callback);
+    return () => {
+      const listeners = this.tradeListeners.get(s);
+      if (listeners) {
+        listeners.delete(callback);
+        if (listeners.size === 0) {
+          this.tradeListeners.delete(s);
+        }
+      }
+    };
+  }
   public static activeInstance: BitunixWebSocketService | null = null;
   private static instanceCount = 0;
   private instanceId = 0;
@@ -1262,9 +1280,17 @@ class BitunixWebSocketService {
              }
 
              if (listeners) {
-                 items.forEach(item => {
-                     listeners.forEach(cb => { try { cb(item); } catch (e) { if (import.meta.env.DEV) console.warn("[BitunixWS] Trade listener error:", e); } });
-                 });
+                 for (const item of items) {
+                     for (const cb of listeners) {
+                         try {
+                             cb(item);
+                         } catch (e) {
+                             if (import.meta.env.DEV) {
+                                 console.warn("[BitunixWS] Trade listener error:", e);
+                             }
+                         }
+                     }
+                 }
              }
         } else {
              // FALLBACK: Log invalid trade data structure


### PR DESCRIPTION
Fixed trade listeners logic and test failures in `bitunixWs.ts`.

- **Verified:** Confirmed that the "double execution of trade listeners" issue is not present by adding a specific test case in `src/services/bitunixWs.test.ts`.
- **Fixed:** Implemented the missing `subscribeTrade` method in `BitunixWebSocketService`, which was causing `TradeFlowBackground` to fail (implicitly) and made the listener loop unreachable dead code.
- **Refactored:** Replaced nested `forEach` loops with `for-of` loops in `src/services/bitunixWs.ts` for better readability and code health.
- **Fixed Test:** Updated `should use Fast Path for valid price message` test expectation to correctly handle `Decimal` types and optional fields.

All tests passed.


---
*PR created automatically by Jules for task [17073826702128964121](https://jules.google.com/task/17073826702128964121) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
