### PR TITLE
🧹 Code health improvement: Remove unused import in JournalContent.svelte

### DIFF
--- a/src/components/shared/JournalContent.svelte
+++ b/src/components/shared/JournalContent.svelte
@@ -27,7 +27,7 @@
     import { icons } from "../../lib/constants";
     import { browser } from "$app/environment";
     import { getComputedColor } from "../../utils/colors";
-    import { formatDynamicDecimal } from "../../utils/utils";
+
     import DashboardNav from "./DashboardNav.svelte";
     import { Decimal } from "decimal.js";
     import { onMount, untrack } from "svelte";


### PR DESCRIPTION
🎯 What: Removed the unused import `formatDynamicDecimal` from `src/components/shared/JournalContent.svelte`.
💡 Why: Improves code maintainability and tidiness without affecting logic. Unused imports can clutter the file and occasionally hinder tree-shaking (though modern tools usually handle it).
✅ Verification: Ran `npm run check` and verified zero typescript/svelte diagnostics errors. Ran `npm run test` and ensured the change introduced no regressions in the relevant modules.
✨ Result: Cleaner imports in `JournalContent.svelte`.

---
*PR created automatically by Jules for task [11062830445413104811](https://jules.google.com/task/11062830445413104811) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
