### PR TITLE
chore: remove unused comments in PositionsList.svelte

### DIFF
--- a/src/components/shared/PositionsList.svelte
+++ b/src/components/shared/PositionsList.svelte
@@ -40,7 +40,6 @@
     ontpSl,
   }: Props = $props();
 
-  // Removed local tooltip state
 
   function handleMouseEnter(event: MouseEvent, pos: any) {
     const coords = getTooltipPosition(event);


### PR DESCRIPTION
Removed the comment '// Removed local tooltip state' from src/components/shared/PositionsList.svelte. 

The requested line `// import PositionTooltip from "./PositionTooltip.svelte"; // Global handled` was not found in the file, likely already removed. The removed comment was the only remaining artifact related to the removed tooltip logic. Verified with `npm run check`.

---
*PR created automatically by Jules for task [13743551333569524134](https://jules.google.com/task/13743551333569524134) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
