### PR TITLE
chore: clean up OpenOrdersList.svelte

### DIFF
--- a/src/components/shared/OpenOrdersList.svelte
+++ b/src/components/shared/OpenOrdersList.svelte
@@ -29,8 +29,6 @@
 
   let { orders = [], loading = false, error = "", oncancel }: Props = $props();
 
-  // Removed local tooltip state
-
   function handleMouseEnter(event: MouseEvent, order: any) {
     const coords = getTooltipPosition(event);
     uiState.showTooltip("order", order, coords.x, coords.y);


### PR DESCRIPTION
Removed 'Removed local tooltip state' comment from `src/components/shared/OpenOrdersList.svelte`. The original commented-out import (OrderDetailsTooltip) was confirmed missing before changes were applied. Verified with `npm run check`.

---
*PR created automatically by Jules for task [5397142694083733956](https://jules.google.com/task/5397142694083733956) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
