### PR TITLE
Fix deployment: Commit WASM artifact and align paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,3 @@ reports/
 target/
 technicals-wasm/target/
 __pycache__/
-static/wasm/technicals_wasm.wasm
-static/wasm/technicals_wasm.wasm

--- a/src/utils/wasmTechnicals.ts
+++ b/src/utils/wasmTechnicals.ts
@@ -22,7 +22,8 @@ export async function loadWasm() {
             // RELIABLE PATHS: Files are now in /static/wasm/
             // SvelteKit serves /static content at the root path /
             const wasmJsPath = '/wasm/technicals_wasm.js';
-            const wasmBinaryPath = '/wasm/technicals_wasm_bg.wasm';
+            // Align with scripts/build_wasm.sh output
+            const wasmBinaryPath = '/wasm/technicals_wasm.wasm';
 
             console.log(`[WASM] Loading engine from ${wasmJsPath}...`);
             


### PR DESCRIPTION
- Removed `static/wasm/technicals_wasm.wasm` from `.gitignore` to ensure the binary is available on Render (which skips WASM builds).
- Updated `src/utils/wasmTechnicals.ts` to look for `technicals_wasm.wasm` instead of `_bg.wasm`, matching the build script's output.
- This resolves the build/runtime failure caused by missing WASM assets in production.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
