### PR TITLE
chore: remove verbose WASM initialization logs from wasmTechnicals.ts

### DIFF
--- a/src/utils/wasmTechnicals.ts
+++ b/src/utils/wasmTechnicals.ts
@@ -25,7 +25,6 @@ export async function loadWasm() {
             // Align with scripts/build_wasm.sh output
             const wasmBinaryPath = '/wasm/technicals_wasm.wasm';
 
-            console.log(`[WASM] Loading engine from ${wasmJsPath}...`);
             
             // Use standard dynamic import for the glue code
             const mod = await import(/* @vite-ignore */ wasmJsPath);
@@ -34,7 +33,6 @@ export async function loadWasm() {
             await mod.default(wasmBinaryPath);
             
             wasmModule = mod;
-            console.log(`[WASM] ACE Engine initialized successfully.`);
             return wasmModule;
         } catch (e: any) {
             console.error(`[WASM] ACE Engine Load Failed:`, e.message);


### PR DESCRIPTION
- Removed `console.log` for "Loading engine..."
- Removed `console.log` for "ACE Engine initialized successfully"
- Kept `console.error` for critical failures to ensure debuggability
- Verified with `npm run check` and `npm test`

---
*PR created automatically by Jules for task [8288980822810498286](https://jules.google.com/task/8288980822810498286) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
