### PR TITLE
🧹 Remove unused 'untrack' import in CandlestickChart.svelte

### DIFF
--- a/src/components/shared/CandlestickChart.svelte
+++ b/src/components/shared/CandlestickChart.svelte
@@ -16,7 +16,7 @@
 -->
 
 <script lang="ts">
-  import { onMount, untrack } from "svelte";
+  import { onMount } from "svelte";
   import { Chart, type ChartConfiguration, type Plugin } from "chart.js";
   import { browser } from "$app/environment";
   import "../../lib/chartSetup"; // Ensure Chart.js defaults are loaded


### PR DESCRIPTION
🎯 **What:** Removed the unused `untrack` import from `svelte` in `src/components/shared/CandlestickChart.svelte`.
💡 **Why:** This improves maintainability, cleans up the module scope, and reduces bundler/linter noise by removing dead code. The behavior of the application is untouched.
✅ **Verification:** Ran `npm run check` and `npm run test` successfully. Verified visually that `untrack` was unused anywhere in the file.
✨ **Result:** Improved code hygiene.

---
*PR created automatically by Jules for task [2610858014929177322](https://jules.google.com/task/2610858014929177322) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
