### PR TITLE
🧹 [code health improvement] Removed leftover debugging console log

### DIFF
--- a/src/lib/windows/implementations/CandleChartView.svelte
+++ b/src/lib/windows/implementations/CandleChartView.svelte
@@ -402,12 +402,6 @@
                                 : null;
                         lastRenderedCount = unique.length;
 
-                        if (import.meta.env.DEV) {
-                            const timeScale = chart.timeScale();
-                            const currentRange = timeScale.getVisibleLogicalRange();
-                            console.log(`[Chart Render] ${symbol}:${timeframe} Unique: ${unique.length}. First: ${new Date(Number(unique[0].time)*1000).toLocaleString()}. Range: ${JSON.stringify(currentRange)}`);
-                        }
-
                         // Update Indicators if enabled
                         if (
                             indicatorsEnabled &&


### PR DESCRIPTION
🎯 **What:** Removed the `import.meta.env.DEV` debugging block and its `console.log` from `src/lib/windows/implementations/CandleChartView.svelte`.
💡 **Why:** Leftover console logs in rendering loops add unnecessary noise and reduce maintainability. Removing them improves code readability.
✅ **Verification:** Ran `npm run check` to verify Svelte diagnostics and types are intact. `npm run test` ran (unrelated failures exist but Svelte components render fine).
✨ **Result:** Cleaner rendering function without debug overhead.

---
*PR created automatically by Jules for task [15969025863131146400](https://jules.google.com/task/15969025863131146400) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
