### PR TITLE
Fix Background Effects (Galaxy & TradeFlow)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cachy-app",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/components/shared/backgrounds/engines/GalaxyEngine.ts
+++ b/src/components/shared/backgrounds/engines/GalaxyEngine.ts
@@ -50,6 +50,7 @@ export class GalaxyEngine extends BaseEngine {
         const randoms = new Float32Array(particleCount * 3);
         const scales = new Float32Array(particleCount);
         const colorMixs = new Float32Array(particleCount);
+        const indices = new Float32Array(particleCount);
 
         for (let i = 0; i < particleCount; i++) {
             const i3 = i * 3;
@@ -59,6 +60,7 @@ export class GalaxyEngine extends BaseEngine {
             scales[i] = Math.random();
             positions[i3] = positions[i3 + 1] = positions[i3 + 2] = 0;
             colorMixs[i] = Math.random();
+            indices[i] = i;
         }
 
         this.galaxyGeometry = new THREE.BufferGeometry();
@@ -66,6 +68,7 @@ export class GalaxyEngine extends BaseEngine {
         this.galaxyGeometry.setAttribute("aRandom", new THREE.BufferAttribute(randoms, 3));
         this.galaxyGeometry.setAttribute("aScale", new THREE.BufferAttribute(scales, 1));
         this.galaxyGeometry.setAttribute("aColorMix", new THREE.BufferAttribute(colorMixs, 1));
+        this.galaxyGeometry.setAttribute("aIndex", new THREE.BufferAttribute(indices, 1));
 
         this.galaxyMaterial = new THREE.ShaderMaterial({
             depthWrite: false,
@@ -107,6 +110,7 @@ export class GalaxyEngine extends BaseEngine {
                 attribute vec3 aRandom;
                 attribute float aScale;
                 attribute float aColorMix;
+                attribute float aIndex;
 
                 varying float vRadiusRatio;
                 varying vec3 vOutsideColor;
@@ -114,7 +118,7 @@ export class GalaxyEngine extends BaseEngine {
                 #define PI 3.14159265359
 
                 void main() {
-                    float particleId = float(gl_VertexID);
+                    float particleId = aIndex;
                     float radiusRatio = fract(particleId / uParticleCount);
                     float radius = pow(radiusRatio, uConcentrationPower) * uRadius;
 

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -79,6 +79,7 @@ class BitunixWebSocketService {
     const s = normalizeSymbol(symbol, "bitunix");
     if (!this.tradeListeners.has(s)) {
       this.tradeListeners.set(s, new Set());
+      this.subscribe(s, "trade");
     }
     this.tradeListeners.get(s)!.add(callback);
     return () => {
@@ -87,6 +88,7 @@ class BitunixWebSocketService {
         listeners.delete(callback);
         if (listeners.size === 0) {
           this.tradeListeners.delete(s);
+          this.unsubscribe(s, "trade");
         }
       }
     };


### PR DESCRIPTION
- **Galaxy3D:** `src/components/shared/backgrounds/engines/GalaxyEngine.ts` was updated to use an explicit `aIndex` attribute instead of `gl_VertexID` which is not supported in WebGL 1. This fixes the shader compilation error.
- **TradeFlow:** `src/services/bitunixWs.ts` was corrected so that `subscribeTrade` actually triggers a WebSocket subscription (`this.subscribe`) and cleans it up (`this.unsubscribe`) when listeners are removed. This ensures trade data flows to the visualizer.
- **Camera Setting:** Changes to `cameraRotationX` were **not** applied as requested.

The changes were verified locally with unit tests for the WebSocket logic and syntax checks for the shader code.

---
*PR created automatically by Jules for task [15973059433900737588](https://jules.google.com/task/15973059433900737588) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
