### PR TITLE
🧪 test(chat): add coverage for local chat history clearing

### DIFF
--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -139,4 +139,15 @@ describe('ChatManager', () => {
     expect(merged).toHaveLength(1);
     expect(merged[0].id).toBe('me2');
   });
+
+  it('clears history correctly', () => {
+    (chatState as any).messages = [
+      { id: '1', text: 'Hello', timestamp: 100 },
+      { id: '2', text: 'World', timestamp: 200 }
+    ];
+
+    chatState.clearHistory();
+
+    expect((chatState as any).messages).toHaveLength(0);
+  });
 });

--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -145,9 +145,13 @@ describe('ChatManager', () => {
       { id: '1', text: 'Hello', timestamp: 100 },
       { id: '2', text: 'World', timestamp: 200 }
     ];
+    (chatState as any).latestSeenTimestamp = 200;
 
     chatState.clearHistory();
 
     expect((chatState as any).messages).toHaveLength(0);
+    // latestSeenTimestamp is intentionally preserved so the next poll
+    // only fetches new messages rather than re-fetching cleared history
+    expect((chatState as any).latestSeenTimestamp).toBe(200);
   });
 });


### PR DESCRIPTION
🎯 **What:** The `chatState.clearHistory()` method in `src/stores/chat.svelte.ts` was missing test coverage.
📊 **Coverage:** Added a test case `clears history correctly` that initializes the `chatState` with mock messages, calls `clearHistory()`, and asserts the `messages` array is successfully emptied to length 0. 
✨ **Result:** Improved test coverage and reliability for local chat state management.

---
*PR created automatically by Jules for task [13932038706566930910](https://jules.google.com/task/13932038706566930910) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
