### PR TITLE
🧪 Add tests for requestUtils API credential extraction

### DIFF
--- a/src/utils/server/requestUtils.test.ts
+++ b/src/utils/server/requestUtils.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractApiCredentials } from './requestUtils';
+
+describe('extractApiCredentials', () => {
+    it('should return undefined when no credentials are provided', () => {
+        const request = new Request('http://localhost');
+        const result = extractApiCredentials(request);
+
+        expect(result).toEqual({
+            apiKey: undefined,
+            apiSecret: undefined,
+            passphrase: undefined
+        });
+    });
+
+    it('should extract credentials from headers', () => {
+        const headers = new Headers();
+        headers.set('x-api-key', 'header-key');
+        headers.set('x-api-secret', 'header-secret');
+        headers.set('x-api-passphrase', 'header-passphrase');
+
+        const request = new Request('http://localhost', { headers });
+        const result = extractApiCredentials(request);
+
+        expect(result).toEqual({
+            apiKey: 'header-key',
+            apiSecret: 'header-secret',
+            passphrase: 'header-passphrase'
+        });
+    });
+
+    it('should extract credentials from body if headers are missing', () => {
+        const request = new Request('http://localhost');
+        const body = {
+            apiKey: 'body-key',
+            apiSecret: 'body-secret',
+            passphrase: 'body-passphrase'
+        };
+        const result = extractApiCredentials(request, body);
+
+        expect(result).toEqual({
+            apiKey: 'body-key',
+            apiSecret: 'body-secret',
+            passphrase: 'body-passphrase'
+        });
+    });
+
+    it('should prefer headers over body when both are provided', () => {
+        const headers = new Headers();
+        headers.set('x-api-key', 'header-key');
+        headers.set('x-api-passphrase', 'header-passphrase');
+        // apiSecret is missing from headers
+
+        const request = new Request('http://localhost', { headers });
+        const body = {
+            apiKey: 'body-key', // Should be ignored in favor of header
+            apiSecret: 'body-secret', // Should be used since header is missing
+            passphrase: 'body-passphrase' // Should be ignored in favor of header
+        };
+        const result = extractApiCredentials(request, body);
+
+        expect(result).toEqual({
+            apiKey: 'header-key',
+            apiSecret: 'body-secret',
+            passphrase: 'header-passphrase'
+        });
+    });
+
+    it('should safely handle non-object body types', () => {
+        const request = new Request('http://localhost');
+
+        expect(extractApiCredentials(request, null)).toEqual({
+            apiKey: undefined,
+            apiSecret: undefined,
+            passphrase: undefined
+        });
+
+        expect(extractApiCredentials(request, "just a string")).toEqual({
+            apiKey: undefined,
+            apiSecret: undefined,
+            passphrase: undefined
+        });
+
+        expect(extractApiCredentials(request, 123)).toEqual({
+            apiKey: undefined,
+            apiSecret: undefined,
+            passphrase: undefined
+        });
+    });
+
+    it('should convert body properties to strings', () => {
+        const request = new Request('http://localhost');
+        const body = {
+            apiKey: 12345,
+            apiSecret: true,
+            passphrase: { nested: 'value' }
+        };
+        const result = extractApiCredentials(request, body);
+
+        expect(result).toEqual({
+            apiKey: '12345',
+            apiSecret: 'true',
+            passphrase: '[object Object]'
+        });
+    });
+});

--- a/src/utils/server/requestUtils.test.ts
+++ b/src/utils/server/requestUtils.test.ts
@@ -97,6 +97,37 @@ describe('extractApiCredentials', () => {
         });
     });
 
+    it('should safely handle array body type', () => {
+        const request = new Request('http://localhost');
+
+        expect(extractApiCredentials(request, ['a', 'b'])).toEqual({
+            apiKey: undefined,
+            apiSecret: undefined,
+            passphrase: undefined
+        });
+    });
+
+    it('should fall back to body when header is empty string', () => {
+        const headers = new Headers();
+        headers.set('x-api-key', '');
+        headers.set('x-api-secret', '');
+        headers.set('x-api-passphrase', '');
+
+        const request = new Request('http://localhost', { headers });
+        const body = {
+            apiKey: 'body-key',
+            apiSecret: 'body-secret',
+            passphrase: 'body-passphrase'
+        };
+        const result = extractApiCredentials(request, body);
+
+        expect(result).toEqual({
+            apiKey: 'body-key',
+            apiSecret: 'body-secret',
+            passphrase: 'body-passphrase'
+        });
+    });
+
     it('should convert body properties to strings', () => {
         const request = new Request('http://localhost');
         const body = {


### PR DESCRIPTION
🎯 **What:** Added a missing test suite for `src/utils/server/requestUtils.ts`.

📊 **Coverage:**
- Empty headers/body inputs
- Pure header extractions
- Pure body fallback extractions
- Header vs Body precedence
- Edge cases with non-object body inputs
- Conversion of numeric properties to strings in body payloads

✨ **Result:** Ensured API credential extraction logic behaves robustly across valid and malformed requests, increasing coverage and confidence against regressions.

---
*PR created automatically by Jules for task [10036416983421750548](https://jules.google.com/task/10036416983421750548) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
