### PR TITLE
Refactor sentiment API error handling

### DIFF
--- a/src/routes/api/sentiment/+server.ts
+++ b/src/routes/api/sentiment/+server.ts
@@ -54,7 +54,16 @@ export const POST: RequestHandler = async ({ request }) => {
         if (!resultText) return json({ error: 'NO_RESULT' }, { status: 500 });
         const analysis = JSON.parse(resultText.replace(/```json/g, '').replace(/```/g, '').trim());
         return json({ analysis });
-    } catch (e: any) {
-        return json({ error: e.message || 'INTERNAL_ERROR' }, { status: 500 });
+    } catch (e: unknown) {
+        console.error('Sentiment API Error:', e);
+        let message = 'INTERNAL_ERROR';
+        if (e instanceof Error) {
+            message = e.message;
+        } else if (typeof e === 'string') {
+            message = e;
+        } else if (typeof e === 'object' && e !== null && 'message' in e) {
+            message = String((e as any).message);
+        }
+        return json({ error: message }, { status: 500 });
     }
 };

--- a/src/routes/api/sentiment/sentiment.test.ts
+++ b/src/routes/api/sentiment/sentiment.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from './+server';
+
+describe('POST /api/sentiment error handling', () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should return 500 and error message when a standard Error is thrown', async () => {
+        const error = new Error('Test Error');
+        const request = {
+            json: vi.fn().mockRejectedValue(error),
+        } as unknown as Request;
+
+        const response = await POST({ request } as any);
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toEqual({ error: 'Test Error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Sentiment API Error:', error);
+    });
+
+    it('should return 500 and message when a string error is thrown', async () => {
+        const errorString = 'Just a string error';
+        const request = {
+            json: vi.fn().mockRejectedValue(errorString),
+        } as unknown as Request;
+
+        const response = await POST({ request } as any);
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toEqual({ error: 'Just a string error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Sentiment API Error:', errorString);
+    });
+
+    it('should return 500 and fallback message for unknown object without message', async () => {
+        const weirdObj = { foo: 'bar' };
+        const request = {
+            json: vi.fn().mockRejectedValue(weirdObj),
+        } as unknown as Request;
+
+        const response = await POST({ request } as any);
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toEqual({ error: 'INTERNAL_ERROR' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Sentiment API Error:', weirdObj);
+    });
+
+    it('should return 500 and message from object with message property', async () => {
+        const objError = { message: 'Custom Object Error' };
+        const request = {
+            json: vi.fn().mockRejectedValue(objError),
+        } as unknown as Request;
+
+        const response = await POST({ request } as any);
+        expect(response.status).toBe(500);
+        const body = await response.json();
+        expect(body).toEqual({ error: 'Custom Object Error' });
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Sentiment API Error:', objError);
+    });
+});


### PR DESCRIPTION
Replaced `any` with `unknown` in `src/routes/api/sentiment/+server.ts` to improve type safety.
Implemented robust type narrowing for error messages.
Added `console.error` to log errors for better server-side observability.
Added unit tests in `src/routes/api/sentiment/sentiment.test.ts` to verify error handling logic.

---
*PR created automatically by Jules for task [4496513856076384454](https://jules.google.com/task/4496513856076384454) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
