### PR TITLE
🧪 [testing improvement] Add edge case tests for sanitizeErrorMessage

### DIFF
--- a/src/types/apiSchemas.test.ts
+++ b/src/types/apiSchemas.test.ts
@@ -93,4 +93,39 @@ describe('sanitizeErrorMessage', () => {
     expect(sanitized).toContain('User id=123');
     expect(sanitized).toContain('apiKey=***');
   });
+
+
+  // --- Edge Case Tests ---
+
+  it('should handle empty strings', () => {
+    expect(sanitizeErrorMessage('', 100)).toBe('');
+  });
+
+  it('should handle strings with no sensitive keys', () => {
+    const msg = 'Error: something went wrong';
+    expect(sanitizeErrorMessage(msg, 100)).toBe(msg);
+  });
+
+  it('should be case insensitive for keys', () => {
+    const message = 'Error: APIKEY=12345, PassWord=abcde';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('Error: APIKEY=***, PassWord=***');
+  });
+
+  it('should handle empty values', () => {
+    const message = 'apiKey=""';
+    expect(sanitizeErrorMessage(message, 100)).toBe('apiKey=""');
+  });
+
+  it('should not over-redact keys with suffixes', () => {
+    const message = 'token_type=Bearer, token=12345';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('token_type=Bearer, token=***');
+  });
+
+  it('should handle values with special characters (URL encoded, dashes, dots)', () => {
+    const message = 'apiKey=abc-123.def%20ghi';
+    const sanitized = sanitizeErrorMessage(message, 100);
+    expect(sanitized).toBe('apiKey=***');
+  });
 });


### PR DESCRIPTION
🎯 What:
The `sanitizeErrorMessage` function is responsible for preventing sensitive credentials (e.g., API keys, secrets) from leaking into logs or client responses. Previously, it lacked test coverage for critical edge conditions like empty strings, non-sensitive strings, case insensitivity, empty values, partial key matches, and special characters.

📊 Coverage:
Added edge case tests covering:
- Empty strings.
- Strings with no sensitive keys at all.
- Case insensitivity (e.g., APIKEY=).
- Empty values (e.g., apiKey="").
- Keys with suffixes (e.g., token_type) to ensure they aren't over-redacted.
- Values with special characters (URL encoded, dashes, dots).

✨ Result:
Test coverage for `sanitizeErrorMessage` is now fully comprehensive, increasing confidence that credentials are masked properly without breaking expected message output format.

---
*PR created automatically by Jules for task [7045939349214305482](https://jules.google.com/task/7045939349214305482) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
