### PR TITLE
fix: snap BlockEngine camera properly on first trade

### DIFF
--- a/src/components/shared/backgrounds/engines/BlockEngine.ts
+++ b/src/components/shared/backgrounds/engines/BlockEngine.ts
@@ -35,6 +35,7 @@ export class BlockEngine extends BaseEngine {
     
     private smoothMin = 0;
     private smoothMax = 100;
+    private isFirstTrade = true;
     
     private readonly fibLevels = [0.0, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0];
     private dummyObj = new THREE.Object3D();
@@ -291,9 +292,11 @@ export class BlockEngine extends BaseEngine {
         this.blockScales[idx] = Math.max(Math.pow(trade.amount, 0.4) * (s.volumeScale || 1.0), 1.0);
         
         // CRITICAL FIX: Snap camera to price on first trade
-        if (this.smoothMin < 1.0 && trade.price > 100.0) {
-            this.smoothMin = trade.price - 20.0;
-            this.smoothMax = trade.price + 20.0;
+        if (this.isFirstTrade) {
+            const margin = Math.max(trade.price * 0.005, 0.0001); // proportional margin or absolute minimum
+            this.smoothMin = trade.price - margin;
+            this.smoothMax = trade.price + margin;
+            this.isFirstTrade = false;
         }
         
         const color = trade.type === 'buy' 
@@ -319,6 +322,7 @@ export class BlockEngine extends BaseEngine {
     }
 
     private cleanupResources() {
+        this.isFirstTrade = true;
          if (this.blockMesh) {
             this.blockMesh.geometry.dispose();
             (this.blockMesh.material as THREE.Material).dispose();

--- a/src/components/shared/backgrounds/engines/BlockEngine.ts
+++ b/src/components/shared/backgrounds/engines/BlockEngine.ts
@@ -195,15 +195,14 @@ export class BlockEngine extends BaseEngine {
              activeMax = this.smoothMax * 0.99 + 0.1;
         }
 
-        let range = activeMax - activeMin;
-        if (range < 0.1) range = 0.1;
-        
         // Smooth camera/bound movement
         this.smoothMin = this.smoothMin + (activeMin - this.smoothMin) * 0.05;
         this.smoothMax = this.smoothMax + (activeMax - this.smoothMax) * 0.05;
         
         const worldHeight = 60.0;
-        const heightScale = worldHeight / (this.smoothMax - this.smoothMin);
+        let range = this.smoothMax - this.smoothMin;
+        if (range < 0.1) range = 0.1;
+        const heightScale = worldHeight / range;
         const sizeBase = (s.size || 0.08) * 28.0; // Boosted
         const slabH = sizeBase * 0.15;
         const ageAttr = this.blockMesh.geometry.getAttribute('aAge') as THREE.BufferAttribute;
@@ -323,6 +322,16 @@ export class BlockEngine extends BaseEngine {
 
     private cleanupResources() {
         this.isFirstTrade = true;
+        this.smoothMin = 0;
+        this.smoothMax = 100;
+        this.nextBlockIdx = 0;
+        this.blockPrices.fill(0);
+        this.blockTimestamps.fill(0);
+        this.blockX.fill(0);
+        this.blockZ.fill(0);
+        this.blockRot.fill(0);
+        this.blockScales.fill(0);
+        this.blockTypes.fill(0);
          if (this.blockMesh) {
             this.blockMesh.geometry.dispose();
             (this.blockMesh.material as THREE.Material).dispose();


### PR DESCRIPTION
The camera snapping logic in `BlockEngine` incorrectly assumed that the first trade would always have a price greater than 100, and it used fixed static bounds (+/- 20). 
This PR introduces an `isFirstTrade` boolean flag to accurately capture the first trade, and establishes dynamic, proportional boundaries based on the actual price (while guaranteeing an absolute minimum margin). It also correctly resets the flag within `cleanupResources` to ensure the engine re-initializes cleanly.

---
*PR created automatically by Jules for task [10871088123746544880](https://jules.google.com/task/10871088123746544880) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
