### PR TITLE
fix: remove duplicate lastUpdated property in flash-close test mock

### DIFF
--- a/src/tests/flash-close.test.ts
+++ b/src/tests/flash-close.test.ts
@@ -114,7 +114,6 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
                 liquidationPrice: new Decimal('45000'),
                 unrealizedPnl: new Decimal('0'),
                 marginMode: 'cross',
-                lastUpdated: Date.now(),
                 lastUpdated: Date.now()
             }
         ]);


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
