### PR TITLE
🧹 fix(components): remove unused settingsState import in SettingsContent.svelte

### DIFF
--- a/src/components/settings/SettingsContent.svelte
+++ b/src/components/settings/SettingsContent.svelte
@@ -16,7 +16,6 @@
 -->
 
 <script lang="ts">
-    import { settingsState } from "../../stores/settings.svelte";
     import { uiState } from "../../stores/ui.svelte";
     import { modalState } from "../../stores/modal.svelte";
     import { _ } from "../../locales/i18n";


### PR DESCRIPTION
* 🎯 **What:** Removed an unused import of `settingsState` from `src/components/settings/SettingsContent.svelte`
* 💡 **Why:** Reduces unused code, improves linting and code hygiene, without affecting behavior.
* ✅ **Verification:** Checked with `npm run check` and successfully rendered page without crashes. Test suite passed with no regressions on the removed code.
* ✨ **Result:** Codebase is slightly cleaner.

---
*PR created automatically by Jules for task [13190809407019873252](https://jules.google.com/task/13190809407019873252) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
