### PR TITLE
test: improve coverage for toNumFast and fix serialized decimal bug

### DIFF
--- a/src/utils/fastConversion.ts
+++ b/src/utils/fastConversion.ts
@@ -49,7 +49,9 @@ export const toNumFast = (val: any): number => {
         // Fallback for serialized Decimal (state only, no methods)
         // e.g. from JSON.parse()
         if ((val as any).s !== undefined && (val as any).e !== undefined) {
-             return new Decimal(val).toNumber();
+             const d = new Decimal(0);
+             Object.assign(d, val);
+             return d.toNumber();
         }
     }
 

--- a/tests/unit/fastConversion.test.ts
+++ b/tests/unit/fastConversion.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * Fast Conversion Unit Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toNumFast } from '../../src/utils/fastConversion';
+import { Decimal } from 'decimal.js';
+
+describe('toNumFast', () => {
+    describe('Numbers', () => {
+        it('should return number as is', () => {
+            expect(toNumFast(123)).toBe(123);
+            expect(toNumFast(0)).toBe(0);
+            expect(toNumFast(-5)).toBe(-5);
+            expect(toNumFast(1.5)).toBe(1.5);
+            expect(toNumFast(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+            expect(toNumFast(Number.MIN_SAFE_INTEGER)).toBe(Number.MIN_SAFE_INTEGER);
+        });
+    });
+
+    describe('Strings', () => {
+        it('should parse valid numeric strings', () => {
+            expect(toNumFast('123')).toBe(123);
+            expect(toNumFast('123.45')).toBe(123.45);
+            expect(toNumFast('-5')).toBe(-5);
+            expect(toNumFast('0')).toBe(0);
+        });
+
+        it('should handle invalid strings', () => {
+            expect(toNumFast('abc')).toBe(0); // parseFloat('abc') is NaN -> returns 0
+            expect(toNumFast('')).toBe(0); // parseFloat('') is NaN -> returns 0
+            expect(toNumFast('  ')).toBe(0);
+            expect(toNumFast('12abc')).toBe(12); // parseFloat behavior
+        });
+    });
+
+    describe('Decimal Instances', () => {
+        it('should handle Decimal instances', () => {
+            expect(toNumFast(new Decimal(123))).toBe(123);
+            expect(toNumFast(new Decimal('123.45'))).toBe(123.45);
+            expect(toNumFast(new Decimal(0))).toBe(0);
+            expect(toNumFast(new Decimal(-5))).toBe(-5);
+        });
+    });
+
+    describe('Decimal-like Objects', () => {
+        it('should use .toNumber() if available', () => {
+            const mockDecimal = { toNumber: () => 42 };
+            // @ts-ignore
+            expect(toNumFast(mockDecimal)).toBe(42);
+        });
+    });
+
+    describe('Serialized Decimal Objects', () => {
+        it('should handle serialized Decimal objects', () => {
+            // Testing the path: if ((val as any).s !== undefined && (val as any).e !== undefined) { return new Decimal(val).toNumber(); }
+            // This happens when val is NOT instanceof Decimal and does NOT have toNumber method.
+
+            // Create a plain object that looks like a Decimal but isn't an instance.
+            // Using a real Decimal to copy properties so it's a valid structure for Decimal constructor if supported.
+            const realDecimal = new Decimal(123);
+            const plainObject = {
+                s: realDecimal.s,
+                e: realDecimal.e,
+                d: realDecimal.d,
+                // No toNumber method
+            };
+
+            // If new Decimal(plainObject) works, this passes.
+            // If it throws, we catch it here.
+            try {
+                const result = toNumFast(plainObject);
+                expect(result).toBe(123);
+            } catch (e) {
+                // If it fails, maybe the code path is indeed problematic for plain objects.
+                // But let's assume for now it might work or we want to verify.
+                throw e;
+            }
+        });
+    });
+
+    describe('Edge Cases', () => {
+        it('should return 0 for null', () => {
+            expect(toNumFast(null)).toBe(0);
+        });
+
+        it('should return 0 for undefined', () => {
+            expect(toNumFast(undefined)).toBe(0);
+        });
+
+        it('should return 0 for empty object', () => {
+            expect(toNumFast({})).toBe(0);
+        });
+
+        it('should return 0 for boolean', () => {
+            // @ts-ignore
+            expect(toNumFast(true)).toBe(0);
+            // @ts-ignore
+            expect(toNumFast(false)).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
## 🧪 Testing Improvement: `toNumFast`

I have implemented comprehensive unit tests for `src/utils/fastConversion.ts` and fixed a bug uncovered during testing.

### Changes
1.  **Added Tests:** Created `tests/unit/fastConversion.test.ts` covering:
    -   Numbers (integers, floats, negative, zero)
    -   Strings (valid, invalid, empty)
    -   `Decimal` instances
    -   Objects with `.toNumber()`
    -   Serialized `Decimal` objects (plain objects with `s`, `e`, `d`)
    -   Edge cases (`null`, `undefined`, boolean, empty objects)

2.  **Bug Fix:** Updated `toNumFast` to correctly handle serialized `Decimal` objects (e.g., from `JSON.parse()`). Previously, passing a plain object to `new Decimal(val)` threw an error. The fix uses manual property assignment or `Object.assign` to create a valid `Decimal` instance before calling `.toNumber()`.

### Verification
-   `tests/unit/fastConversion.test.ts` passes successfully (10/10 tests).
-   Ran full unit test suite (`tests/unit`) to ensure no regressions. Existing failures in `timeUtils.test.ts` are unrelated to these changes.
-   Verified types with `npm run check`.

### Summary (German)
Ich habe die Testabdeckung für `toNumFast` erweitert und einen Bug bei der Verarbeitung von serialisierten Decimal-Objekten behoben. Die neuen Tests validieren nun alle gängigen Eingabetypen und Randfälle.

---
*PR created automatically by Jules for task [15903444132090946378](https://jules.google.com/task/15903444132090946378) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
