### PR TITLE
🧹 Remove console logging in TradeFlowBackground

### DIFF
--- a/src/components/shared/backgrounds/TradeFlowBackground.svelte
+++ b/src/components/shared/backgrounds/TradeFlowBackground.svelte
@@ -205,7 +205,6 @@
     // Restore injection hook for debugging and testing
     if (typeof window !== 'undefined') {
       (window as any).__injectTrade = (trade: any) => {
-        console.log('__injectTrade called:', trade);
         if (worker) {
           worker.postMessage({
             type: 'onTrade',
@@ -220,7 +219,6 @@
           });
         }
       };
-      console.log('Sonar debug hook initialized: window.__injectTrade');
     }
 
     return () => {


### PR DESCRIPTION
🎯 **What:** Removed `console.log` statements from `src/components/shared/backgrounds/TradeFlowBackground.svelte`.
💡 **Why:** To clean up console output and remove debug logs that were left in the codebase. The `window.__injectTrade` hook remains available for debugging but without noisy logging.
✅ **Verification:**
- Ran `npm run check` (svelte-check) - Passed.
- Verified that the `__injectTrade` function is still defined, just without logging.
- Existing unit tests run, failures unrelated to this change.
✨ **Result:** Cleaner console output.

---
*PR created automatically by Jules for task [10452739152077979416](https://jules.google.com/task/10452739152077979416) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
