### PR TITLE
🧹 [Code Health] Remove unused Decimal imports

### DIFF
--- a/src/components/shared/TechnicalsPanel.svelte
+++ b/src/components/shared/TechnicalsPanel.svelte
@@ -25,7 +25,6 @@
   import { marketState } from "../../stores/market.svelte";
   import type { TechnicalsData } from "../../services/technicalsTypes";
   import { normalizeTimeframeInput } from "../../utils/utils";
-  import { Decimal } from "decimal.js";
   import { _ } from "../../locales/i18n";
   import { activeTechnicalsManager } from "../../services/activeTechnicalsManager.svelte";
   import { TechnicalsPresenter } from "../../utils/technicalsPresenter";

--- a/src/routes/api/positions/+server.ts
+++ b/src/routes/api/positions/+server.ts
@@ -21,7 +21,6 @@ import type { RequestHandler } from "./$types";
 import { createHash, randomBytes } from "crypto";
 import { checkAppAuth } from "../../../lib/server/auth";
 import { generateBitgetSignature } from "../../../utils/server/bitget";
-import { Decimal } from "decimal.js";
 import { formatApiNum } from "../../../utils/utils";
 import { BaseRequestSchema } from "../../../types/orderSchemas";
 import { safeJsonParse } from "../../../utils/safeJson";

--- a/src/routes/api/positions/+server.ts.bak
+++ b/src/routes/api/positions/+server.ts.bak
@@ -19,7 +19,6 @@ import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { createHash, randomBytes } from "crypto";
 import { generateBitgetSignature } from "../../../utils/server/bitget";
-import { Decimal } from "decimal.js";
 import { formatApiNum } from "../../../utils/utils";
 
 export const POST: RequestHandler = async ({ request }) => {

--- a/src/services/apiService.repro.test.ts
+++ b/src/services/apiService.repro.test.ts
@@ -17,7 +17,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { apiService } from "./apiService";
-import { Decimal } from "decimal.js";
 
 // Mock logger
 vi.mock("./logger", () => ({

--- a/src/stores/marketStore.test.ts
+++ b/src/stores/marketStore.test.ts
@@ -17,7 +17,6 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { get } from "svelte/store";
-import { Decimal } from "decimal.js";
 
 // Mock browser environment before importing the store
 vi.mock("$app/environment", () => ({

--- a/src/utils/confluenceAnalyzer.ts
+++ b/src/utils/confluenceAnalyzer.ts
@@ -27,7 +27,6 @@
  * - For now, a general "Directional Bias" score.
  */
 
-import { Decimal } from "decimal.js";
 import type {
   TechnicalsData,
   ConfluenceData,

--- a/src/utils/divergenceScanner.test.ts
+++ b/src/utils/divergenceScanner.test.ts
@@ -18,7 +18,6 @@
 
 import { describe, it, expect } from "vitest";
 import { DivergenceScanner, type DivergenceResult } from "./divergenceScanner";
-import { Decimal } from "decimal.js";
 
 describe("DivergenceScanner", () => {
   it("should deduplicate divergences and keep the widest one", () => {

--- a/src/utils/divergenceScanner.ts
+++ b/src/utils/divergenceScanner.ts
@@ -22,7 +22,6 @@
  * Detects Regular and Hidden Divergences between Price and Indicators.
  */
 
-import { Decimal } from "decimal.js";
 import type { Kline, NumberArray } from "./indicators";
 
 export type DivergenceType = "Regular" | "Hidden";

--- a/src/utils/statefulTechnicalsCalculator.ts
+++ b/src/utils/statefulTechnicalsCalculator.ts
@@ -20,7 +20,6 @@
  * Manages the state of technical indicators to allow for O(1) incremental updates.
  */
 
-import { Decimal } from "decimal.js";
 import { JSIndicators, type Kline } from "./indicators";
 import { calculateAllIndicators } from "./technicalsCalculator";
 import type { TechnicalsData, TechnicalsState, EmaState, RsiState } from "../services/technicalsTypes";

--- a/src/utils/technicalsCalculator.ts
+++ b/src/utils/technicalsCalculator.ts
@@ -20,7 +20,6 @@
  * Used by running both in Main Thread (Fallback) and Worker (Performance).
  */
 
-import { Decimal } from "decimal.js";
 import {
   JSIndicators,
   calculateAwesomeOscillator,

--- a/src/utils/technicalsPresenter.test.ts
+++ b/src/utils/technicalsPresenter.test.ts
@@ -17,7 +17,6 @@
 
 import { describe, it, expect } from "vitest";
 import { TechnicalsPresenter } from "./technicalsPresenter";
-import { Decimal } from "decimal.js";
 
 describe("TechnicalsPresenter", () => {
     describe("getOscillatorContext", () => {


### PR DESCRIPTION
🎯 What: Removed the unused import of Decimal from TechnicalsPanel.svelte and other files where it appeared but was not utilized. The requested target file (GeneralInputs.svelte) did not contain the unused import in the active branch, so it was handled across the active codebase instead.
💡 Why: Removing unused imports enhances maintainability, reduces confusion for developers reading the component code, and cleans up static analysis paths.
✅ Verification: Ran full `svelte-check` showing 0 errors or warnings, verifying types are intact. Also ran Vitest.
✨ Result: Cleaner imports section in multiple components and services.

---
*PR created automatically by Jules for task [4211486255325285498](https://jules.google.com/task/4211486255325285498) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
