### PR TITLE
test: ensure flash-close tests mock lastUpdated date correctly

### DIFF
--- a/src/tests/flash-close.test.ts
+++ b/src/tests/flash-close.test.ts
@@ -113,7 +113,9 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
                 leverage: new Decimal('10'),
                 liquidationPrice: new Decimal('45000'),
                 unrealizedPnl: new Decimal('0'),
-                marginMode: 'cross'
+                marginMode: 'cross',
+                lastUpdated: Date.now(),
+                lastUpdated: Date.now()
             }
         ]);
 


### PR DESCRIPTION
The tests for flash-close now correctly mock lastUpdated in the OMS to bypass the ensureFreshness staleness check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
