### PR TITLE
🧹 remove console logging in FloatingWindows Store

### DIFF
--- a/src/stores/floatingWindows.svelte.ts
+++ b/src/stores/floatingWindows.svelte.ts
@@ -60,13 +60,11 @@ class FloatingWindowsStore {
         };
 
         this.windows.push(newWindow);
-        console.log('FloatingWindow opened:', { id: newWindow.id, url, title });
     }
 
     closeWindow(id: string): void {
         const index = this.windows.findIndex((w) => w.id === id);
         if (index !== -1) {
-            console.log('FloatingWindow closed:', { id });
             this.windows.splice(index, 1);
         }
     }
@@ -75,7 +73,6 @@ class FloatingWindowsStore {
         const window = this.windows.find((w) => w.id === id);
         if (window) {
             window.zIndex = this.nextZIndex++;
-            console.log('FloatingWindow focused:', { id, zIndex: window.zIndex });
         }
     }
 


### PR DESCRIPTION
Removed debug console.log statements from `src/stores/floatingWindows.svelte.ts` to clean up the production code and improve maintainability. These logs were identified as unnecessary debug output. All three instances in `openWindow`, `closeWindow`, and `focusWindow` were removed. Verification was done through manual code review as no specific tests for this store were available and the environment lacked dependencies for general testing.

---
*PR created automatically by Jules for task [885964845407222836](https://jules.google.com/task/885964845407222836) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
