### PR TITLE
🧪 Add tests for getPresetById in rssPresets

### DIFF
--- a/src/config/rssPresets.test.ts
+++ b/src/config/rssPresets.test.ts
@@ -17,9 +17,29 @@
 
 
 import { describe, it, expect } from 'vitest';
-import { getPresetUrls, getRSSUrlsByIds, RSS_PRESETS } from './rssPresets';
+import { getPresetUrls, getRSSUrlsByIds, getPresetById, RSS_PRESETS } from './rssPresets';
 
 describe('rssPresets', () => {
+  describe('getPresetById', () => {
+    it('should return the correct preset object for a valid ID', () => {
+      const preset = getPresetById('coindesk');
+      expect(preset).toBeDefined();
+      expect(preset?.id).toBe('coindesk');
+      expect(preset?.name).toBe('CoinDesk');
+      expect(preset?.category).toBe('crypto');
+    });
+
+    it('should return undefined for a non-existent ID', () => {
+      const preset = getPresetById('fake-id');
+      expect(preset).toBeUndefined();
+    });
+
+    it('should return undefined for an empty string', () => {
+      const preset = getPresetById('');
+      expect(preset).toBeUndefined();
+    });
+  });
+
   describe('getPresetUrls', () => {
     it('should return correct URLs for existing IDs', () => {
       const ids = ['coindesk', 'decrypt'];


### PR DESCRIPTION
🎯 **What:** The `getPresetById` function in `src/config/rssPresets.ts` lacked test coverage.
📊 **Coverage:** Added test cases for the happy path (valid existing ID), handling non-existent IDs, and handling empty strings.
✨ **Result:** Improved test reliability and ensured edge cases for `getPresetById` are correctly managed without regressions.

---
*PR created automatically by Jules for task [2835643693561950634](https://jules.google.com/task/2835643693561950634) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
