### PR TITLE
🧹 chore: remove commented-out imports in shared components

### DIFF
--- a/src/components/shared/OpenOrdersList.svelte
+++ b/src/components/shared/OpenOrdersList.svelte
@@ -19,7 +19,6 @@
   import { _ } from "../../locales/i18n";
   import { formatDynamicDecimal } from "../../utils/utils";
   import { uiState } from "../../stores/ui.svelte";
-  // import OrderDetailsTooltip from "./OrderDetailsTooltip.svelte"; // Global handled
 
   interface Props {
     orders?: any[];

--- a/src/components/shared/PositionsList.svelte
+++ b/src/components/shared/PositionsList.svelte
@@ -20,7 +20,6 @@
   import { formatDynamicDecimal } from "../../utils/utils";
   import { Decimal } from "decimal.js";
   import { uiState } from "../../stores/ui.svelte";
-  // import PositionTooltip from "./PositionTooltip.svelte"; // Global handled
   import Button from "./Button.svelte";
   import { _ } from "../../locales/i18n";
   import type { OMSPosition } from "../../services/omsTypes";


### PR DESCRIPTION
Removed commented-out imports in `src/components/shared/OpenOrdersList.svelte` and `src/components/shared/PositionsList.svelte`.

🎯 **What:** The code health issue addressed was the presence of dead code (commented-out imports).
💡 **Why:** Removing dead code improves maintainability and reduces clutter in the codebase.
✅ **Verification:** Verified that only commented-out lines were removed. Full test suite could not be run due to environment setup issues, but the change is safe as it only affects comments. Code review confirmed the change is correct.
✨ **Result:** Cleaner and more readable shared component files.

---
*PR created automatically by Jules for task [11874985411625413697](https://jules.google.com/task/11874985411625413697) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
