### PR TITLE
🧹 Remove debug logging in Market Store

### DIFF
--- a/src/stores/market.svelte.ts
+++ b/src/stores/market.svelte.ts
@@ -20,7 +20,6 @@ import { browser } from "$app/environment";
 import { untrack } from "svelte";
 import { settingsState } from "./settings.svelte";
 import { BufferPool } from "../utils/bufferPool";
-import { logger } from "../services/logger";
 import type { Kline, KlineBuffers } from "../services/technicalsTypes";
 
 export interface MarketData {
@@ -475,22 +474,6 @@ export class MarketManager {
 
     // Get existing history or init empty
     let history = current.klines[timeframe] || [];
-    if (source === 'rest') {
-      logger.debug("market", `REST Update ${symbol}:${timeframe}`, {
-        new: newKlines.length,
-        prevHistory: history.length,
-        range: newKlines.length > 0 ? `${newKlines[0].time} - ${newKlines[newKlines.length - 1].time}` : "empty"
-      });
-    } else if (source === 'ws') {
-      const hTime = history.length > 0 ? history[history.length - 1].time : "N/A";
-      const nTime = newKlines.length > 0 ? newKlines[0].time : "N/A";
-      logger.debug("market", `WS Update ${symbol}:${timeframe}`, {
-        hist: history.length,
-        last: hTime,
-        new: newKlines.length,
-        desc: nTime
-      });
-    }
     if (!current.klines[timeframe]) current.klines[timeframe] = history;
 
     // Get existing buffers
@@ -730,13 +713,6 @@ export class MarketManager {
         // Assignment new merged array
         current.klines[timeframe] = history;
         
-        logger.debug("market", `Merge ${symbol}:${timeframe}`, {
-          merged: newKlines.length,
-          into: hLen,
-          result: history.length,
-          limit: effectiveLimit
-        });
-
         // Full rebuild needed (now on optimized size)
         if (buffers) releaseBuffers(buffers);
         buffers = rebuildBuffers(history);


### PR DESCRIPTION
Removed `logger.debug` statements from `src/stores/market.svelte.ts` to clean up production logs, as requested. Also removed the unused `logger` import.

Manual verification was performed as the test environment lacked dependencies. Checked for syntax errors and confirmed removal of target lines.

---
*PR created automatically by Jules for task [13833438511760280613](https://jules.google.com/task/13833438511760280613) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
