### PR TITLE
🧹 Remove console.log from UI Store

### DIFF
--- a/src/stores/ui.svelte.ts
+++ b/src/stores/ui.svelte.ts
@@ -436,7 +436,6 @@ class UiManager {
       if (type === "success") toastService.success(message);
       else toastService.info(message);
 
-      console.log(`[Toast ${type}] ${message}`);
       this.toastMessage = message;
       this.showSaveFeedback = true;
       setTimeout(() => {


### PR DESCRIPTION
Removed debug `console.log` from `src/stores/ui.svelte.ts` inside `showToast`.

This change improves code hygiene by removing unnecessary console output in production builds. The logging logic was redundant as toast notifications are handled by the `toastService`.

Verified with `npm run check` and regression testing (existing failures confirmed unrelated). No functional changes.

---
*PR created automatically by Jules for task [1288043800919854541](https://jules.google.com/task/1288043800919854541) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
