### PR TITLE
🧹 Remove DEV-only safeJsonParse regex checks in bitunixWs

### DIFF
--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -436,16 +436,7 @@ class BitunixWebSocketService {
 
           const message = safeJsonParse(rawData || event.data);
 
-          if (import.meta.env.DEV) {
-             const raw = typeof event.data === 'string' ? event.data : '';
-             // Check if we have potential large integers unquoted (>= 15 digits)
-             if (raw && /:\s*-?\d{15,}/.test(raw)) {
-                  const unsafe = JSON.parse(raw);
-                  if (JSON.stringify(message) === JSON.stringify(unsafe)) {
-                      console.warn("[BitunixWS] WARNING: Large integer detected but safeJsonParse did not alter the result. Potential regex failure?", raw);
-                  }
-             }
-          }
+
 
           this.handleMessage(message, "public");
         } catch (e) {
@@ -566,16 +557,7 @@ class BitunixWebSocketService {
 
           const message = safeJsonParse(rawData || event.data);
 
-          if (import.meta.env.DEV) {
-             const raw = typeof event.data === 'string' ? event.data : '';
-             // Check if we have potential large integers unquoted (>= 15 digits)
-             if (raw && /:\s*-?\d{15,}/.test(raw)) {
-                  const unsafe = JSON.parse(raw);
-                  if (JSON.stringify(message) === JSON.stringify(unsafe)) {
-                      console.warn("[BitunixWS] WARNING: Large integer detected but safeJsonParse did not alter the result. Potential regex failure?", raw);
-                  }
-             }
-          }
+
 
           this.handleMessage(message, "private");
         } catch (e) {


### PR DESCRIPTION
🎯 **What:** The duplicated `DEV`-only block checking regex against `safeJsonParse` outputs was removed from `ws.onmessage` handlers within both `connectPublic` and `connectPrivate` functions in `src/services/bitunixWs.ts`.
💡 **Why:** This reduces visual noise and duplication in the high-frequency message handling logic, thereby improving maintainability and code readability without affecting any production-facing logic.
✅ **Verification:** Ran targeted unit tests via `npx vitest run src/services/bitunixWs` to ensure message processing and type-safety mechanisms still operate as expected. All pertinent tests passed.
✨ **Result:** A cleaner and more streamlined `bitunixWs.ts`.

---
*PR created automatically by Jules for task [15251730133597799738](https://jules.google.com/task/15251730133597799738) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
