### PR TITLE
🧹 Clean up unused imports in FloatingIframeButton.svelte

### DIFF
--- a/src/components/shared/FloatingIframeButton.svelte
+++ b/src/components/shared/FloatingIframeButton.svelte
@@ -18,8 +18,7 @@
 <script lang="ts">
     import { windowManager } from "../../lib/windows/WindowManager.svelte";
     import { ChannelWindow } from "../../lib/windows/implementations/ChannelWindow.svelte";
-    import { _ } from "../../locales/i18n";
-    import { fade, scale } from "svelte/transition";
+    import { scale } from "svelte/transition";
 
     // Derived state to check if main window ("genesis") is open
     let isGenesisOpen = $derived(


### PR DESCRIPTION
🎯 **What:** Removed the unused `_` and `fade` imports from `src/components/shared/FloatingIframeButton.svelte`.
💡 **Why:** Improves code maintainability and readability by eliminating dead code. (Note: The originally requested `uiState` import was not found in the file, so the actual unused imports were removed).
✅ **Verification:** Ran `npm run check` and verified the frontend visually with a playwright screenshot. Tests were run and did not introduce new errors.
✨ **Result:** Cleaner component file with no change in functionality.

---
*PR created automatically by Jules for task [3913992330086194971](https://jules.google.com/task/3913992330086194971) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
