### PR TITLE
🔒 [security] Sanitize Markdown rendering in CandlestickPatternsView

### DIFF
--- a/src/components/shared/CandlestickPatternsView.svelte
+++ b/src/components/shared/CandlestickPatternsView.svelte
@@ -23,7 +23,7 @@
         type PatternDefinition,
     } from "../../services/candlestickPatterns";
     import CandlestickChart from "./CandlestickChart.svelte";
-    import { renderTrustedMarkdown } from "../../utils/markdownUtils";
+    import { markdown } from "../../actions/markdown";
     import { safeJsonParse } from "../../utils/safeJson";
     import "katex/dist/katex.min.css";
 
@@ -119,9 +119,6 @@
         return text;
     }
 
-    function renderMarkdown(text: string) {
-        return renderTrustedMarkdown(text);
-    }
 </script>
 
 <div class="flex flex-col md:flex-row h-full gap-4">
@@ -292,14 +289,13 @@
                         >
                             {$_("chartPatterns.description")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderMarkdown(
-                                getLocalizedText(
-                                    currentPattern.id,
-                                    "description",
-                                ),
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern.id,
+                                "description",
                             )}
-                        </div>
+                        ></div>
                     </div>
                 </div>
 
@@ -314,14 +310,13 @@
                         >
                             {$_("chartPatterns.tradingStrategy")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderMarkdown(
-                                getLocalizedText(
-                                    currentPattern.id,
-                                    "indicatorCombination",
-                                ) || "No specific strategy data available.",
-                            )}
-                        </div>
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern.id,
+                                "indicatorCombination",
+                            ) || "No specific strategy data available."}
+                        ></div>
                     </div>
 
                     <!-- Interpretation -->
@@ -333,14 +328,13 @@
                         >
                             {$_("chartPatterns.interpretation")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderMarkdown(
-                                getLocalizedText(
-                                    currentPattern.id,
-                                    "interpretation",
-                                ),
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern.id,
+                                "interpretation",
                             )}
-                        </div>
+                        ></div>
                     </div>
                 </div>
             </div>

--- a/src/components/shared/ChartPatternsView.svelte
+++ b/src/components/shared/ChartPatternsView.svelte
@@ -20,7 +20,7 @@
     import { _ } from "../../locales/i18n";
     import { CHART_PATTERNS } from "../../services/chartPatterns";
     import ChartPatternChart from "./ChartPatternChart.svelte";
-    import { renderTrustedMarkdown } from "../../utils/markdownUtils";
+    import { markdown } from "../../actions/markdown";
     import { safeJsonParse } from "../../utils/safeJson";
     import "katex/dist/katex.min.css";
 
@@ -295,11 +295,13 @@
                         >
                             {$_("chartPatterns.description")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderTrustedMarkdown(
-                                getLocalizedText(currentPattern, "description"),
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern,
+                                "description",
                             )}
-                        </div>
+                        ></div>
 
                         <!-- Characteristics -->
                         <h3
@@ -328,11 +330,13 @@
                         >
                             {$_("chartPatterns.tradingStrategy")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderTrustedMarkdown(
-                                getLocalizedText(currentPattern, "trading"),
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern,
+                                "trading",
                             )}
-                        </div>
+                        ></div>
                     </div>
 
                     <!-- Interpretation / Advanced -->
@@ -344,28 +348,26 @@
                         >
                             {$_("chartPatterns.interpretation")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderTrustedMarkdown(
-                                getLocalizedText(
-                                    currentPattern,
-                                    "advancedConsiderations",
-                                ),
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern,
+                                "advancedConsiderations",
                             )}
-                        </div>
+                        ></div>
 
                         <h3
                             class="text-sm font-bold uppercase text-[var(--text-secondary)] mt-4 mb-2"
                         >
                             {$_("chartPatterns.performance")}
                         </h3>
-                        <div class="prose dark:prose-invert text-sm max-w-none">
-                            {@html renderTrustedMarkdown(
-                                getLocalizedText(
-                                    currentPattern,
-                                    "performanceStats",
-                                ),
+                        <div
+                            class="prose dark:prose-invert text-sm max-w-none"
+                            use:markdown={getLocalizedText(
+                                currentPattern,
+                                "performanceStats",
                             )}
-                        </div>
+                        ></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
🎯 **What:** Fixed an unsanitized Markdown rendering vulnerability in `CandlestickPatternsView.svelte`.

⚠️ **Risk:** The previous implementation used `renderTrustedMarkdown` via `{@html}`, which explicitly bypasses client-side DOMPurify. This could allow XSS if the pattern descriptions (translation text or database-sourced) were compromised.

🛡️ **Solution:** Switched to the standard `markdown` Svelte action (`use:markdown`), which uses `renderSafeMarkdown` (including DOMPurify) and safely injects a `DocumentFragment` to prevent mXSS. Removed the obsolete local `renderMarkdown` helper and insecure `renderTrustedMarkdown` import.

---
*PR created automatically by Jules for task [11258639705103622296](https://jules.google.com/task/11258639705103622296) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
