### PR TITLE
docs: Create In-depth Status & Risk Report

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,67 +1,33 @@
-# In-Depth Code Analysis & Status Report
+# In-depth Status & Risk Report: cachy-app
 
-## Status Quo & Vulnerabilities (Step 1)
+## 🔴 CRITICAL
+* **Data integrity & mapping**:
+  - In `src/services/tradeService.ts`, the `fetchTpSlOrders` method blindly casts API responses to `any` and then forces them to `TpSlOrder[]` without validating Decimal formats or schema types. This exposes the application to silent data loss, precision bugs during calculations, and completely hidden orders if the API payload changes or drops fields.
+  - In `src/services/newsService.ts`, API payload inputs (`params`) are weakly typed as `any`, leading to potential malformed requests and silent failures during the fetch cycle.
 
-### 🔴 CRITICAL (Risk of financial loss, crash, or security vulnerability)
+## 🟡 WARNING
+* **UI/UX & Accessibility (i18n)**:
+  - `src/services/newsService.ts` contains hardcoded English literal strings within the `try/catch` block for fetching errors (e.g., throwing "NO_API_KEY", and hardcoded text like `"Failed to fetch CryptoPanic"`). These should map to `apiErrors.generic` for unified handling, while still preserving observability for developers.
+* **Resource Management & Performance**:
+  - `src/services/marketWatcher.ts` maintains extensive arrays, requiring bounded eviction strategies to prevent runaway memory leaks.
 
-1.  **Type Safety & Validation in Execution Paths (`src/services/tradeService.ts`)**:
-    *   **Finding**: Critical order execution functions rely heavily on `any` types. Specifically, `cancelTpSlOrder(order: any)` accepts untyped parameters, bypassing the TypeScript compiler entirely.
-    *   **Risk**: The backend might receive malformed execution payloads (e.g., missing `orderId` or `symbol`), resulting in silently failed cancellations while the frontend assumes success.
-    *   **Impact**: Financial loss if a user attempts to cancel a stop-loss or take-profit order, but it executes anyway due to a malformed payload.
+## 🔵 REFACTOR
+* **Code Smells (TypeScript Any)**:
+  - Widespread reliance on `any` instead of `unknown` across API fetching boundaries in `tradeService.ts`, `newsService.ts`, and `marketWatcher.ts`.
 
-2.  **Generic API Serialization Risk (`src/services/tradeService.ts`)**:
-    *   **Finding**: The `signedRequest` method accepts `payload: Record<string, any>` and serializes it using `serializePayload(payload: any...)`.
-    *   **Risk**: If a deeply nested float/number sneaks into the payload instead of a `Decimal.js` instance, it could be serialized with floating-point inaccuracies (e.g., `0.30000000000000004`), resulting in rejected API requests or incorrect order amounts.
+# Action Plan
 
-3.  **Potential WebSocket Resource Leaks (`src/services/bitunixWs.ts`)**:
-    *   **Finding**: `src/services/bitunixWs.leak.test.ts` exists, highlighting a known risk area. While explicit leaks weren't deeply confirmed in this read-only pass, `syntheticSubs` and `pendingSubscriptions` manage complex state that must be rigorously cleared on disconnection or component unmount.
-    *   **Risk**: Memory exhaustion over long trading sessions, leading to a browser tab crash.
+## 1. Type Safety & Validation in `tradeService.ts`
+- Implement robust Zod validation for TP/SL orders by adding `TpSlOrderSchema` to `apiSchemas.ts`.
+- Important: To avoid wiping out an entire list of TP/SL orders due to a single invalid element, validate items *individually* inside `fetchTpSlOrders` and log validation errors for skipped items without crashing the overall position state.
 
-### 🟡 WARNING (Performance issue, UX error, missing i18n)
+## 2. Refactor Typings in `tradeService.ts` & `newsService.ts`
+- Replace `[key: string]: any` and explicit payload casting with `unknown` or `Record<string, unknown>`.
+- In `tradeService.ts`'s `serializePayload`, strictly cast `payload` to ensure recursive checks are safe without dropping to `any`.
+- In `newsService.ts`, refactor payload items from `any` to `Record<string, unknown>`.
 
-1.  **Missing i18n & Hardcoded Errors (`src/services/tradeService.ts`)**:
-    *   **Finding**: The system maps `TRADE_ERRORS.POSITION_NOT_FOUND` to `"trade.positionNotFound"`, but the code throws literal strings like `throw new Error("tradeErrors.positionNotFound")` or `throw new Error("tradeErrors.fetchFailed")`.
-    *   **Risk**: The frontend i18n library (e.g., `svelte-i18n`) will fail to find keys like `"tradeErrors.positionNotFound"` because the correct schema key might be different, displaying a raw, broken string to the user.
-    *   **UX Impact**: Non-actionable error messages when the API fails or a position is missing.
+## 3. Standardize Errors
+- In `newsService.ts`, retain internal contextual debug strings but use them correctly within safe catch blocks, passing the underlying error for proper i18n handling without wiping the developer context.
 
-2.  **Performance "Hot Paths" (`src/services/activeTechnicalsManager.svelte.ts`)**:
-    *   **Finding**: Rapid `.toNumber()` conversions on `Decimal` objects during high-frequency market updates.
-    *   **Risk**: While necessary for charting libraries that only accept native JS numbers, excessive object instantiation and conversion in the UI thread can cause micro-stutters during volatile market conditions.
-
-3.  **Floating Point Parsing Fallback (`src/services/csvService.ts`)**:
-    *   **Finding**: `parseFloat(originalIdAsString)` is used as a fallback for smaller IDs.
-    *   **Risk**: While not directly a financial risk (it's parsing an ID, not a price/quantity), it is unidiomatic and demonstrates a lapse in the strict use of strings/Decimals for external identifiers.
-
-### 🔵 REFACTOR (Code smell, technical debt)
-
-1.  **Widespread Test Mocks Bypassing Types**:
-    *   **Finding**: Extensive use of `as any` in test files (e.g., `(global.fetch as any).mockResolvedValueOnce(...)`, `marketWatcher as any`).
-    *   **Impact**: If the underlying interfaces change (e.g., `marketWatcher` signature), the tests will silently continue to pass because `any` defeats the type checker, eroding confidence in the test suite.
-
----
-
-## Action Plan (Planning Phase - Step 2)
-
-### Group 1: Hardening Financial Execution Types (CRITICAL)
-
-**Justification:** Measurably improves stability by ensuring the execution engine never receives structurally invalid data from the UI.
-*   **Action**: In `tradeService.ts`, replace `cancelTpSlOrder(order: any)` with `cancelTpSlOrder(order: TpSlOrder)`.
-*   **Action**: In `tradeService.ts`, refactor `signedRequest` and `serializePayload` to accept `Record<string, unknown>` and `unknown` respectively, forcing explicit type checking before property access.
-*   **Unit Test to Reproduce (Before Fix)**: Create a mock test where `cancelTpSlOrder` is called with `{ wrongField: 123 }`. In the current state, it compiles and sends an invalid payload. The fix will cause a compilation error, proving the vulnerability is closed.
-
-### Group 2: Standardizing i18n Error Reporting (WARNING)
-
-**Justification:** Improves UX by ensuring broken states provide localized, actionable feedback to the user.
-*   **Action**: In `tradeService.ts`, align the `TRADE_ERRORS` map directly with the exact keys in `src/locales/schema.d.ts` (e.g., `POSITION_NOT_FOUND: "tradeErrors.positionNotFound"`).
-*   **Action**: Replace literal string throws (e.g., `throw new Error("tradeErrors.fetchFailed")`) with the centralized constants (`throw new Error(TRADE_ERRORS.FETCH_FAILED)`).
-
-### Group 3: Hardening WebSocket Memory Management (CRITICAL)
-
-**Justification:** Prevents platform crashes during long trading sessions (measurably improves stability/performance).
-*   **Action**: Audit `bitunixWs.ts`. Implement bounded eviction strategies (e.g., maximum queue sizes) for pending arrays and guarantee that `syntheticSubs.clear()` is called unconditionally during `ws.close` or reconnection cycles.
-*   **Unit Test to Reproduce (Before Fix)**: Expand `bitunixWs.leak.test.ts` to simulate 10,000 rapid subscribe/unsubscribe cycles. Assert that the size of `syntheticSubs` does not continuously grow.
-
-### Execution Guidelines Adherence
-*   **Defensive Programming**: We assume `serializePayload` will eventually receive garbage data and ensure it falls back safely.
-*   **No Regressions**: No structural API payload changes are proposed, only TypeScript enforcement.
-*   **Financial Standards**: The `parseFloat` in `csvService.ts` was noted but deprioritized over `tradeService.ts` execution paths, keeping focus on core trading math.
+## 4. Verification
+- Verify the `report.md` was created properly.


### PR DESCRIPTION
Generated a read-only analysis report (`report.md`) detailing the current status, vulnerabilities, and an action plan to address critical data integrity issues, missing i18n, and TS `any` type smells.

---
*PR created automatically by Jules for task [9596153963011918570](https://jules.google.com/task/9596153963011918570) started by @mydcc*