### PR TITLE
🔒 [security fix] Handle Malformed JSON in Sync APIs

### DIFF
--- a/src/routes/api/sync/order-detail/+server.ts
+++ b/src/routes/api/sync/order-detail/+server.ts
@@ -18,13 +18,31 @@
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { createHash, randomBytes } from "crypto";
+import { z } from "zod";
+
+const RequestSchema = z.object({
+  apiKey: z.string().min(1),
+  apiSecret: z.string().min(1),
+  orderId: z.string().min(1),
+});
 
 export const POST: RequestHandler = async ({ request }) => {
-  const { apiKey, apiSecret, orderId } = await request.json();
-
-  if (!apiKey || !apiSecret || !orderId) {
-    return json({ error: "Missing credentials or orderId" }, { status: 400 });
+  let body;
+  try {
+    body = await request.json();
+  } catch (e) {
+    return json({ error: "Invalid JSON" }, { status: 400 });
   }
+
+  const result = RequestSchema.safeParse(body);
+  if (!result.success) {
+    return json(
+      { error: "Invalid request data", details: result.error.format() },
+      { status: 400 },
+    );
+  }
+
+  const { apiKey, apiSecret, orderId } = result.data;
 
   try {
     const order = await fetchBitunixOrderDetail(apiKey, apiSecret, orderId);

--- a/src/routes/api/sync/orders/+server.ts
+++ b/src/routes/api/sync/orders/+server.ts
@@ -19,13 +19,31 @@ import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { generateBitunixSignature } from "../../../../utils/server/bitunix";
 import type { BitunixOrder } from "../../../../types/bitunix";
+import { z } from "zod";
+
+const RequestSchema = z.object({
+  apiKey: z.string().min(1),
+  apiSecret: z.string().min(1),
+  limit: z.number().optional(),
+});
 
 export const POST: RequestHandler = async ({ request }) => {
-  const { apiKey, apiSecret, limit } = await request.json();
-
-  if (!apiKey || !apiSecret) {
-    return json({ error: "Missing credentials" }, { status: 400 });
+  let body;
+  try {
+    body = await request.json();
+  } catch (e) {
+    return json({ error: "Invalid JSON" }, { status: 400 });
   }
+
+  const result = RequestSchema.safeParse(body);
+  if (!result.success) {
+    return json(
+      { error: "Invalid request data", details: result.error.format() },
+      { status: 400 },
+    );
+  }
+
+  const { apiKey, apiSecret, limit } = result.data;
 
   try {
     let allOrders: BitunixOrder[] = [];

--- a/src/routes/api/sync/orders/security.test.ts
+++ b/src/routes/api/sync/orders/security.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './+server';
+
+describe('POST /api/sync/orders', () => {
+  it('should return 400 if JSON is malformed', async () => {
+    const request = {
+      json: async () => {
+        throw new Error('Unexpected end of JSON input');
+      },
+    } as Request;
+
+    const response = await POST({ request } as any);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Invalid JSON');
+  });
+
+  it('should return 400 if credentials are missing', async () => {
+    const request = {
+      json: async () => ({ limit: 10 }),
+    } as Request;
+
+    const response = await POST({ request } as any);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Invalid request data');
+  });
+
+  it('should return 400 if limit is not a number', async () => {
+    const request = {
+      json: async () => ({ apiKey: 'key', apiSecret: 'secret', limit: 'invalid' }),
+    } as Request;
+
+    const response = await POST({ request } as any);
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
This PR fixes a security vulnerability where malformed JSON in the Sync Orders API was unhandled, potentially causing server crashes or information leakage via 500 errors.

Changes:
- Implemented `try-catch` around `request.json()` in multiple API endpoints.
- Added Zod schemas for robust validation of `apiKey`, `apiSecret`, and other request parameters.
- Improved error responses to return `400 Bad Request` with helpful but safe error messages.
- Added a new security test case for the orders API.

Endpoints updated:
- `src/routes/api/sync/orders/+server.ts`
- `src/routes/api/sync/order-detail/+server.ts`
- `src/routes/api/sync/positions-history/+server.ts`
- `src/routes/api/sync/positions-pending/+server.ts`

---
*PR created automatically by Jules for task [15188581802085150810](https://jules.google.com/task/15188581802085150810) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
