### PR TITLE
fix: correct WebSocket channel mapping for data requirements

### DIFF
--- a/src/services/marketWatcher.ts
+++ b/src/services/marketWatcher.ts
@@ -181,10 +181,11 @@ class MarketWatcher {
     const intended = new Map<string, { symbol: string; channel: string }>();
     this.requests.forEach((channels, symbol) => {
       channels.forEach((reqs, ch) => {
-        const bitunixChannel = ch;
-        // No longer map generic "price" to Bitunix "ticker" - let "price" be "price" (mark price + funding)
-        const key = `${bitunixChannel}:${symbol}`;
-        intended.set(key, { symbol, channel: bitunixChannel });
+        const wsChannels = getChannelsForRequirement(ch);
+        wsChannels.forEach(bitunixChannel => {
+          const key = `${bitunixChannel}:${symbol}`;
+          intended.set(key, { symbol, channel: bitunixChannel });
+        });
       });
     });
 


### PR DESCRIPTION
**Root Cause:**
A recent code change altered the WebSocket subscription sync logic in `marketWatcher.ts`. It started assuming that the data requirements names (like `depth` or `price`) were equal to the actual underlying WebSocket channel names. This broke components like the `MarketOverview` tile that request generic requirements, because the resulting WebSocket messages for invalid channel names failed, causing the Bid/Ask bars (and other data) to disappear.

**Fix:**
Replaced the direct 1:1 mapping mapping with `getChannelsForRequirement(ch)` in the `syncSubscriptions` method in `src/services/marketWatcher.ts`. This correctly translates logical requirement names into an array of actual provider channel names (e.g. `depth` becomes `depth_book5` for bitunix) and properly aggregates those mapped channels into the subscription list.

---
*PR created automatically by Jules for task [5387602361057709186](https://jules.google.com/task/5387602361057709186) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
