### PR TITLE
🧪 Add comprehensive edge case tests for safeTfToMs

### DIFF
--- a/src/utils/timeUtils.test.ts
+++ b/src/utils/timeUtils.test.ts
@@ -26,6 +26,8 @@ describe('safeTfToMs', () => {
         expect(safeTfToMs('4h')).toBe(14400000);
         expect(safeTfToMs('1d')).toBe(86400000);
         expect(safeTfToMs('1w')).toBe(604800000);
+        expect(safeTfToMs('1M')).toBe(2592000000);
+        expect(safeTfToMs('01m')).toBe(60000); // Leading zeros
     });
 
     it('should return default for invalid formats', () => {
@@ -33,10 +35,21 @@ describe('safeTfToMs', () => {
         expect(safeTfToMs('invalid')).toBe(60000);
         expect(safeTfToMs('1x')).toBe(60000); // Invalid unit
         expect(safeTfToMs('-1m')).toBe(60000); // Negative not matched by regex
+        expect(safeTfToMs('0m')).toBe(60000); // Zero value falls back to default
+        expect(safeTfToMs('1.5m')).toBe(60000); // Floats not matched by regex
+        expect(safeTfToMs(' 1m')).toBe(60000); // Leading space not matched by regex
+        expect(safeTfToMs('1 m')).toBe(60000); // Inner space not matched by regex
     });
 
     it('should return default for non-string inputs', () => {
         expect(safeTfToMs(null as any)).toBe(60000);
         expect(safeTfToMs(undefined as any)).toBe(60000);
+    });
+
+    it('should respect custom defaultMs argument', () => {
+        expect(safeTfToMs('invalid', 12345)).toBe(12345);
+        expect(safeTfToMs('', 1000)).toBe(1000);
+        expect(safeTfToMs('0m', 2000)).toBe(2000);
+        expect(safeTfToMs(null as any, 5000)).toBe(5000);
     });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `safeTfToMs` function converts timeframe string inputs to millisecond intervals. While the 'm', 'h', 'd', and 'w' units were tested, edge cases and boundary conditions lacked coverage. Specifically missing were the tests for the 'M' (Month) unit, handling of custom `defaultMs` fallbacks, floats, spacing anomalies, leading zeros, and strict adherence to zero-value handling (`'0m'`).

📊 **Coverage:** What scenarios are now tested
- The `M` (Month) timeframe unit logic (`'1M'` computes to 2,592,000,000 ms).
- Graceful degradation and exact returns of the user-provided `defaultMs` argument when inputs are invalid.
- Rejected boundary values: `'0m'` (zeros), `'1.5m'` (floats), `' 1m'` (leading space), and `'1 m'` (inner space).
- Preserved validity of valid anomalies like `'01m'` (leading zeros).

✨ **Result:** The improvement in test coverage
The unit test suite for `timeUtils` now provides complete deterministic safety over the entirety of the regular expression string parser branch. This guarantees confidence in any future `timeUtils` modifications, preventing unintended behavior on boundary timeframe configurations or custom timeframe fallbacks.

---
*PR created automatically by Jules for task [13071411943303691729](https://jules.google.com/task/13071411943303691729) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
