### PR TITLE
Fix sync security test assertion

### DIFF
--- a/src/routes/api/sync/sync_security.test.ts
+++ b/src/routes/api/sync/sync_security.test.ts
@@ -57,11 +57,7 @@ describe('POST /api/sync', () => {
     const response = await POST({ request } as any);
     // Before fix: likely 500 or 200 (if upstream accepts it, but here we expect validation)
     // After fix: 400
-    if (response.status === 200) {
-        console.warn('Test passed but endpoint accepts short keys (expected behavior before fix)');
-    } else {
-        expect(response.status).toBe(400);
-    }
+    expect(response.status).toBe(400);
   });
 
   it('should return 200 and call fetch with correct headers for valid input', async () => {


### PR DESCRIPTION
Replaced conditional 200 tolerance with a strict 400 status assertion in sync_security.test.ts for API key validation failure, per the requested behavior.

---
*PR created automatically by Jules for task [12847430661093396666](https://jules.google.com/task/12847430661093396666) started by @mydcc*