### PR TITLE
Refactor Gemini API payload types

### DIFF
--- a/src/routes/api/ai/gemini/+server.ts
+++ b/src/routes/api/ai/gemini/+server.ts
@@ -18,6 +18,24 @@
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
+interface GeminiPart {
+  text: string;
+}
+
+interface GeminiContent {
+  role: "user" | "model";
+  parts: GeminiPart[];
+}
+
+interface GeminiSystemInstruction {
+  parts: GeminiPart[];
+}
+
+interface GeminiPayload {
+  contents: GeminiContent[];
+  systemInstruction?: GeminiSystemInstruction;
+}
+
 export const POST: RequestHandler = async ({ request }) => {
   try {
     const { messages, model } = await request.json();
@@ -27,8 +45,8 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ error: "Missing API Key" }, { status: 401 });
     }
 
-    let systemInstruction = undefined;
-    const contents = [];
+    let systemInstruction: GeminiSystemInstruction | undefined = undefined;
+    const contents: GeminiContent[] = [];
 
     for (const msg of messages) {
       if (msg.role === "system") {
@@ -64,7 +82,7 @@ export const POST: RequestHandler = async ({ request }) => {
       systemInstruction = undefined;
     }
 
-    const payload: any = { contents };
+    const payload: GeminiPayload = { contents };
     if (systemInstruction) {
       payload.systemInstruction = systemInstruction;
     }


### PR DESCRIPTION
Replaced 'any' with specific types in Gemini API payload construction. Added interfaces `GeminiPart`, `GeminiContent`, `GeminiSystemInstruction`, and `GeminiPayload` in `src/routes/api/ai/gemini/+server.ts`. Verified with `npm run check`.

---
*PR created automatically by Jules for task [4233396715190385344](https://jules.google.com/task/4233396715190385344) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
