### PR TITLE
🧹 [Code Health] Use native fs/promises import to resolve unused warnings

### DIFF
--- a/src/lib/server/chatStore.test.ts
+++ b/src/lib/server/chatStore.test.ts
@@ -18,14 +18,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { chatStore } from './chatStore';
 import type { ChatMessage } from './chatStore';
-import { promises as fs } from 'fs';
+import fs from 'fs/promises';
 
-vi.mock('fs', () => ({
-  promises: {
-    readFile: vi.fn(),
-    writeFile: vi.fn().mockResolvedValue(undefined),
-    mkdir: vi.fn().mockResolvedValue(undefined),
-    rename: vi.fn().mockResolvedValue(undefined),
+vi.mock('fs/promises', () => ({
+  default: {
+
+  readFile: vi.fn(),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
   }
 }));
 

--- a/src/lib/server/chatStore.test.ts
+++ b/src/lib/server/chatStore.test.ts
@@ -22,11 +22,10 @@ import fs from 'fs/promises';
 
 vi.mock('fs/promises', () => ({
   default: {
-
-  readFile: vi.fn(),
-  writeFile: vi.fn().mockResolvedValue(undefined),
-  mkdir: vi.fn().mockResolvedValue(undefined),
-  rename: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn(),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    rename: vi.fn().mockResolvedValue(undefined),
   }
 }));
 

--- a/src/lib/server/chatStore.ts
+++ b/src/lib/server/chatStore.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { promises as fs } from "fs";
+import fs from "fs/promises";
 import path from "path";
 import { z } from "zod";
 

--- a/src/routes/api/chat-v2/server.test.ts
+++ b/src/routes/api/chat-v2/server.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { promises as fs } from "fs";
+import fs from "fs/promises";
 
 // Mock auth to bypass checks
 vi.mock("../../../lib/server/auth", () => ({


### PR DESCRIPTION
🎯 **What:** Changed `import { promises as fs } from "fs";` to `import fs from "fs/promises";` in `chatStore.ts` and its related test files.
💡 **Why:** `import { promises as fs } from "fs"` correctly imported the file system promises object, but many static analysis tools inaccurately flag the unused `promises` component of the destructor alias. A more modern standard for Node is utilizing `import fs from "fs/promises"` which directly binds the default export, resolving the static analysis warnings, while keeping code clean.
✅ **Verification:** Verified all functionality using the `npx vitest run src/lib/server/chatStore.test.ts src/routes/api/chat-v2/server.test.ts` unit tests along with `npm run check`.
✨ **Result:** Enhanced source code maintainability by eliminating a false-positive unused import warning without regressions.

---
*PR created automatically by Jules for task [5541962215067702936](https://jules.google.com/task/5541962215067702936) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
