### PR TITLE
🔒 Fix log streaming auth vulnerability (force auth in dev)

### DIFF
--- a/src/routes/api/stream-logs/+server.ts
+++ b/src/routes/api/stream-logs/+server.ts
@@ -21,19 +21,16 @@ import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = ({ request, url }) => {
   // Security Check
-  const isDev = process.env.NODE_ENV === "development";
   const secret = env.LOG_STREAM_KEY;
   const token = url.searchParams.get("token");
 
-  if (!isDev) {
-    if (!secret) {
-      return new Response("Log streaming is disabled in production (LOG_STREAM_KEY not set)", {
-        status: 403,
-      });
-    }
-    if (token !== secret) {
-      return new Response("Unauthorized", { status: 401 });
-    }
+  if (!secret) {
+    return new Response("Log streaming is disabled (LOG_STREAM_KEY not set)", {
+      status: 403,
+    });
+  }
+  if (token !== secret) {
+    return new Response("Unauthorized", { status: 401 });
   }
 
   // Setze Header für SSE

--- a/src/tests/security/log_stream_auth.test.ts
+++ b/src/tests/security/log_stream_auth.test.ts
@@ -49,11 +49,23 @@ describe("GET /api/stream-logs Security", () => {
     } as unknown as Request;
   };
 
-  it("should allow access in development mode without token", async () => {
+  it("should deny access in development mode without token", async () => {
     process.env.NODE_ENV = "development";
+    mockEnv.LOG_STREAM_KEY = "dev-secret";
 
     // Simulate Request
     const event = { request: createRequest("http://localhost/api/stream-logs"), url: new URL("http://localhost/api/stream-logs") } as any;
+
+    const response = await GET(event);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should allow access in development mode with correct token", async () => {
+    process.env.NODE_ENV = "development";
+    mockEnv.LOG_STREAM_KEY = "dev-secret";
+
+    const event = { request: createRequest("http://localhost/api/stream-logs?token=dev-secret"), url: new URL("http://localhost/api/stream-logs?token=dev-secret") } as any;
 
     const response = await GET(event);
 


### PR DESCRIPTION
**Security Fix: Log Streaming Authentication**

- **Enforcement:** Removed the `isDev` check in `src/routes/api/stream-logs/+server.ts`. Authentication is now required in all environments (development, production, etc.).
- **Configuration:** Developers must set `LOG_STREAM_KEY` in their `.env` file to access log streams locally.
- **Verification:** Updated `src/tests/security/log_stream_auth.test.ts` to verify that access is denied without a token in development mode, ensuring parity with production security logic.
- **Risk Mitigation:** Prevents accidental exposure of sensitive logs if a production server is run with `NODE_ENV=development`.

This change enforces a "Secure by Default" posture for the application's logging infrastructure.

---
*PR created automatically by Jules for task [5529763271548182699](https://jules.google.com/task/5529763271548182699) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
