### PR TITLE
🔒 [Security] Fix stored XSS via Markdown Action Rendering

### DIFF
--- a/src/actions/markdown.ts
+++ b/src/actions/markdown.ts
@@ -27,7 +27,13 @@ export function markdown(node: HTMLElement, content: string) {
             node.innerHTML = "";
             return;
         }
-        node.innerHTML = renderSafeMarkdown(newContent);
+
+        const rendered = renderSafeMarkdown(newContent);
+        if (typeof rendered === 'string') {
+            node.innerHTML = rendered; // Only safe because we know SSR/error returns ""
+        } else {
+            node.replaceChildren(rendered);
+        }
     };
 
     update(content);

--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -33,7 +33,7 @@ marked.use(markedKatex({
  * SECURITY: Returns empty string during SSR to prevent XSS/hydration mismatches
  * from untrusted content.
  */
-export function renderSafeMarkdown(text: string): string {
+export function renderSafeMarkdown(text: string): string | DocumentFragment {
     try {
         if (!text) return "";
 
@@ -45,14 +45,14 @@ export function renderSafeMarkdown(text: string): string {
         const raw = marked.parse(cleaned) as string;
 
         if (typeof window !== "undefined") {
-            return DOMPurify.sanitize(raw);
+            return DOMPurify.sanitize(raw, { RETURN_DOM_FRAGMENT: true });
         }
 
         // SSR Fallback: Return empty string to prevent XSS.
         return "";
     } catch (e) {
         console.error("Markdown rendering error:", e);
-        return text;
+        return "";
     }
 }
 

--- a/tests/unit/markdownUtils.test.ts
+++ b/tests/unit/markdownUtils.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderSafeMarkdown } from '../../src/utils/markdownUtils';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+// Mock DOMPurify as we are in a non-browser environment
+vi.mock('dompurify', () => {
+    return {
+        default: {
+            sanitize: vi.fn((raw, options) => {
+                if (options?.RETURN_DOM_FRAGMENT) {
+                    return { nodeType: 11, _isFragment: true } as unknown as DocumentFragment;
+                }
+                return raw;
+            })
+        }
+    };
+});
+
+describe('markdownUtils', () => {
+    describe('renderSafeMarkdown', () => {
+        let originalWindow: any;
+
+        beforeEach(() => {
+            originalWindow = global.window;
+            global.window = {} as any;
+        });
+
+        afterEach(() => {
+            global.window = originalWindow;
+            vi.clearAllMocks();
+        });
+
+        it('should return empty string for empty input', () => {
+            expect(renderSafeMarkdown('')).toBe('');
+            expect(renderSafeMarkdown(null as any)).toBe('');
+            expect(renderSafeMarkdown(undefined as any)).toBe('');
+        });
+
+        it('should return empty string during SSR', () => {
+            const temp = global.window;
+            // @ts-ignore
+            delete global.window;
+
+            expect(renderSafeMarkdown('# Hello')).toBe('');
+
+            global.window = temp;
+        });
+
+        it('should return DocumentFragment on the client', () => {
+            const result = renderSafeMarkdown('# Hello');
+            expect(typeof result).toBe('object');
+            expect((result as any)._isFragment).toBe(true);
+            expect(DOMPurify.sanitize).toHaveBeenCalledWith(expect.any(String), { RETURN_DOM_FRAGMENT: true });
+        });
+
+        it('should fail-close (return empty string) if error occurs', () => {
+            // Mock DOMPurify to throw to simulate an error in the try-catch block
+            vi.mocked(DOMPurify.sanitize).mockImplementationOnce(() => {
+                throw new Error('Mock sanitize error');
+            });
+
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = renderSafeMarkdown('# Hello');
+
+            expect(result).toBe(''); // Must not return the raw '# Hello'
+            expect(consoleSpy).toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:**
- Fixed a stored Cross-Site Scripting (XSS) vulnerability caused by direct assignment of sanitized Markdown to `innerHTML` (mXSS risk).
- Fixed a fail-open error handling block in the markdown renderer that returned unsanitized raw text on parser failures.

⚠️ **Risk:**
- High. Malicious input that exploited DOM mutation (mXSS) after sanitization could be executed.
- If the renderer crashed, DOMPurify was completely bypassed by returning the raw payload, leading to direct XSS execution when rendered.

🛡️ **Solution:**
- Configured DOMPurify to return a safe `DocumentFragment` on the client using `RETURN_DOM_FRAGMENT: true`.
- Modified the Svelte action to safely insert the fragment using `node.replaceChildren()` instead of `node.innerHTML`.
- Changed the `catch` block in `renderSafeMarkdown` to fail closed and return an empty string (`""`) on error.
- Added comprehensive unit testing for `renderSafeMarkdown` behaviour.

---
*PR created automatically by Jules for task [295932844408905887](https://jules.google.com/task/295932844408905887) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
