### PR TITLE
Fix chat filter dropping own and system messages

### DIFF
--- a/src/stores/chat.svelte.ts
+++ b/src/stores/chat.svelte.ts
@@ -80,9 +80,20 @@ class ChatManager {
     const minPF = settings.minChatProfitFactor || 0;
 
     // 2. Apply Profit Factor Filter
-    const filteredIncoming = incoming.filter(
-      (m) => (m.profitFactor ?? 0) >= minPF,
-    );
+    // Allow own messages, system messages, or messages meeting the PF requirement
+    const filteredIncoming = incoming.filter((m) => {
+      // Exclude messages from filtering if they are:
+      // - From system
+      // - From me (by senderId 'me' or matching clientId)
+      // - System messages often have undefined profitFactor, so we should check sender type explicitly
+      const isSystem = m.sender === "system";
+      const isMe = m.senderId === "me" || m.clientId === this.clientId;
+
+      if (isSystem || isMe) return true;
+
+      // Otherwise, enforce PF
+      return (m.profitFactor ?? 0) >= minPF;
+    });
 
     const existingIds = new Set(current.map((m) => m.id));
     const uniqueIncoming = filteredIncoming.filter(


### PR DESCRIPTION
- Updated `mergeMessages` in `src/stores/chat.svelte.ts` to exempt system and own messages from `minChatProfitFactor` filtering.
- Added comprehensive tests in `src/stores/chat.test.ts` to verify exemption logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
