### PR TITLE
🧪 test improvement for local chat state clearing

### DIFF
--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -140,16 +140,25 @@ describe('ChatManager', () => {
     expect(merged[0].id).toBe('me2');
   });
 
-  it('clears history correctly', () => {
+  it('clears history correctly and leaves other state intact', () => {
     (chatState as any).messages = [
       { id: '1', text: 'Hello', timestamp: 100 },
       { id: '2', text: 'World', timestamp: 200 }
     ];
     (chatState as any).latestSeenTimestamp = 200;
+    (chatState as any).lastSentTimestamp = 150;
+    (chatState as any).loading = true;
+    (chatState as any).clientId = 'existing-client-id';
 
     chatState.clearHistory();
 
     expect((chatState as any).messages).toHaveLength(0);
+
+    // Ensure other states remain unaffected
+    expect((chatState as any).lastSentTimestamp).toBe(150);
+    expect((chatState as any).loading).toBe(true);
+    expect((chatState as any).clientId).toBe('existing-client-id');
+
     // latestSeenTimestamp is intentionally preserved so the next poll
     // only fetches new messages rather than re-fetching cleared history
     expect((chatState as any).latestSeenTimestamp).toBe(200);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of explicit assertions ensuring that the `clearHistory()` method in the `ChatManager` strictly clears only the chat history (`messages`), without unintentionally altering or mutating other important state values like `lastSentTimestamp`, `loading`, and `clientId`.
📊 **Coverage:** A specific test case was modified and enhanced to verify that `clearHistory()` sets `messages` to an empty array (`[]`) while verifying `lastSentTimestamp`, `loading`, `clientId` and `latestSeenTimestamp` remain intact.
✨ **Result:** The improvement in test coverage guarantees that future modifications to the local chat state manager's clearing logic will be correctly tracked and asserted to avoid unintended regressions with unaffected variables.

---
*PR created automatically by Jules for task [3308988240280678550](https://jules.google.com/task/3308988240280678550) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
