### PR TITLE
🧹 [bitunixWs] Cleanup dead code in trade listener loop

### DIFF
--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -1274,10 +1274,6 @@ class BitunixWebSocketService {
              // Dispatch to listeners
              const listeners = this.tradeListeners.get(symbol);
              
-             // DEBUG LOG
-             if (import.meta.env.DEV) {
-                 // console.log(`[BitunixWS] Received ${items.length} trades for ${symbol}. Listeners: ${listeners ? listeners.size : 0}`);
-             }
 
              if (listeners) {
                  for (const item of items) {


### PR DESCRIPTION
🧹 [bitunixWs] Cleanup dead code in trade listener loop

🎯 **What:** Removed commented-out debug code in `src/services/bitunixWs.ts` around line 1277 that was inside the trade listener execution block.
💡 **Why:** The original issue (double execution of trade listeners) was confirmed to be already resolved in the current codebase (likely due to a prior refactor). The remaining commented-out code was dead and confusing, so it was removed to improve code health.
✅ **Verification:**
- Verified via `grep` and manual inspection that the duplicated iteration block is not present.
- Ran `npx vitest run src/services/bitunixWs.test.ts` which confirmed that trade listeners are executed exactly once per trade (test `should execute trade listeners exactly once for each trade` passed).
- Ran `npm run check` to ensure no type errors.
✨ **Result:** Cleaned up `src/services/bitunixWs.ts` and confirmed the absence of the "Double Execution" bug.

---
*PR created automatically by Jules for task [12240154660216979221](https://jules.google.com/task/12240154660216979221) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
