### PR TITLE
🔒 fix: implement fail-closed authentication in checkAppAuth

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -11,15 +11,19 @@ import { env } from "$env/dynamic/private";
 import { json } from "@sveltejs/kit";
 
 /**
- * Checks if the request contains the correct App Access Token if one is configured on the server.
- * Returns null if authorized (or no token configured), or a 401 Response if unauthorized.
+ * Checks if the request contains the correct App Access Token.
+ * Returns null if authorized, or a 401 Response if unauthorized (including if no token is configured).
  */
 export function checkAppAuth(request: Request): Response | null {
   const serverToken = env.APP_ACCESS_TOKEN;
 
-  // If no token is configured on the server, we allow access (legacy/default mode)
+  // Security: Fail closed if no token is configured on the server.
+  // This prevents accidental exposure of the API if the configuration is missing.
   if (!serverToken) {
-    return null;
+    return json(
+      { error: "Unauthorized: App Access Token not configured on server" },
+      { status: 401 }
+    );
   }
 
   const clientToken = request.headers.get("x-app-access-token");

--- a/tests/auth_fail_closed.test.ts
+++ b/tests/auth_fail_closed.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkAppAuth } from '../src/lib/server/auth';
+
+// Mock SvelteKit modules
+vi.mock('$env/dynamic/private', () => ({
+  env: {
+    APP_ACCESS_TOKEN: undefined
+  }
+}));
+
+vi.mock('@sveltejs/kit', () => ({
+  json: vi.fn((data, init) => ({
+    status: init?.status || 200,
+    json: async () => data
+  }))
+}));
+
+describe('checkAppAuth fail-closed validation', () => {
+  it('should DENY access when APP_ACCESS_TOKEN is missing', () => {
+    const request = new Request('http://localhost/api/test', {
+      headers: {}
+    });
+
+    const result = checkAppAuth(request);
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(401);
+  });
+});


### PR DESCRIPTION
### 🔒 [security fix] Implement Fail-Closed Authentication

🎯 **What:** The `checkAppAuth` function was using a "fail-open" configuration, allowing API access if the `APP_ACCESS_TOKEN` environment variable was missing.

⚠️ **Risk:** If the server was started without a configured access token (due to misconfiguration or accidental omission), all sensitive API endpoints (including AI, Orders, and Sync services) would be exposed without any authentication.

🛡️ **Solution:** Modified `src/lib/server/auth.ts` to implement a "fail-closed" mechanism. The system now explicitly returns a `401 Unauthorized` response if `APP_ACCESS_TOKEN` is not configured. Updated JSDoc and added a unit test to verify this secure behavior.

---
*PR created automatically by Jules for task [17077235368692898219](https://jules.google.com/task/17077235368692898219) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
