### PR TITLE
fix(security): sanitize logs and error response in positions-history route

### DIFF
--- a/src/routes/api/sync/orders/+server.ts
+++ b/src/routes/api/sync/orders/+server.ts
@@ -21,6 +21,7 @@ import { generateBitunixSignature } from "../../../../utils/server/bitunix";
 import { checkAppAuth } from "../../../../lib/server/auth";
 import type { BitunixOrder } from "../../../../types/bitunix";
 import { z } from "zod";
+import { sanitizeErrorMessage } from "../../../../types/apiSchemas";
 
 const RequestSchema = z.object({
   apiKey: z.string().min(1),
@@ -89,14 +90,21 @@ export const POST: RequestHandler = async ({ request }) => {
     ]);
 
     // Process results
+    // Helper to sanitize error messages consistently
+    const sanitizeMsg = (msg: string): string => {
+      let safe = msg;
+      if (apiKey.length > 4) safe = safe.replaceAll(apiKey, "***");
+      if (apiSecret.length > 4) safe = safe.replaceAll(apiSecret, "***");
+      return sanitizeErrorMessage(safe, 1000);
+    };
+
     if (regularResult.status === "fulfilled") {
       allOrders = allOrders.concat(regularResult.value);
     } else {
       const msg = (regularResult.reason as Error).message || "Unknown error";
-      // Sanitize
       console.error(
         "Error fetching regular orders:",
-        msg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
+        sanitizeMsg(msg),
       );
     }
 
@@ -106,7 +114,7 @@ export const POST: RequestHandler = async ({ request }) => {
       const msg = (tpslResult.reason as Error).message || "Unknown error";
       console.warn(
         "Error fetching TP/SL orders:",
-        msg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
+        sanitizeMsg(msg),
       );
     }
 
@@ -116,7 +124,7 @@ export const POST: RequestHandler = async ({ request }) => {
       const msg = (planResult.reason as Error).message || "Unknown error";
       console.warn(
         "Error fetching plan orders:",
-        msg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***"),
+        sanitizeMsg(msg),
       );
     }
 
@@ -124,7 +132,10 @@ export const POST: RequestHandler = async ({ request }) => {
   } catch (e: unknown) {
     // Log only the message to prevent leaking sensitive data (e.g. headers/keys in error objects)
     const rawMsg = e instanceof Error ? e.message : String(e);
-    const safeMsg = rawMsg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***");
+    let safeMsg = rawMsg;
+    if (apiKey.length > 4) safeMsg = safeMsg.replaceAll(apiKey, "***");
+    if (apiSecret.length > 4) safeMsg = safeMsg.replaceAll(apiSecret, "***");
+    safeMsg = sanitizeErrorMessage(safeMsg, 1000);
     console.error(
       `Error fetching orders from Bitunix:`,
       safeMsg,

--- a/src/routes/api/sync/positions-history/+server.ts
+++ b/src/routes/api/sync/positions-history/+server.ts
@@ -20,6 +20,7 @@ import type { RequestHandler } from "./$types";
 import { generateBitunixSignature } from "../../../../utils/server/bitunix";
 import { z } from "zod";
 import { checkAppAuth } from "../../../../lib/server/auth";
+import { sanitizeErrorMessage } from "../../../../types/apiSchemas";
 
 const RequestSchema = z.object({
   apiKey: z.string().min(1),
@@ -58,8 +59,10 @@ export const POST: RequestHandler = async ({ request }) => {
   } catch (e: any) {
 
     const rawMsg = e instanceof Error ? e.message : String(e);
-    // Mask sensitive data
-    const safeMsg = rawMsg.replaceAll(apiKey, "***").replaceAll(apiSecret, "***");
+    // Mask sensitive data (SECURITY FIX)
+    let safeMsg = sanitizeErrorMessage(rawMsg, 1000);
+    if (apiKey && apiKey.length > 4) safeMsg = safeMsg.replaceAll(apiKey, "***");
+    if (apiSecret && apiSecret.length > 4) safeMsg = safeMsg.replaceAll(apiSecret, "***");
 
     console.error(`Error fetching history positions from Bitunix:`, safeMsg);
 

--- a/src/routes/api/sync/positions-history/+server.ts
+++ b/src/routes/api/sync/positions-history/+server.ts
@@ -60,9 +60,11 @@ export const POST: RequestHandler = async ({ request }) => {
 
     const rawMsg = e instanceof Error ? e.message : String(e);
     // Mask sensitive data (SECURITY FIX)
-    let safeMsg = sanitizeErrorMessage(rawMsg, 1000);
+    // Mask keys before truncating so partial keys at the boundary are not left unmasked
+    let safeMsg = rawMsg;
     if (apiKey && apiKey.length > 4) safeMsg = safeMsg.replaceAll(apiKey, "***");
     if (apiSecret && apiSecret.length > 4) safeMsg = safeMsg.replaceAll(apiSecret, "***");
+    safeMsg = sanitizeErrorMessage(safeMsg, 1000);
 
     console.error(`Error fetching history positions from Bitunix:`, safeMsg);
 


### PR DESCRIPTION
- imported `sanitizeErrorMessage` from `src/types/apiSchemas`
- removed explicit, hardcoded manual replacement logic which could crash on undefined
- guarded against empty strings before performing explicit replacements needed to fulfill the test conditions
- ensured tests from `positions_history_security.test.ts` pass
- removed AI leftover development files

---
*PR created automatically by Jules for task [18056195383634315710](https://jules.google.com/task/18056195383634315710) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
