### PR TITLE
Fix(security): Sanitize API keys in TP/SL error logs (MYD-54)

### DIFF
--- a/src/routes/api/tpsl/+server.ts
+++ b/src/routes/api/tpsl/+server.ts
@@ -22,7 +22,7 @@ import {
   validateBitunixKeys,
 } from "../../../utils/server/bitunix";
 import { checkAppAuth } from "../../../lib/server/auth";
-import { TpSlRequestSchema } from "../../../types/apiSchemas";
+import { TpSlRequestSchema, sanitizeErrorMessage } from "../../../types/apiSchemas";
 
 const BASE_URL = "https://fapi.bitunix.com";
 
@@ -98,7 +98,11 @@ export const POST: RequestHandler = async ({ request }) => {
 
     return json(result);
   } catch (e: any) {
-    console.error(`Error processing TP/SL request:`, e.message || e);
+        let rawMsg = e instanceof Error ? e.message : String(e);
+    if (typeof e === "object" && e !== null && !e.message) {
+      try { rawMsg = JSON.stringify(e); } catch {}
+    }
+    console.error(`Error processing TP/SL request:`, sanitizeErrorMessage(rawMsg, 1000));
 
     // Determine appropriate status code
     let status = 500;

--- a/src/types/apiSchemas.test.ts
+++ b/src/types/apiSchemas.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeErrorMessage } from './apiSchemas';
+
+describe('sanitizeErrorMessage', () => {
+  it('should redact simple key=value pairs', () => {
+    const message = 'Error: apiKey=1234567890abcdef failed';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('Error: apiKey=*** failed');
+  });
+
+  it('should redact key: value pairs', () => {
+    const message = 'Error: apiSecret: secret_key_value failed';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('Error: apiSecret: *** failed');
+  });
+
+  it('should redact JSON formatted strings', () => {
+    const message = '{"error":"Something wrong","apiKey":"1234567890abcdef"}';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('{"error":"Something wrong","apiKey":"***"}');
+  });
+
+  it('should redact JSON with spaces', () => {
+    const message = '{ "apiKey" : "12345" }';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('{ "apiKey" : "***" }');
+  });
+
+  it('should redact query parameters', () => {
+    const message = 'QueryParams: ?apiKey=12345&secret=abcde';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toContain('apiKey=***');
+    expect(sanitized).toContain('secret=***');
+    expect(sanitized).not.toContain('12345');
+    expect(sanitized).not.toContain('abcde');
+  });
+
+  it('should handle mixed quotes', () => {
+    const message = "Mixed quotes: 'apiKey': \"12345\"";
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe("Mixed quotes: 'apiKey': \"***\"");
+  });
+
+  it('should handle unquoted keys/values (if applicable)', () => {
+    const message = 'No quotes: apiKey: 12345';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('No quotes: apiKey: ***');
+  });
+
+  it('should handle other sensitive keys', () => {
+    const keys = ['token', 'password', 'passphrase', 'api_key'];
+    keys.forEach(key => {
+      const msg = `${key}=secret123`;
+      const sanitized = sanitizeErrorMessage(msg, 100);
+      expect(sanitized).toBe(`${key}=***`);
+    });
+  });
+
+  it('should limit length correctly', () => {
+    const longMessage = 'A'.repeat(200);
+    const sanitized = sanitizeErrorMessage(longMessage, 50);
+    expect(sanitized.length).toBeLessThanOrEqual(53); // 50 + "..."
+    expect(sanitized.endsWith('...')).toBe(true);
+  });
+
+  it('should not limit length if maxLength is 0', () => {
+    const longMessage = 'A'.repeat(200);
+    const sanitized = sanitizeErrorMessage(longMessage, 0);
+    expect(sanitized.length).toBe(200);
+    expect(sanitized.endsWith('...')).toBe(false);
+  });
+
+  it('should preserve non-sensitive parts', () => {
+    const msg = 'User id=123, apiKey=secret';
+    const sanitized = sanitizeErrorMessage(msg, 100);
+    expect(sanitized).toContain('User id=123');
+    expect(sanitized).toContain('apiKey=***');
+  });
+});


### PR DESCRIPTION
Enhanced `sanitizeErrorMessage` in `src/types/apiSchemas.ts` to support JSON, key-value pairs, and mixed quotes, preserving whitespace/formatting while masking values.
Updated `src/routes/api/tpsl/+server.ts` to sanitize error messages before logging them.
Added `src/types/apiSchemas.test.ts` with comprehensive unit tests for sanitization logic.

---
*PR created automatically by Jules for task [7039325575601844088](https://jules.google.com/task/7039325575601844088) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
