### PR TITLE
refactor(openai): use unknown type in catch block

### DIFF
--- a/src/routes/api/ai/openai/+server.ts
+++ b/src/routes/api/ai/openai/+server.ts
@@ -17,6 +17,7 @@
 
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
+import { getErrorMessage } from "../../../../utils/errorUtils";
 
 export const POST: RequestHandler = async ({ request }) => {
   try {
@@ -57,8 +58,8 @@ export const POST: RequestHandler = async ({ request }) => {
         Connection: "keep-alive",
       },
     });
-  } catch (e: any) {
+  } catch (e: unknown) {
     console.error("OpenAI Proxy Error:", e);
-    return json({ error: e.message }, { status: 500 });
+    return json({ error: getErrorMessage(e) }, { status: 500 });
   }
 };

--- a/src/utils/errorUtils.test.ts
+++ b/src/utils/errorUtils.test.ts
@@ -16,22 +16,47 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { getBitunixErrorKey } from "./errorUtils";
+import { getBitunixErrorKey, getErrorMessage } from "./errorUtils";
 
 describe("errorUtils", () => {
-  it("should return the correct key for a known error code", () => {
-    expect(getBitunixErrorKey(10001)).toBe("bitunixErrors.10001");
-    expect(getBitunixErrorKey("10003")).toBe("bitunixErrors.10003");
-    expect(getBitunixErrorKey(30042)).toBe("bitunixErrors.30042");
+  describe("getBitunixErrorKey", () => {
+    it("should return the correct key for a known error code", () => {
+      expect(getBitunixErrorKey(10001)).toBe("bitunixErrors.10001");
+      expect(getBitunixErrorKey("10003")).toBe("bitunixErrors.10003");
+      expect(getBitunixErrorKey(30042)).toBe("bitunixErrors.30042");
+    });
+
+    it("should return generic error key for unknown error code", () => {
+      expect(getBitunixErrorKey(99999)).toBe("apiErrors.generic");
+      expect(getBitunixErrorKey("invalid_code")).toBe("apiErrors.generic");
+    });
+
+    it("should handle number and string inputs correctly", () => {
+      expect(getBitunixErrorKey(20001)).toBe("bitunixErrors.20001");
+      expect(getBitunixErrorKey("20001")).toBe("bitunixErrors.20001");
+    });
   });
 
-  it("should return generic error key for unknown error code", () => {
-    expect(getBitunixErrorKey(99999)).toBe("apiErrors.generic");
-    expect(getBitunixErrorKey("invalid_code")).toBe("apiErrors.generic");
-  });
+  describe("getErrorMessage", () => {
+    it("should extract message from Error object", () => {
+      const error = new Error("Test error");
+      expect(getErrorMessage(error)).toBe("Test error");
+    });
 
-  it("should handle number and string inputs correctly", () => {
-    expect(getBitunixErrorKey(20001)).toBe("bitunixErrors.20001");
-    expect(getBitunixErrorKey("20001")).toBe("bitunixErrors.20001");
+    it("should return string if error is a string", () => {
+      expect(getErrorMessage("String error")).toBe("String error");
+    });
+
+    it("should extract message from object with message property", () => {
+      const error = { message: "Object error" };
+      expect(getErrorMessage(error)).toBe("Object error");
+    });
+
+    it("should return string representation for other types", () => {
+      expect(getErrorMessage(123)).toBe("123");
+      expect(getErrorMessage(null)).toBe("null");
+      expect(getErrorMessage(undefined)).toBe("undefined");
+      expect(getErrorMessage({ foo: "bar" })).toBe("[object Object]");
+    });
   });
 });

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -107,3 +107,20 @@ export function mapApiErrorToLabel(error: any): string | null {
 
   return null;
 }
+
+/**
+ * Safely extracts an error message from an unknown error object.
+ * This is useful in try-catch blocks where the error type is unknown.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as any).message);
+  }
+  return String(error);
+}


### PR DESCRIPTION
Replaces 'any' with 'unknown' in OpenAI API catch block and implements safe error message extraction using a new utility function 'getErrorMessage'.

---
*PR created automatically by Jules for task [17274631147602234478](https://jules.google.com/task/17274631147602234478) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
