### PR TITLE
🧹 [Code Health] Remove unused uiState import from FloatingIframeButton

### DIFF
--- a/src/components/shared/FloatingIframeButton.svelte
+++ b/src/components/shared/FloatingIframeButton.svelte
@@ -16,7 +16,6 @@
 -->
 
 <script lang="ts">
-    import { uiState } from "../../stores/ui.svelte";
     import { windowManager } from "../../lib/windows/WindowManager.svelte";
     import { ChannelWindow } from "../../lib/windows/implementations/ChannelWindow.svelte";
     import { _ } from "../../locales/i18n";


### PR DESCRIPTION
🎯 **What:** Removed an unused import `uiState` from `src/components/shared/FloatingIframeButton.svelte`.
💡 **Why:** Improves code cleanliness, removes unused dependencies, and resolves a static analysis warning.
✅ **Verification:** Ran `npm run check` successfully, verifying no type errors. Ran `npm run test` to ensure no regressions.
✨ **Result:** A cleaner, warning-free Svelte component.

---
*PR created automatically by Jules for task [11446243608525278059](https://jules.google.com/task/11446243608525278059) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
