### PR TITLE
fix: Journal header KPI layout and zoom buttons

### DIFF
--- a/src/components/shared/windows/WindowFrame.svelte
+++ b/src/components/shared/windows/WindowFrame.svelte
@@ -767,7 +767,7 @@
         display: flex;
         align-items: center;
         overflow: hidden;
-        flex: 0 1 auto;
+        flex: 1; /* Take up remaining space so header-indicators is pushed to right */
     }
     .title-wrapper {
         display: flex;

--- a/src/stores/ui.svelte.ts
+++ b/src/stores/ui.svelte.ts
@@ -291,6 +291,7 @@ class UiManager {
           windowType: "journal",
           width: 1200,
           height: 800,
+          allowZoom: false,
         });
         return win;
       });


### PR DESCRIPTION
- Changed `.header-content` in `WindowFrame.svelte` to `flex: 1` so that the `.header-spacer` correctly pushes the `headerSnippet` (KPI indicators) to the far right.
- Set `allowZoom: false` for the `journal` window in `ui.svelte.ts` to disable the unnecessary A-/A+ font size adjustment buttons.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
