### PR TITLE
chore: remove outdated deployment force comment in SonarEngine

### DIFF
--- a/src/components/shared/backgrounds/engines/SonarEngine.ts
+++ b/src/components/shared/backgrounds/engines/SonarEngine.ts
@@ -18,7 +18,6 @@
 import * as THREE from 'three';
 import { BaseEngine, type EngineContext } from './BaseEngine';
 
-// Fixed import typo - Force Re-deploy
 export class SonarEngine extends BaseEngine {
     private pointCloud: THREE.Points | null = null;
     private material: THREE.ShaderMaterial | null = null;


### PR DESCRIPTION
Removed the `// Fixed import typo - Force Re-deploy` comment from
`src/components/shared/backgrounds/engines/SonarEngine.ts` as the typo
was already fixed and the note was no longer needed for redeployment.

---
*PR created automatically by Jules for task [8707106442854398781](https://jules.google.com/task/8707106442854398781) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
