### PR TITLE
🧪 Add validation test for broker capabilities configuration

### DIFF
--- a/src/config/brokerCapabilities.test.ts
+++ b/src/config/brokerCapabilities.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BROKER_CAPABILITIES } from './brokerCapabilities';
+
+describe('BROKER_CAPABILITIES', () => {
+    it('should have valid configuration for all defined brokers', () => {
+        const brokers = Object.keys(BROKER_CAPABILITIES);
+        expect(brokers.length).toBeGreaterThan(0);
+
+        for (const broker of brokers) {
+            const capabilities = BROKER_CAPABILITIES[broker];
+            expect(capabilities).toBeDefined();
+            expect(capabilities.nativeTimeframes).toBeInstanceOf(Array);
+            expect(capabilities.nativeTimeframes.length).toBeGreaterThan(0);
+
+            // Ensure every timeframe is a string
+            capabilities.nativeTimeframes.forEach(tf => {
+                expect(typeof tf).toBe('string');
+            });
+        }
+    });
+
+    it('should have correct nativeTimeframes for bitunix', () => {
+        expect(BROKER_CAPABILITIES.bitunix).toBeDefined();
+        expect(BROKER_CAPABILITIES.bitunix.nativeTimeframes).toEqual([
+            "1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M"
+        ]);
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The configuration object `BROKER_CAPABILITIES` in `src/config/brokerCapabilities.ts` lacked a unit test to guarantee that its exported capabilities were correctly structured. Without a test, a missing key or incorrectly formatted array could silently cause issues during runtime.

📊 **Coverage:** What scenarios are now tested
1. **Structural Validation:** Verified that `BROKER_CAPABILITIES` is defined and contains at least one broker configuration.
2. **Type Checking:** Asserts that `nativeTimeframes` is present for each registered broker, is an array of elements, and contains only primitive strings.
3. **Values Verification:** Asserts that the configurations for `bitunix` exactly match expected timeframes `["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M"]`.

✨ **Result:** The improvement in test coverage
Prevents future regressions where an invalid configuration object for a new or existing broker breaks parsing logic. Improves confidence in the underlying capabilities data definitions.

---
*PR created automatically by Jules for task [14802336049946498274](https://jules.google.com/task/14802336049946498274) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
