### PR TITLE
Fix localSymbol input clearing snap-back

### DIFF
--- a/src/components/inputs/TradeSetupInputs.svelte
+++ b/src/components/inputs/TradeSetupInputs.svelte
@@ -72,6 +72,7 @@
 
   // Local state for input to prevent immediate store updates
   let localSymbol = $state(symbol || "");
+  let lastPropSymbol = $state(symbol); // Track prop for external changes
   let isSymbolFocused = $state(false);
   let selectedSuggestionIndex = $state(-1);
 
@@ -120,8 +121,21 @@
     const currentFocused = isSymbolFocused;
 
     untrack(() => {
-      // Only update local from props if user is NOT focused
+      // 1. If prop changed externally (e.g. Preset), always sync even if focused
+      if (currentSymbol !== lastPropSymbol) {
+        localSymbol = currentSymbol || "";
+        lastPropSymbol = currentSymbol;
+        return;
+      }
+
+      // 2. Standard sync when NOT focused
       if (!currentFocused && currentSymbol !== localSymbol) {
+        // FIX: If user cleared the input, do NOT snap back to old prop value.
+        // The debounce will eventually update the prop/store to empty.
+        if (localSymbol === "" && currentSymbol !== "") {
+          return;
+        }
+
         localSymbol = currentSymbol || "";
       }
     });


### PR DESCRIPTION
Addresses the UI bug where clearing the symbol input field would cause it to "snap back" to its previous value when focus was lost or before the debounced store update finished.

Changes:
- Added `lastPropSymbol` state to `TradeSetupInputs.svelte`.
- Updated the `$effect` for symbol synchronization:
    - Explicitly sync if the prop changes externally (compares with `lastPropSymbol`).
    - Guard against overwriting `localSymbol` with the prop if `localSymbol` is currently an empty string.
- Verified logic via a standalone Node.js simulation script covering edge cases (focused/unfocused clearing, external overrides).

---
*PR created automatically by Jules for task [7395495404214918389](https://jules.google.com/task/7395495404214918389) started by @mydcc*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mydcc/cachy-app/pull/1424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
