### PR TITLE
Fix relative path resolution in verify_translations.py

### DIFF
--- a/scripts/verify_translations.py
+++ b/scripts/verify_translations.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 # Fix path relative to script location in scripts/ dir
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DE_FILE = PROJECT_ROOT / 'src/locales/locales/de.json'
 EN_FILE = PROJECT_ROOT / 'src/locales/locales/en.json'
 


### PR DESCRIPTION
Updated PROJECT_ROOT calculation to use `Path(__file__).resolve().parent.parent` instead of `Path(__file__).parent.parent.resolve()`. This ensures the script can reliably locate the translation JSON files regardless of the directory it is executed from.

---
*PR created automatically by Jules for task [13058764828888619](https://jules.google.com/task/13058764828888619) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
