### PR TITLE
🧹 Remove commented out console warning

### DIFF
--- a/SUBMIT_MESSAGE.md
+++ b/SUBMIT_MESSAGE.md
@@ -1,0 +1,15 @@
+# 🧹 Remove commented out console warning
+
+## 🎯 What
+Removed a commented-out `console.warn` statement in `src/lib/windows/implementations/CandleChartView.svelte`.
+
+## 💡 Why
+The code was commented out and no longer needed. Keeping commented-out code reduces readability.
+
+## ✅ Verification
+- Verified the removal in the file.
+- Ran `npm run check` to ensure no regressions.
+- Verified the surrounding logic remains intact.
+
+## ✨ Result
+Cleaner codebase.

--- a/src/lib/windows/implementations/CandleChartView.svelte
+++ b/src/lib/windows/implementations/CandleChartView.svelte
@@ -359,7 +359,6 @@
                         // For now, indicators update only on new candles or full refreshes.
                     } catch (e) {
                         // Fallback to full render
-                        // console.warn("[CandleChart] Live update failed, falling back", e);
                     }
                 } else {
                     // Slow Path: Full Render (History load or New Candle)


### PR DESCRIPTION
Removed a commented-out `console.warn` statement in `src/lib/windows/implementations/CandleChartView.svelte` that was no longer needed, improving code readability. Verified with `npm run check`.

---
*PR created automatically by Jules for task [6218478657873411436](https://jules.google.com/task/6218478657873411436) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
