### PR TITLE
🧹 Remove unused trackClick and Decimal imports in GeneralInputs.svelte

### DIFF
--- a/src/components/inputs/GeneralInputs.svelte
+++ b/src/components/inputs/GeneralInputs.svelte
@@ -22,9 +22,9 @@
   import { numberInput } from "../../utils/inputUtils";
   import { enhancedInput } from "../../lib/actions/inputEnhancements";
   import { _ } from "../../locales/i18n";
-  import { trackClick } from "../../lib/actions";
+
   import { trackCustomEvent } from "../../services/trackingService";
-  import { Decimal } from "decimal.js";
+
 
   interface Props {
     tradeType: string;


### PR DESCRIPTION
🎯 **What:** The `trackClick` and `Decimal` imports in `src/components/inputs/GeneralInputs.svelte` were found to be completely unused within the component.
💡 **Why:** Removing dead code makes the file cleaner, prevents confusion, and is a good hygiene practice for long-term maintainability.
✅ **Verification:** Verified that `trackClick` and `Decimal` are nowhere used in `GeneralInputs.svelte`. Ran `npm run check` without errors, and created a visual Playwright script to verify that the UI renders correctly.
✨ **Result:** A cleaner component with unused imports removed, leaving functionality completely intact.

---
*PR created automatically by Jules for task [10180000032446325612](https://jules.google.com/task/10180000032446325612) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
