### PR TITLE
Fix ADX enabled flag and refactor indicator loading

### DIFF
--- a/src/stores/indicator.svelte.ts
+++ b/src/stores/indicator.svelte.ts
@@ -301,15 +301,6 @@ class IndicatorManager {
     try {
       const parsed = JSON.parse(stored);
 
-      // Migration for ADX
-      let adxParsed = { ...defaultSettings.adx, ...(parsed.adx || {}) };
-      if (
-        parsed.adx &&
-        parsed.adx.length !== undefined &&
-        parsed.adx.adxSmoothing === undefined
-      ) {
-        adxParsed.adxSmoothing = parsed.adx.length;
-      }
       // Migration for enabled flags (if missing)
       const merge = (key: keyof IndicatorSettings, fallback: any) => {
           const val = parsed[key] || {};
@@ -334,9 +325,12 @@ class IndicatorManager {
       this.stochastic = merge('stochastic', defaultSettings.stochastic);
       this.williamsR = merge('williamsR', defaultSettings.williamsR);
       this.cci = merge('cci', defaultSettings.cci);
-      this.adx = adxParsed; // Assuming adx is special case handled above, but missing enabled?
-      // Fix ADX enabled:
-      if (this.adx.enabled === undefined) this.adx.enabled = defaultSettings.adx.enabled;
+
+      this.adx = merge('adx', defaultSettings.adx);
+      // Migration for ADX: Handle old 'length' property
+      if (parsed.adx?.length !== undefined && parsed.adx?.adxSmoothing === undefined) {
+        this.adx.adxSmoothing = parsed.adx.length;
+      }
 
       this.ao = merge('ao', defaultSettings.ao);
       this.momentum = merge('momentum', defaultSettings.momentum);


### PR DESCRIPTION
This change addresses a logic issue where the ADX indicator's `enabled` flag could remain `undefined` if missing from `localStorage`. By refactoring ADX to use the existing `merge` helper function, we ensure it follows the same robust initialization pattern as other indicators, while also maintaining and cleaning up the migration logic for legacy ADX settings.

---
*PR created automatically by Jules for task [8467735730997298508](https://jules.google.com/task/8467735730997298508) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
