### PR TITLE
test(marketWatcher): update gap benchmark logic

### DIFF
--- a/src/services/marketWatcher.bench.ts
+++ b/src/services/marketWatcher.bench.ts
@@ -38,7 +38,7 @@ describe('marketWatcher fillGaps', () => {
         });
 
         // Fixed pattern: Every 20 candles, introduce a gap of 5 candles
-        if (i % 20 === 19) {
+        if ((i + 1) % 20 === 0) {
             // Gap of 5 minutes
             currentTime += (5 + 1) * intervalMs;
         } else {


### PR DESCRIPTION
Refactored the modulo condition used in `src/services/marketWatcher.bench.ts` to introduce gaps to match the stated pattern "Every 20 candles". The mathematical logic (`(i + 1) % 20 === 0`) is clearer than `i % 20 === 19`.

This is a non-functional informational code clarity improvement.

---
*PR created automatically by Jules for task [15063712907985800076](https://jules.google.com/task/15063712907985800076) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
