### PR TITLE
docs: generate read-only code analysis report

### DIFF
--- a/report.md
+++ b/report.md
@@ -5,63 +5,54 @@
 ### 🔴 CRITICAL (Risk of financial loss, crash, or security vulnerability)
 
 1.  **Type Safety & Validation in Execution Paths (`src/services/tradeService.ts`)**:
-    *   **Finding**: Critical order execution functions rely heavily on `any` types. Specifically, `cancelTpSlOrder(order: any)` accepts untyped parameters, bypassing the TypeScript compiler entirely.
-    *   **Risk**: The backend might receive malformed execution payloads (e.g., missing `orderId` or `symbol`), resulting in silently failed cancellations while the frontend assumes success.
-    *   **Impact**: Financial loss if a user attempts to cancel a stop-loss or take-profit order, but it executes anyway due to a malformed payload.
+    *   **Finding**: Order fetching and serialization mechanisms heavily rely on `any` and `unknown` casting incorrectly (`let data: any = {}`, `params: any = {}`).
+    *   **Risk**: The application may silently fail to type-check payload constructions (e.g. `cancelTpSlOrder` returning untyped responses or properties bypassing safety nets).
+    *   **Impact**: Data inconsistencies could lead to unverified orders appearing on the platform.
 
-2.  **Generic API Serialization Risk (`src/services/tradeService.ts`)**:
-    *   **Finding**: The `signedRequest` method accepts `payload: Record<string, any>` and serializes it using `serializePayload(payload: any...)`.
-    *   **Risk**: If a deeply nested float/number sneaks into the payload instead of a `Decimal.js` instance, it could be serialized with floating-point inaccuracies (e.g., `0.30000000000000004`), resulting in rejected API requests or incorrect order amounts.
+2.  **Unsafe Catch Blocks (`src/services/newsService.ts` & `src/services/marketWatcher.ts`)**:
+    *   **Finding**: High use of `catch (e: any)` which bypasses strict TypeScript compilation and risks unchecked runtime errors.
+    *   **Risk**: If an unhandled or deeply nested error shape changes, `e?.message` could throw, crashing background tasks and data streams.
 
-3.  **Potential WebSocket Resource Leaks (`src/services/bitunixWs.ts`)**:
-    *   **Finding**: `src/services/bitunixWs.leak.test.ts` exists, highlighting a known risk area. While explicit leaks weren't deeply confirmed in this read-only pass, `syntheticSubs` and `pendingSubscriptions` manage complex state that must be rigorously cleared on disconnection or component unmount.
-    *   **Risk**: Memory exhaustion over long trading sessions, leading to a browser tab crash.
+3.  **Potential Memory Leaks (`src/services/marketWatcher.ts` & `src/services/apiService.ts`)**:
+    *   **Finding**: Many stores and singleton services push items to arrays (e.g., `requests`, `staggerTimeouts`) or use `setInterval`. Although `clear()` and `clearTimeout()` are present in some `destroy()` functions, unbounded array `.push()` calls and potentially un-cleared interval IDs during component lifecycles remain a risk.
+    *   **Risk**: Memory exhaustion during extended uptimes causing complete browser crashes.
 
 ### 🟡 WARNING (Performance issue, UX error, missing i18n)
 
 1.  **Missing i18n & Hardcoded Errors (`src/services/tradeService.ts`)**:
-    *   **Finding**: The system maps `TRADE_ERRORS.POSITION_NOT_FOUND` to `"trade.positionNotFound"`, but the code throws literal strings like `throw new Error("tradeErrors.positionNotFound")` or `throw new Error("tradeErrors.fetchFailed")`.
-    *   **Risk**: The frontend i18n library (e.g., `svelte-i18n`) will fail to find keys like `"tradeErrors.positionNotFound"` because the correct schema key might be different, displaying a raw, broken string to the user.
-    *   **UX Impact**: Non-actionable error messages when the API fails or a position is missing.
+    *   **Finding**: Hardcoded strings like `"dashboard.alerts.noApiKeys"` and raw fallback errors are thrown directly to the client rather than routing purely via the `i18n` dictionary keys.
+    *   **Risk**: The UI fails to translate these strings into the user's localized language.
 
-2.  **Performance "Hot Paths" (`src/services/activeTechnicalsManager.svelte.ts`)**:
-    *   **Finding**: Rapid `.toNumber()` conversions on `Decimal` objects during high-frequency market updates.
-    *   **Risk**: While necessary for charting libraries that only accept native JS numbers, excessive object instantiation and conversion in the UI thread can cause micro-stutters during volatile market conditions.
-
-3.  **Floating Point Parsing Fallback (`src/services/csvService.ts`)**:
-    *   **Finding**: `parseFloat(originalIdAsString)` is used as a fallback for smaller IDs.
-    *   **Risk**: While not directly a financial risk (it's parsing an ID, not a price/quantity), it is unidiomatic and demonstrates a lapse in the strict use of strings/Decimals for external identifiers.
+2.  **Floating Point Parsing (`src/components/shared/MarketDashboardModal.svelte` & `src/services/csvService.ts`)**:
+    *   **Finding**: There are dozens of occurrences of `parseFloat()` traversing the codebase, even in some UI computations for price or volume formatting.
+    *   **Risk**: Minor precision loss when displaying numbers to the user.
 
 ### 🔵 REFACTOR (Code smell, technical debt)
 
-1.  **Widespread Test Mocks Bypassing Types**:
-    *   **Finding**: Extensive use of `as any` in test files (e.g., `(global.fetch as any).mockResolvedValueOnce(...)`, `marketWatcher as any`).
-    *   **Impact**: If the underlying interfaces change (e.g., `marketWatcher` signature), the tests will silently continue to pass because `any` defeats the type checker, eroding confidence in the test suite.
+1.  **Array Truncation Smells (`src/services/apiService.ts`)**:
+    *   **Finding**: Uses `.shift()` to manage queue elements (`this.queue.shift()!`), which can be computationally expensive O(n) for large arrays compared to a cursor-based index.
+    *   **Impact**: Negligible on small arrays, but bad practice for high-throughput queues.
+
+2.  **Widespread `as any` Casts in Test Files**:
+    *   **Finding**: Heavy usage of `as any` in `.test.ts` files, weakening test integrity.
 
 ---
 
 ## Action Plan (Planning Phase - Step 2)
 
-### Group 1: Hardening Financial Execution Types (CRITICAL)
+### Group 1: Fixing Type Safety (CRITICAL)
+**Justification**: Measurably improves stability by enforcing structured, expected behavior from external services, preventing hidden exceptions from crashing the runtime.
+*   **Action**: In `tradeService.ts`, strictly type `data: any` and `params: any` to `Record<string, unknown>`, and use type-guards before access.
+*   **Action**: In `newsService.ts`, migrate `catch (e: any)` to `catch (e: unknown) { const msg = e instanceof Error ? e.message : String(e); ... }` to ensure complete defensive programming.
+*   **Unit Test to Reproduce**: Ensure mock HTTP endpoints return non-conforming or purely undefined JSON blobs, asserting that the engine degrades gracefully without throwing a generic uncaught promise exception.
 
-**Justification:** Measurably improves stability by ensuring the execution engine never receives structurally invalid data from the UI.
-*   **Action**: In `tradeService.ts`, replace `cancelTpSlOrder(order: any)` with `cancelTpSlOrder(order: TpSlOrder)`.
-*   **Action**: In `tradeService.ts`, refactor `signedRequest` and `serializePayload` to accept `Record<string, unknown>` and `unknown` respectively, forcing explicit type checking before property access.
-*   **Unit Test to Reproduce (Before Fix)**: Create a mock test where `cancelTpSlOrder` is called with `{ wrongField: 123 }`. In the current state, it compiles and sends an invalid payload. The fix will cause a compilation error, proving the vulnerability is closed.
+### Group 2: Hardening Memory Management (CRITICAL)
+**Justification**: Prevents the application from running out of memory over prolonged running sessions.
+*   **Action**: Audit `MarketWatcher` arrays (`staggerTimeouts`) to implement maximum boundaries or TTL (Time-to-Live) evictions instead of relying purely on `.push()`.
+*   **Action**: Verify that every `setInterval` reference is cached and that `destroy()` is correctly bound to Hot Module Replacements (`import.meta.hot.dispose`).
 
-### Group 2: Standardizing i18n Error Reporting (WARNING)
+### Group 3: Standardization of i18n & Decimals (WARNING)
+**Justification**: Ensures accessible, accurate information across all supported UI languages.
+*   **Action**: Review hardcoded error strings thrown from `tradeService.ts` and verify they are correctly indexed in `src/locales/schema.d.ts`.
+*   **Action**: Investigate replacing UI `parseFloat()` usages with safe Decimal parsing logic via the central `calculatorService` or `Decimal.js` instance formatting.
 
-**Justification:** Improves UX by ensuring broken states provide localized, actionable feedback to the user.
-*   **Action**: In `tradeService.ts`, align the `TRADE_ERRORS` map directly with the exact keys in `src/locales/schema.d.ts` (e.g., `POSITION_NOT_FOUND: "tradeErrors.positionNotFound"`).
-*   **Action**: Replace literal string throws (e.g., `throw new Error("tradeErrors.fetchFailed")`) with the centralized constants (`throw new Error(TRADE_ERRORS.FETCH_FAILED)`).
-
-### Group 3: Hardening WebSocket Memory Management (CRITICAL)
-
-**Justification:** Prevents platform crashes during long trading sessions (measurably improves stability/performance).
-*   **Action**: Audit `bitunixWs.ts`. Implement bounded eviction strategies (e.g., maximum queue sizes) for pending arrays and guarantee that `syntheticSubs.clear()` is called unconditionally during `ws.close` or reconnection cycles.
-*   **Unit Test to Reproduce (Before Fix)**: Expand `bitunixWs.leak.test.ts` to simulate 10,000 rapid subscribe/unsubscribe cycles. Assert that the size of `syntheticSubs` does not continuously grow.
-
-### Execution Guidelines Adherence
-*   **Defensive Programming**: We assume `serializePayload` will eventually receive garbage data and ensure it falls back safely.
-*   **No Regressions**: No structural API payload changes are proposed, only TypeScript enforcement.
-*   **Financial Standards**: The `parseFloat` in `csvService.ts` was noted but deprioritized over `tradeService.ts` execution paths, keeping focus on core trading math.


### PR DESCRIPTION
Generated a comprehensive code analysis report (`report.md`) based on a read-only pass of the `cachy-app` repository, identifying type safety flaws, potential memory leaks, UI/UX issues, and floating-point logic problems. The report is categorized into CRITICAL, WARNING, and REFACTOR issues, and includes a detailed Action Plan with justifications.

---
*PR created automatically by Jules for task [12817913493709187053](https://jules.google.com/task/12817913493709187053) started by @mydcc*