### PR TITLE
refactor(test): improve type safety in newsService_limit.test.ts

### DIFF
--- a/src/services/newsService_limit.test.ts
+++ b/src/services/newsService_limit.test.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { newsService } from './newsService';
 import { dbService } from './dbService';
 
@@ -88,7 +88,7 @@ describe('NewsService Limits', () => {
             text: async () => JSON.stringify({ results: manyItems }),
             json: async () => ({ results: manyItems })
         };
-        (global.fetch as any).mockResolvedValue(mockResponse);
+        vi.mocked(global.fetch).mockResolvedValue(mockResponse as any);
 
         await newsService.fetchNews('BTC');
 
@@ -96,7 +96,7 @@ describe('NewsService Limits', () => {
         expect(dbService.put).toHaveBeenCalled();
 
         // Verify items length in the saved object
-        const callArgs = (dbService.put as any).mock.calls[0][1];
+        const callArgs = vi.mocked(dbService.put).mock.calls[0][1];
         expect(callArgs.items.length).toBe(100);
     });
 
@@ -106,7 +106,7 @@ describe('NewsService Limits', () => {
             text: async () => JSON.stringify({ results: [] }),
             json: async () => ({ results: [] })
         };
-        (global.fetch as any).mockResolvedValue(mockResponse);
+        vi.mocked(global.fetch).mockResolvedValue(mockResponse as any);
 
         await newsService.fetchNews('ETH');
 


### PR DESCRIPTION
Improved type safety in `src/services/newsService_limit.test.ts` by replacing `as any` casts with `vi.mocked` and properly typed `global.fetch` and `dbService` mocks. This code health improvement ensures better test maintainability and adheres to stricter type checking practices. The originally reported commented-out console log was found to be already removed.

---
*PR created automatically by Jules for task [13870332688047020811](https://jules.google.com/task/13870332688047020811) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
