### PR TITLE
fix: sanitize sensitive data in error responses

### DIFF
--- a/src/routes/api/sync/orders/+server.ts
+++ b/src/routes/api/sync/orders/+server.ts
@@ -96,7 +96,7 @@ export const POST: RequestHandler = async ({ request }) => {
       // Sanitize
       console.error(
         "Error fetching regular orders:",
-        msg.replaceAll(apiKey, "***"),
+        msg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
       );
     }
 
@@ -106,7 +106,7 @@ export const POST: RequestHandler = async ({ request }) => {
       const msg = (tpslResult.reason as Error).message || "Unknown error";
       console.warn(
         "Error fetching TP/SL orders:",
-        msg.replaceAll(apiKey, "***"),
+        msg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
       );
     }
 
@@ -116,7 +116,7 @@ export const POST: RequestHandler = async ({ request }) => {
       const msg = (planResult.reason as Error).message || "Unknown error";
       console.warn(
         "Error fetching plan orders:",
-        msg.replaceAll(apiKey, "***"),
+        msg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
       );
     }
 
@@ -124,11 +124,12 @@ export const POST: RequestHandler = async ({ request }) => {
   } catch (e: unknown) {
     // Log only the message to prevent leaking sensitive data (e.g. headers/keys in error objects)
     const rawMsg = e instanceof Error ? e.message : String(e);
+    const safeMsg = rawMsg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***");
     console.error(
       `Error fetching orders from Bitunix:`,
-      rawMsg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
+      safeMsg,
     );
-    return json({ error: rawMsg || "Failed to fetch orders" }, { status: 500 });
+    return json({ error: safeMsg || "Failed to fetch orders" }, { status: 500 });
   }
 };
 

--- a/src/routes/api/sync/orders/+server.ts
+++ b/src/routes/api/sync/orders/+server.ts
@@ -225,13 +225,14 @@ async function fetchBitunixData(
   if (!response.ok) {
     const text = await response.text();
     // Try to parse JSON error from text
+    let jsonError: { msg?: string } | undefined;
     try {
-      const jsonError = JSON.parse(text);
-      if (jsonError.msg) {
-        throw new Error(jsonError.msg); // Pass upstream message
-      }
-    } catch (e) {
-      // ignore
+      jsonError = JSON.parse(text);
+    } catch {
+      // not JSON, ignore
+    }
+    if (jsonError?.msg) {
+      throw new Error(jsonError.msg); // Pass upstream message
     }
     // Truncate text to avoid massive logs or leaking too much info
     const safeText = text.length > 200 ? text.substring(0, 200) + "..." : text;

--- a/src/routes/api/sync/orders/security.test.ts
+++ b/src/routes/api/sync/orders/security.test.ts
@@ -18,6 +18,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './+server';
 
+vi.mock('../../../../lib/server/auth', () => ({
+  checkAppAuth: vi.fn(() => null)
+}));
+
+
 describe('POST /api/sync/orders', () => {
   it('should return 400 if JSON is malformed', async () => {
     const request = {

--- a/src/routes/api/sync/positions-history/+server.ts
+++ b/src/routes/api/sync/positions-history/+server.ts
@@ -56,7 +56,7 @@ export const POST: RequestHandler = async ({ request }) => {
     );
     return json({ data: positions });
   } catch (e: any) {
-    // SECURITY FIX: Sanitize logs and error response
+
     const rawMsg = e instanceof Error ? e.message : String(e);
     // Mask sensitive data
     const safeMsg = rawMsg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***");

--- a/src/routes/api/sync/positions-history/positions_history_security.test.ts
+++ b/src/routes/api/sync/positions-history/positions_history_security.test.ts
@@ -18,6 +18,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './+server';
 
+vi.mock('../../../../lib/server/auth', () => ({
+  checkAppAuth: vi.fn(() => null)
+}));
+
+
 // Mock fetch globally
 const fetchMock = vi.fn();
 vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
- Update error handling in `positions-history/+server.ts` to use `safeMsg` instead of `rawMsg` for both logs and the JSON response, preventing API key leaks to clients.
- Applied identical sanitization fixes to `orders/+server.ts` for consistency and security.
- Addressed failing tests by correctly mocking `checkAppAuth` using Vitest's `vi.mock()` placed safely after module imports.

---
*PR created automatically by Jules for task [6130340862286567887](https://jules.google.com/task/6130340862286567887) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
