### PR TITLE
🔒 Fix Server-Side Content Escaping for Tooltips

### DIFF
--- a/src/actions/markdown.ts
+++ b/src/actions/markdown.ts
@@ -24,16 +24,12 @@ import { renderSafeMarkdown } from "../utils/markdownUtils";
 export function markdown(node: HTMLElement, content: string) {
     const update = (newContent: string) => {
         if (!newContent) {
-            node.innerHTML = "";
+            node.replaceChildren();
             return;
         }
 
         const rendered = renderSafeMarkdown(newContent);
-        if (typeof rendered === 'string') {
-            node.innerHTML = rendered; // Only safe because we know SSR/error returns ""
-        } else {
-            node.replaceChildren(rendered);
-        }
+        node.replaceChildren(rendered); // Works for both string (SSR fallback) and DocumentFragment
     };
 
     update(content);


### PR DESCRIPTION
🎯 **What:**
Removed the `allowHtml` configuration option from the `tooltip` action and replaced `DOMPurify.sanitize(...)` with a strict `textContent` assignment for all tooltips. 

⚠️ **Risk:**
While `DOMPurify` was used correctly on the client side, allowing HTML string interpolation via `innerHTML` into a floating tooltip creates a dangerous XSS attack surface if raw or malicious user-generated data accidentally reaches the `content` property of the tooltip configuration. Bypassing client-side DOMPurify is possible under certain configurations or mutation events.

🛡️ **Solution:**
To eliminate the vulnerability and minimize the blast radius, the `allowHtml` functionality was completely excised. The action now strictly guarantees safety by assigning `config.content` to `contentContainer.textContent`, converting any potential HTML tags into harmless string literals. Additionally, the `dompurify` dependency import was removed from the file to clean up the code.

---
*PR created automatically by Jules for task [13758905375689737071](https://jules.google.com/task/13758905375689737071) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
