### PR TITLE
Fix AssistantView Error Message Timeout

### DIFF
--- a/src/lib/windows/implementations/AssistantView.svelte
+++ b/src/lib/windows/implementations/AssistantView.svelte
@@ -56,8 +56,6 @@
         }
     });
 
-    let errorTimeout: ReturnType<typeof setTimeout> | undefined;
-
     async function handleSend() {
         if (!messageText.trim()) return;
 
@@ -82,10 +80,6 @@
             messageText = "";
         } catch (e: any) {
             errorMessage = e.message || "Error";
-            // Critical fix: Do NOT auto-clear error after 3s.
-            // Users need to see what went wrong.
-            // if (errorTimeout) clearTimeout(errorTimeout);
-            // errorTimeout = setTimeout(() => (errorMessage = ""), 3000);
         } finally {
             isSending = false;
             // Keep focus only if not error?
@@ -93,13 +87,6 @@
             if (inputEl) inputEl.focus();
         }
     }
-
-    // Cleanup effect
-    $effect(() => {
-        return () => {
-            if (errorTimeout) clearTimeout(errorTimeout);
-        };
-    });
 
     function handleKeydown(e: KeyboardEvent) {
         if (e.key === "Enter" && !e.shiftKey) {


### PR DESCRIPTION
- Removes commented out setTimeout code that used to clear error messages.
- Removes errorTimeout state variable entirely.
- Removes $effect hook that cleared the timeout on component unmount.
- The UI will now display error messages until manually cleared by another action, so users can see what went wrong.

---
*PR created automatically by Jules for task [1926177045360866600](https://jules.google.com/task/1926177045360866600) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
