### PR TITLE
🧹 fix: replace empty catch blocks with logging in engineBenchmark

### DIFF
--- a/src/services/engineBenchmark.ts
+++ b/src/services/engineBenchmark.ts
@@ -28,6 +28,7 @@ import { calculationStrategy } from './calculationStrategy';
 import { calculateIndicatorsFromArrays } from '../utils/technicalsCalculator';
 import { indicatorState } from '../stores/indicator.svelte';
 import type { IndicatorSettings } from '../types/indicators';
+import { logger } from './logger';
 
 export interface BenchmarkRun {
   engine: 'ts' | 'wasm' | 'gpu';
@@ -126,7 +127,8 @@ export async function benchmarkEngine(
       } else {
         return []; // Engine not available
       }
-    } catch {
+    } catch (e) {
+      logger.error('technicals', `Engine ${engine} failed during benchmark`, e);
       return []; // Engine failed
     }
 
@@ -158,12 +160,16 @@ export async function runBenchmark(
   try {
       const { wasmCalculator } = await import('./wasmCalculator');
       if (wasmCalculator.isAvailable()) engines.push('wasm');
-  } catch(e) {}
+  } catch (e) {
+      logger.debug('technicals', 'Failed to load wasmCalculator', e);
+  }
   
   try {
       const { WebGpuCalculator } = await import('./webGpuCalculator');
       if (await WebGpuCalculator.isSupported()) engines.push('gpu');
-  } catch(e) {}
+  } catch (e) {
+      logger.debug('technicals', 'Failed to load WebGpuCalculator', e);
+  }
 
   for (const size of sizes) {
     const klines = generateTestKlines(size);

--- a/src/services/engineBenchmark.ts
+++ b/src/services/engineBenchmark.ts
@@ -25,7 +25,6 @@
 
 import { technicalsService } from './technicalsService';
 import { calculationStrategy } from './calculationStrategy';
-import { calculateIndicatorsFromArrays } from '../utils/technicalsCalculator';
 import { indicatorState } from '../stores/indicator.svelte';
 import type { IndicatorSettings } from '../types/indicators';
 import { logger } from './logger';


### PR DESCRIPTION
This PR addresses the code health issue of empty catch blocks in `src/services/engineBenchmark.ts`.

🎯 **What:** 
- Replaced three empty catch blocks with appropriate logging using the centralized `logger` service.
- Optional engine loading (WASM, WebGPU) now logs at `debug` level on failure.
- Core benchmark execution failures now log at `error` level.

💡 **Why:** 
Empty catch blocks hide potential issues and make debugging difficult. Proper logging ensures that failures in engine loading or execution are visible in the logs, improving maintainability and observability.

✅ **Verification:** 
The changes were verified by inspecting the source code after applying the edits. Manual verification confirmed that the imports are correct and the catch blocks are properly implemented with error parameters. Full test suite execution was attempted but skipped due to sandbox environment limitations (network timeouts during dependency installation).

✨ **Result:** 
Improved error visibility and maintainability in the benchmark utility.

---
*PR created automatically by Jules for task [1693833166911477512](https://jules.google.com/task/1693833166911477512) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
