### PR TITLE
🔒 Fix Timing Attack in Auth Token Comparison

### DIFF
--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -33,13 +33,17 @@ describe("checkAppAuth", () => {
     mockEnv.APP_ACCESS_TOKEN = undefined;
   });
 
-  it("should return null if no APP_ACCESS_TOKEN is configured", () => {
+  it("should return 401 if no APP_ACCESS_TOKEN is configured", async () => {
     const request = new Request("http://localhost", {
       headers: { "x-app-access-token": "any-token" }
     });
 
     const result = checkAppAuth(request);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(401);
+
+    const body = await result?.json();
+    expect(body.error).toContain("App Access Token not configured");
   });
 
   it("should return 401 if APP_ACCESS_TOKEN is configured but header is missing", async () => {


### PR DESCRIPTION
- Replaced insecure string comparison with crypto.timingSafeEqual in src/lib/server/auth.ts
- Implemented SHA-256 hashing to ensure constant-length inputs for timingSafeEqual
- Updated src/lib/server/auth.test.ts to assert fail-closed security policy (expecting 401 when unconfigured)

---
*PR created automatically by Jules for task [5339306148191588919](https://jules.google.com/task/5339306148191588919) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
