### PR TITLE
🧹 Refactor BitgetWS to use centralized Logger

### DIFF
--- a/src/services/bitgetWs.ts
+++ b/src/services/bitgetWs.ts
@@ -183,8 +183,8 @@ class BitgetWebSocketService {
         if (this.connectionTimeout) clearTimeout(this.connectionTimeout);
         if (this.ws !== ws) return;
 
-        if (settingsState.enableNetworkLogs && import.meta.env.DEV) {
-          console.log("%c[WS-Bitget] Connected", "color: #0fa; font-weight: bold;");
+        if (settingsState.enableNetworkLogs) {
+          logger.log("network", "[WS-Bitget] Connected");
         }
         marketState.connectionStatus = "connected";
         marketState.updateTelemetry({ activeConnections: (marketState.telemetry.activeConnections || 0) + 1 });
@@ -360,7 +360,7 @@ class BitgetWebSocketService {
 
       this.ws.send(JSON.stringify(payload));
     } catch (e) {
-      if (import.meta.env.DEV) console.warn("[WS-Bitget] Login error:", e);
+      logger.warn("network", "[WS-Bitget] Login error", e);
     }
   }
 
@@ -378,7 +378,7 @@ class BitgetWebSocketService {
     // Check event response
     if ((msg as any).event === "login" && (msg as any).code === "00000") {
       this.isAuthenticated = true;
-      if (import.meta.env.DEV) console.log("%c[WS-Bitget] Login success", "color: #0fa;");
+      if (settingsState.enableNetworkLogs) logger.log("network", "[WS-Bitget] Login success");
       this.subscribePrivate();
       return;
     }


### PR DESCRIPTION
Replaces direct console logging with the centralized logger service in `src/services/bitgetWs.ts`.
- Replaces `console.log` with `logger.log("network", ...)`
- Replaces `console.warn` with `logger.warn("network", ...)`
- Removes manual CSS styling in logs.
- Wraps success logs in `if (settingsState.enableNetworkLogs)` check.
- Restores `marketState.connectionStatus` which was inadvertently removed during refactoring.
- Improves code health and consistency across WebSocket services.

---
*PR created automatically by Jules for task [14444667937112071300](https://jules.google.com/task/14444667937112071300) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
