### PR TITLE
🧪 test: add missing tests for server HTTP security headers

### DIFF
--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { headersHandler } from './hooks.server';
+import type { RequestEvent } from '@sveltejs/kit';
+
+// Mock the dependencies
+vi.mock('$app/environment', () => ({
+  building: false
+}));
+
+vi.mock('$lib/server/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}));
+
+describe('headersHandler (Server Hook)', () => {
+  it('should set the expected HTTP security headers on the response', async () => {
+    // Arrange
+    const mockEvent = {} as RequestEvent;
+
+    // Create a standard Response to represent what resolve() would return
+    const mockResponse = new Response('test body', { status: 200 });
+
+    // Mock the resolve function to return the response
+    const mockResolve = vi.fn().mockResolvedValue(mockResponse);
+
+    // Act
+    const result = await headersHandler({ event: mockEvent, resolve: mockResolve });
+
+    // Assert
+    expect(mockResolve).toHaveBeenCalledWith(mockEvent);
+    expect(result).toBe(mockResponse);
+
+    // Check security headers
+    expect(result.headers.get('Cross-Origin-Opener-Policy')).toBe('same-origin-allow-popups');
+    expect(result.headers.get('Cross-Origin-Embedder-Policy')).toBe('credentialless');
+    expect(result.headers.get('X-Frame-Options')).toBe('SAMEORIGIN');
+    expect(result.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(result.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(result.headers.get('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=()');
+  });
+});

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -15,8 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { headersHandler } from './hooks.server';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 import type { RequestEvent } from '@sveltejs/kit';
 
 // Mock the dependencies
@@ -31,6 +30,22 @@ vi.mock('$lib/server/logger', () => ({
     error: vi.fn(),
   }
 }));
+
+// Save original console methods before the import patches them
+const originalLog = console.log;
+const originalWarn = console.warn;
+const originalError = console.error;
+
+// Import after mocks are set up (vi.mock calls are hoisted automatically)
+import { headersHandler } from './hooks.server';
+
+afterAll(() => {
+  // Restore the original console methods to prevent cross-test contamination
+  console.log = originalLog;
+  console.warn = originalWarn;
+  console.error = originalError;
+  delete (global as any)._isConsolePatched;
+});
 
 describe('headersHandler (Server Hook)', () => {
   it('should set the expected HTTP security headers on the response', async () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for the `headersHandler` SvelteKit middleware in `src/hooks.server.ts` has been fully addressed by introducing `src/hooks.server.test.ts`.
📊 **Coverage:** The scenario of asserting that all required security headers (COOP, COEP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy) are correctly appended to standard SvelteKit responses is now fully tested using Vitest and mock SvelteKit dependencies.
✨ **Result:** Test coverage for the core server hooks has significantly improved, providing a safety net to ensure future codebase refactoring won't regress our HTTP security posture.

---
*PR created automatically by Jules for task [14219500174219561139](https://jules.google.com/task/14219500174219561139) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
