### PR TITLE
🧹 Remove dead code and optimization comments in MACD

### DIFF
--- a/src/utils/indicators.ts
+++ b/src/utils/indicators.ts
@@ -363,23 +363,6 @@ export const JSIndicators = {
       pool.release(emaSlow);
     }
 
-    // macdLine is a new Float64Array (or reused)
-    // We use subarray for efficiency (no copy)
-    const macdLineSub = macdLine.subarray(slow - 1);
-
-    // Calculate signal on the sliced part
-    // Note: ema now skips leading NaNs.
-    // macdLine has NaNs up to slow-1.
-    // So we don't strictly need to subarray if we pass full array?
-    // But passing full array preserves indices.
-    // If we pass subarray, we get a short array back starting with NaNs.
-    // The original logic was:
-    // const macdSignalPart = this.ema(macdLineSub, signal);
-    // paddedSignal.set(macdSignalPart, slow - 1);
-
-    // If macdLine has leading NaNs, we can just pass macdLine to ema!
-    // And it will return a signal line aligned with macdLine (with more NaNs).
-
     // Optimization: Avoid subarray and copy back.
     const signalLine = (outSignal && outSignal.length === len) ? outSignal : new Float64Array(len);
     this.ema(macdLine, signal, signalLine);


### PR DESCRIPTION
Refactored `src/utils/indicators.ts` to remove the unused `macdLineSub` variable and the associated commented-out code block in the `macd` function. This cleanup aligns the code with the active optimization strategy, improving readability and maintainability.

- Removed `const macdLineSub`
- Removed obsolete comments about `subarray` logic
- Removed commented-out implementation using `macdLineSub`
- Verified with `npm test src/utils/indicators.test.ts` and `npm run check`

---
*PR created automatically by Jules for task [16623152486177558476](https://jules.google.com/task/16623152486177558476) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
