### PR TITLE
Fix BitunixWS memory leak

### DIFF
--- a/src/services/bitunixWs.leak.test.ts
+++ b/src/services/bitunixWs.leak.test.ts
@@ -91,4 +91,21 @@ describe('BitunixWebSocketService Leak', () => {
         expect((bitunixWs as any).syntheticSubs.size).toBe(0);
         expect((bitunixWs as any).pendingSubscriptions.size).toBe(0);
     });
+
+    it('should bound syntheticSubs and pendingSubscriptions growth under rapid subscribe/unsubscribe cycles', () => {
+        // [HARDENING] Test bounded eviction limits
+        for (let i = 0; i < 10000; i++) {
+            const sym = `TEST${i}USDT`;
+            bitunixWs.subscribe(sym, 'kline_2h'); // 2h is synthetic, relies on 1h
+            // Unsubscribe immediately to simulate rapid cycles and ensure ref counts hit 0 allowing eviction
+            bitunixWs.unsubscribe(sym, 'kline_2h');
+        }
+
+        // The max limit is set to 5000 in BitunixWS.
+        // It allows up to 5001 before evicting elements with count 0.
+        expect((bitunixWs as any).syntheticSubs.size).toBeLessThanOrEqual(5001);
+        expect((bitunixWs as any).pendingSubscriptions.size).toBeLessThanOrEqual(5001);
+
+        (bitunixWs as any).destroy();
+    });
 });

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -1401,6 +1401,19 @@ class BitunixWebSocketService {
         const synthKey = `${normalizedSymbol}:${channel.replace("kline_", "")}`;
 
         const count = this.syntheticSubs.get(synthKey) || 0;
+
+        // [HARDENING] Bounded eviction to prevent memory leaks
+        if (count === 0 && this.syntheticSubs.size > 5000) {
+            logger.warn("network", `[BitunixWS] syntheticSubs limit exceeded (5000). Evicting oldest inactive.`);
+            // Only evict entries with a reference count of 0
+            for (const [key, val] of this.syntheticSubs.entries()) {
+                 if (val === 0) {
+                      this.syntheticSubs.delete(key);
+                      break;
+                 }
+            }
+        }
+
         this.syntheticSubs.set(synthKey, count + 1);
 
         if (import.meta.env.DEV) {
@@ -1412,6 +1425,19 @@ class BitunixWebSocketService {
 
     // Reference Counting Logic
     const currentCount = this.pendingSubscriptions.get(subKey) || 0;
+
+    // [HARDENING] Bounded eviction to prevent memory leaks
+    if (currentCount === 0 && this.pendingSubscriptions.size > 5000) {
+        logger.warn("network", `[BitunixWS] pendingSubscriptions limit exceeded (5000). Evicting oldest inactive.`);
+        // Only evict entries with a reference count of 0
+        for (const [key, val] of this.pendingSubscriptions.entries()) {
+             if (val === 0) {
+                  this.pendingSubscriptions.delete(key);
+                  break;
+             }
+        }
+    }
+
     this.pendingSubscriptions.set(subKey, currentCount + 1);
 
     // Only subscribe if this is the first requester


### PR DESCRIPTION
Harden WebSocket Memory Management in BitunixWS by enforcing a bounded eviction limit for internal reference counting maps to prevent memory exhaustion during extended trading sessions.

---
*PR created automatically by Jules for task [18008080189122919243](https://jules.google.com/task/18008080189122919243) started by @mydcc*