### PR TITLE
Clean up redundant caching logic in service-worker

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -86,12 +86,7 @@ self.addEventListener("fetch", (event) => {
         throw new Error("invalid response from fetch");
       }
 
-      // CRITICAL FIX: Only cache static assets, NOT dynamic content
-      // This prevents Service Worker memory explosion from caching klines, news, API responses
-      const isCacheable =
-        response.status === 200 &&
-        ASSETS.includes(url.pathname) && // ONLY cache known static assets
-        !url.pathname.startsWith("/api/");
+      const isCacheable = response.status === 200 && ASSETS.includes(url.pathname);
 
       if (isCacheable) {
         cache.put(fetchEvent.request, response.clone()).catch((err) => {


### PR DESCRIPTION
The 'CRITICAL FIX' comment and the explicitly coded check for '!url.pathname.startsWith("/api/")' were removed from the 'isCacheable' assignment in 'service-worker.ts'. This logic was entirely redundant because:
1. An early return ('if (url.pathname.startsWith("/api/")) return;') completely bypasses caching logic for API paths.
2. The 'ASSETS.includes(url.pathname)' array explicitly strictly checks against known statically built assets, meaning it will never match an API endpoint or dynamic asset.

This simplifies the file without altering the intended caching behavior.

---
*PR created automatically by Jules for task [15515475085346392346](https://jules.google.com/task/15515475085346392346) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
