### PR TITLE
🧪 [test]: validate full default state for results store

### DIFF
--- a/src/stores/results.test.ts
+++ b/src/stores/results.test.ts
@@ -44,10 +44,7 @@ describe('Results Manager', () => {
 
     describe('ResultsManager methods', () => {
         it('should initialize with initial state', () => {
-            expect(resultsState.positionSize).toBe("-");
-            expect(resultsState.requiredMargin).toBe("-");
-            expect(resultsState.showTotalMetricsGroup).toBe(false);
-            expect(resultsState.calculatedTpDetails).toEqual([]);
+            expect(resultsState).toMatchObject(INITIAL_RESULTS_STATE);
         });
 
         it('should update specific fields using update()', () => {


### PR DESCRIPTION
🎯 **What:** The initial state tests in `src/stores/results.test.ts` only individually asserted a subset of fields (e.g., `positionSize`, `showTotalMetricsGroup`), rather than verifying that the entire instantiated `resultsState` correctly matched the `INITIAL_RESULTS_STATE`. This left a testing gap where new fields added to the state might not be properly validated on initialization.

📊 **Coverage:** The `'should initialize with initial state'` test now uses a pure structural object assertion (`expect(resultsState).toMatchObject(INITIAL_RESULTS_STATE)`). This ensures 100% field coverage for the initial state of the `resultsState` store.

✨ **Result:** A trivial to write and maintain test that catches any regressions or uninitialized fields if `ResultsState` is modified in the future, providing a more robust safety net for refactoring.

---
*PR created automatically by Jules for task [9295434672456298585](https://jules.google.com/task/9295434672456298585) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
