### PR TITLE
Refactor LogEntry type usage in stream-logs API

### DIFF
--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -18,9 +18,9 @@
 import { EventEmitter } from "events";
 
 // Definiere die Log-Level
-type LogLevel = "info" | "warn" | "error" | "debug";
+export type LogLevel = "info" | "warn" | "error" | "debug";
 
-interface LogEntry {
+export interface LogEntry {
   timestamp: string;
   level: LogLevel;
   message: string;

--- a/src/routes/api/stream-logs/+server.ts
+++ b/src/routes/api/stream-logs/+server.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { logger } from "$lib/server/logger";
+import { logger, type LogEntry } from "$lib/server/logger";
 import { env } from "$env/dynamic/private";
 import type { RequestHandler } from "./$types";
 
@@ -46,7 +46,7 @@ export const GET: RequestHandler = ({ request, url }) => {
   const stream = new ReadableStream({
     start(controller) {
       // Callback function to handle new logs
-      const onLog = (logEntry: any) => {
+      const onLog = (logEntry: LogEntry) => {
         try {
           const data = `data: ${JSON.stringify(logEntry)}\n\n`;
           controller.enqueue(data);


### PR DESCRIPTION
- Export `LogEntry` and `LogLevel` from `src/lib/server/logger.ts`.
- Replace `any` type with `LogEntry` in `src/routes/api/stream-logs/+server.ts`.
- Verified with `svelte-check` and unit tests.

---
*PR created automatically by Jules for task [10014160610322312307](https://jules.google.com/task/10014160610322312307) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
