### PR TITLE
fix: Adjust journal window controls and minimization

### DIFF
--- a/src/lib/windows/WindowRegistry.svelte.ts
+++ b/src/lib/windows/WindowRegistry.svelte.ts
@@ -226,7 +226,7 @@ class WindowRegistry {
 
         // --- DOCUMENTATION & INFORMATION ---
 
-        const markdownTypes: WindowType[] = ['journal', 'guide', 'changelog', 'privacy', 'whitepaper'];
+        const markdownTypes: WindowType[] = ['guide', 'changelog', 'privacy', 'whitepaper'];
         markdownTypes.forEach(t => {
             this.configs.set(t, {
                 type: t,
@@ -239,8 +239,8 @@ class WindowRegistry {
                     allowZoom: false,
                     allowFontSize: true,
                     centerByDefault: true,
-                    showHeaderIndicators: t === 'journal',
-                    allowFeedDuck: t !== 'journal'
+                    showHeaderIndicators: false,
+                    allowFeedDuck: true
                 },
                 layout: {
                     ...baseLayout,
@@ -248,6 +248,30 @@ class WindowRegistry {
                     height: 800
                 }
             });
+        });
+
+        // Journal Window overrides
+        this.configs.set('journal', {
+            type: 'journal',
+            flags: {
+                ...baseFlags,
+                isResizable: true,
+                allowMaximize: true,
+                showMaximizeButton: true,
+                showMinimizeButton: true,
+                allowMinimize: true,
+                allowZoom: false,
+                allowFontSize: false, // We set this false per instructions
+                centerByDefault: true,
+                showHeaderIndicators: true,
+                allowFeedDuck: false,
+                canMinimizeToPanel: true // Ensure it minimizes to the sidebar dock if applicable
+            },
+            layout: {
+                ...baseLayout,
+                width: 1000,
+                height: 800
+            }
         });
 
         /** Hybrid AI assistant / Side-chat window. */

--- a/src/stores/ui.svelte.ts
+++ b/src/stores/ui.svelte.ts
@@ -291,7 +291,9 @@ class UiManager {
           windowType: "journal",
           width: 1200,
           height: 800,
-          allowZoom: false,
+          allowFontSize: false,
+          allowMinimize: true,
+          allowMaximize: true,
         });
         return win;
       });


### PR DESCRIPTION
- Set `allowFontSize: false` for the `journal` window in `ui.svelte.ts` to hide the font size (A-/A+) buttons.
- Configured the `journal` WindowType in `WindowRegistry.svelte.ts` to `allowMinimize: true`, `showMinimizeButton: true`, and `canMinimizeToPanel: true`. This gives the window exactly 3 buttons (minimize, maximize, close) and ensures it behaves like a standard dockable window when minimized.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
