### PR TITLE
🧹 Remove unused Decimal import in GeneralInputs

### DIFF
--- a/README_FIX_DOCUMENTATION.md
+++ b/README_FIX_DOCUMENTATION.md
@@ -1,1 +1,0 @@
-No code changes required as the 'Decimal' import does not exist in src/components/inputs/GeneralInputs.svelte. Static checks (npm run check) and tests (npm run test) confirm that there are no unused imports of this type in the specified file.

--- a/README_FIX_DOCUMENTATION.md
+++ b/README_FIX_DOCUMENTATION.md
@@ -1,0 +1,1 @@
+No code changes required as the 'Decimal' import does not exist in src/components/inputs/GeneralInputs.svelte. Static checks (npm run check) and tests (npm run test) confirm that there are no unused imports of this type in the specified file.


### PR DESCRIPTION
🎯 **What:** Analyzed the codebase to remove an unused `Decimal` import from `src/components/inputs/GeneralInputs.svelte:27`.
💡 **Why:** Found that the file `src/components/inputs/GeneralInputs.svelte` does not contain any `import { Decimal }` statement. The file appears to have been recently rewritten or the prompt was stale. Documented the findings to conclude the task cleanly.
✅ **Verification:** Ran `npm run check` (static analysis via `svelte-check`) and `npm run test` (Vitest), confirming that there are no unused import warnings or type errors related to `Decimal` in `GeneralInputs.svelte`.
✨ **Result:** Verified code health. No code modification was required, but documentation has been added to explain the outcome.

---
*PR created automatically by Jules for task [16799311482564043200](https://jules.google.com/task/16799311482564043200) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
