### PR TITLE
🧹 Code Health: Remove unused `k_smooth` and `d_len` parameters from stoch_raw shader

### DIFF
--- a/src/services/webGpuCalculator.ts
+++ b/src/services/webGpuCalculator.ts
@@ -636,8 +636,8 @@ export class WebGpuCalculator {
   }
   
   async calculateStochRaw(high: Float32Array, low: Float32Array, close: Float32Array, kLen: number): Promise<Float32Array> {
-      // Params: k_len, k_smooth (unused in raw), d_len (unused), data_len
-      return this.compute('stochRaw', stochRawShader, [high, low, close], [kLen, 0, 0, high.length], high.length) as Promise<Float32Array>;
+      // Params: k_len, data_len
+      return this.compute('stochRaw', stochRawShader, [high, low, close], [kLen, high.length], high.length) as Promise<Float32Array>;
   }
 
   async calculateSuperTrend(

--- a/src/shaders/stoch_raw.wgsl
+++ b/src/shaders/stoch_raw.wgsl
@@ -6,8 +6,6 @@
 
 struct Params {
     k_len: u32,
-    k_smooth: u32,
-    d_len: u32,
     data_len: u32,
 };
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the passing of unused uniform parameters (`k_smooth` and `d_len`) in the `calculateStochRaw` method and their existence in the `Params` struct of the `stoch_raw.wgsl` WebGPU shader.
💡 **Why:** As the comments indicate, the smoothing and %D calculations happen on CPU/GPU via subsequent SMA passes, making `k_smooth` and `d_len` strictly unused in the raw stochastic shader. Removing them simplifies the shader interface and the calculator logic, improving maintainability.
✅ **Verification:** Modified code correctly binds only `k_len` and `data_len` and aligns uniform array lengths. Checked tests (pre-existing test failures are unrelated) to verify that this clean-up doesn't break dependent workflows.
✨ **Result:** A more explicit, cleaner, and less bloated shader interface that accurately reflects its inputs.

---
*PR created automatically by Jules for task [9498022670077260284](https://jules.google.com/task/9498022670077260284) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
