### PR TITLE
chore: remove unused Button import in PositionsList.svelte

### DIFF
--- a/src/components/shared/PositionsList.svelte
+++ b/src/components/shared/PositionsList.svelte
@@ -20,7 +20,6 @@
   import { formatDynamicDecimal } from "../../utils/utils";
   import { Decimal } from "decimal.js";
   import { uiState } from "../../stores/ui.svelte";
-  import Button from "./Button.svelte";
   import { _ } from "../../locales/i18n";
   import type { OMSPosition } from "../../services/omsTypes";
 


### PR DESCRIPTION
Removed the unused 'Button' import from src/components/shared/PositionsList.svelte.
The component uses native <button> elements, making this import redundant.

---
*PR created automatically by Jules for task [8718330547713486228](https://jules.google.com/task/8718330547713486228) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
