### PR TITLE
Refactor logger.error to support toast options

### DIFF
--- a/src/services/logger.test.ts
+++ b/src/services/logger.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from './logger';
+import { toastService } from './toastService.svelte';
+import * as appEnvironment from '$app/environment';
+
+// Mock dependencies
+vi.mock('./toastService.svelte', () => ({
+    toastService: {
+        error: vi.fn(),
+        add: vi.fn()
+    }
+}));
+
+// Mock settingsState
+vi.mock('../stores/settings.svelte', () => ({
+    settingsState: {
+        debugMode: false,
+        logSettings: {
+            ui: true,
+            network: false,
+            general: true
+        }
+    }
+}));
+
+// Mock browser check
+vi.mock('$app/environment', () => ({
+    browser: true
+}));
+
+describe('LoggerService', () => {
+    let consoleErrorSpy: any;
+    let consoleLogSpy: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        // Reset browser mock default
+        // @ts-ignore
+        appEnvironment.browser = true;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should log error to console when category enabled', () => {
+        logger.error('general', 'Test error');
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('[GENERAL] Test error'), '');
+    });
+
+    it('should support legacy boolean force parameter', () => {
+        // network is disabled in mock settings, forcing it should log
+        logger.error('network', 'Should log forced', undefined, true);
+        expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('should NOT log when category disabled and not forced', () => {
+        logger.error('network', 'Should not log', undefined, false);
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should toast when explicitly requested via options object', () => {
+        logger.error('general', 'Toast me', undefined, { toast: true });
+
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(toastService.error).toHaveBeenCalledWith('Toast me');
+    });
+
+    it('should auto-toast for UI category when forced (critical UI errors)', () => {
+        // Legacy behavior: force=true on UI category -> toast
+        logger.error('ui', 'UI Critical', undefined, true);
+        expect(toastService.error).toHaveBeenCalledWith('UI Critical');
+    });
+
+    it('should NOT auto-toast for UI category when NOT forced', () => {
+        logger.error('ui', 'UI Info', undefined, false);
+        expect(toastService.error).not.toHaveBeenCalled();
+    });
+
+    it('should handle options object with force: true', () => {
+        // network is disabled, but forced via options
+        logger.error('network', 'Forced via options', undefined, { force: true });
+        expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('should handle silent option to suppress console output', () => {
+        logger.error('general', 'Silent error', undefined, { silent: true });
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+        // Let's verify silent + toast
+        logger.error('general', 'Silent toast', undefined, { silent: true, toast: true });
+        expect(consoleErrorSpy).not.toHaveBeenCalled(); // Still silent console
+        expect(toastService.error).toHaveBeenCalledWith('Silent toast'); // But toast shown
+    });
+});


### PR DESCRIPTION
I have completed the task to implement specific instrumentation for error toasting in `src/services/logger.ts`.

**Changes:**
-   **Refactored `logger.error`**: Now accepts an optional `options` object (`LogOptions`) as the last argument, supporting:
    -   `force`: Boolean to bypass log settings (backward compatible).
    -   `toast`: Boolean to explicitly trigger a UI toast.
    -   `silent`: Boolean to suppress console output while still allowing toasts.
-   **Auto-Toasting**: Errors in the `ui` category with `force: true` (or legacy `true` argument) will automatically trigger a toast, addressing critical UI feedback needs.
-   **Cleanup**: Removed the temporary `errorWithToast` method.
-   **Testing**: Added `src/services/logger.test.ts` with comprehensive test cases for the new options and legacy behavior.

The solution maintains backward compatibility for all existing `logger.error` calls while providing the requested granular control.

---
*PR created automatically by Jules for task [5002433866792250173](https://jules.google.com/task/5002433866792250173) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
