### PR TITLE
fix(bitunixWs): honour force on private reconnect, and use validated depth data

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -138,4 +138,4 @@ jobs:
       #    lowered, never raised, so the backlog cannot grow silently.
       #    Lower it as warnings are fixed; see docs/ROADMAP.md item 21.
       - name: Run ESLint
-        run: npx eslint . --max-warnings 1124
+        run: npx eslint . --max-warnings 1107

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Cachy is a comprehensive web application for crypto traders designed to precisel
 
   > **Lint is a required CI check.** The error count is **0 and must stay 0** — any error fails the build.
   >
-  > Warnings are capped by a **ratchet**: CI runs `eslint . --max-warnings 1124`, the size of the pre-existing `no-explicit-any` / `no-unused-vars` backlog. That number may only ever be *lowered*, never raised, so the backlog can shrink but cannot grow. When you fix warnings, lower the ceiling in `.github/workflows/audit.yml` to match. See `docs/ROADMAP.md` item 21.
+  > Warnings are capped by a **ratchet**: CI runs `eslint . --max-warnings 1107`, the size of the pre-existing `no-explicit-any` / `no-unused-vars` backlog. That number may only ever be *lowered*, never raised, so the backlog can shrink but cannot grow. When you fix warnings, lower the ceiling in `.github/workflows/audit.yml` to match. See `docs/ROADMAP.md` item 21.
   >
   > If a rule fires on something deliberate, do not silence it globally: add an inline `eslint-disable-next-line` with a `--` explanation, as done for the Svelte 5 dependency-registration reads in `tradeCalculator.svelte.ts`.
 

--- a/docs/REPO-AUDIT.md
+++ b/docs/REPO-AUDIT.md
@@ -195,8 +195,8 @@ a required CI check** (`.github/workflows/audit.yml`). Highlights:
   `safeJson.bench.ts` disables `no-loss-of-precision` because its fixtures
   deliberately exceed IEEE 754 precision — that is the thing being benchmarked.
 
-**1124 warnings remain**, dominated by `no-explicit-any` (983) and
-`no-unused-vars` (388). CI enforces `--max-warnings 1124` as a ratchet: the
+**1107 warnings remain**, dominated by `no-explicit-any` (983) and
+`no-unused-vars` (388). CI enforces `--max-warnings 1107` as a ratchet: the
 ceiling may only be lowered, so the backlog can shrink but never grow.
 
 Verified across the whole change: `npm run check` stays at 0 errors and the full
@@ -758,6 +758,6 @@ states and the disconnected case.
 | Check | Result |
 | --- | --- |
 | `npm run check` | 1925 files, **0 errors, 0 warnings** |
-| `npm test` | **847 passing, 0 failing** (gate suite; wall-clock benchmarks run separately via `npm run test:perf`, 9 passing) |
-| `npx eslint .` | **0 errors**, 1124 warnings under the CI ratchet |
+| `npm test` | **850 passing, 0 failing** (gate suite; wall-clock benchmarks run separately via `npm run test:perf`, 9 passing) |
+| `npx eslint .` | **0 errors**, 1107 warnings under the CI ratchet |
 | `npx semantic-release --dry-run` | Config valid, resolves to "publish from main, develop" |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -322,6 +322,38 @@ was corrected in the process: `detect_leaks.cjs` checks **timer** cleanup
 specifically (`setInterval` without `clearInterval`), not listeners or
 subscriptions in general.
 
+**Item 21, second pass: 1124 → 1107 — and it found two real bugs.** This is the
+pass the first one predicted: an "assigned but never used" warning looks the
+same whether it is a leftover or a value someone forgot to use, and only reading
+the code tells them apart. `bitunixWs.ts` had 17 of them, and two were the second
+kind.
+
+**`connectPrivate(force)` accepted the parameter and ignored it.** Its sibling
+`connectPublic(force)` uses it in three places, including "when already
+connected, do not return early — rebuild". `connectPrivate` returned
+unconditionally, so `connect(force: true)` rebuilt the public socket and silently
+left the **authenticated** one — the stream carrying order and position updates —
+exactly as it was. A forced reconnect never reached it.
+
+**The depth handler validated the payload and then discarded the result.** It
+bound `bids` / `asks` from the Zod-parsed data, whose `SafeString` transform
+exists to keep orderbook levels as strings, and then passed the raw `data.b` /
+`data.a` to `marketState`. The comment directly above said the transform had
+already normalised them. So a level the exchange sent as a number arrived as a
+number while the declared type said string.
+
+Both are covered by `bitunixWs_force_reconnect.test.ts`, verified as genuine
+guards: reverting each fix fails its test, restoring it passes.
+
+Also removed from the same file: a `JSON.stringify` of **every inbound message**
+whose only consumer was an unused length — a full serialisation per tick on a
+market-data socket, discarded. Plus six dead imports and a dead interface.
+
+Two `ws.onerror` handlers were left deliberately silent, only losing their unused
+parameter. The private one carries a comment showing the logging was commented
+out on purpose; `onclose` fires straight after and drives the reconnect. Not a
+place to "fix" by restoring noise.
+
 ### Code health
 
 | # | Item | Status |
@@ -329,7 +361,7 @@ subscriptions in general.
 | 18 | ~~Fix the pre-existing test failures~~ — done: **28 → 0**. The gate suite passes (821 tests) and CI runs all of it instead of three hand-picked files. Wall-clock benchmarks moved to a non-blocking job — see below | 🟢 |
 | 19 | ~~Attach `cause` to rethrown errors~~ — done: all 10 sites in `apiService.ts`, `tradeService.ts`, `news/+server.ts` and `storageUtils.ts` now chain the original failure | 🟢 |
 | 20 | ~~Burn down the 112 ESLint errors, then make lint a required CI check~~ — done: 0 errors, lint is now a required check | 🟢 |
-| 21 | Burn down the remaining 1124 `no-explicit-any` / `no-unused-vars` warnings, lowering the CI ceiling as you go, then restore both rules to `error` | 🟡 |
+| 21 | Burn down the remaining 1107 `no-explicit-any` / `no-unused-vars` warnings, lowering the CI ceiling as you go, then restore both rules to `error` | 🟡 |
 | 22 | ~~Resolve `.deploy.conf` being committed alongside its own `.example`~~ — done: untracked and ignored, template corrected, migration documented | 🟢 |
 | 23 | ~~Deduplicate `chartpatterns.html`~~ — done: the root copy was an early draft with 4 of 56 patterns | 🟢 |
 | 24 | ~~Group and document the ~20 ad-hoc scripts~~ — done: `scripts/README.md`, grouped by whether anything runs them | 🟢 |

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -29,22 +29,15 @@ import { mapToOMSPosition, mapToOMSOrder } from "./mappers";
 import { safeJsonParse } from "../utils/safeJson";
 import CryptoJS from "crypto-js";
 import { Decimal } from "decimal.js";
-import type {
-  BitunixWSMessage,
-  BitunixPriceData,
-  BitunixTickerData,
-} from "../types/bitunix";
+import type { BitunixWSMessage } from "../types/bitunix";
 import {
   BitunixWSMessageSchema,
   BitunixPriceDataSchema,
-  BitunixTickerDataSchema,
   StrictPriceDataSchema,
   StrictTickerDataSchema,
   StrictDepthDataSchema,
-  BitunixOrderSchema,
   BitunixPositionSchema,
   isAllowedChannel,
-  validateSymbol,
 } from "../types/bitunixValidation";
 
 export interface TradeData {
@@ -63,11 +56,6 @@ const PING_INTERVAL = 5000;
 const WATCHDOG_TIMEOUT = 20000;
 const RECONNECT_DELAY = 500;
 const CONNECTION_TIMEOUT_MS = 10000;
-
-interface Subscription {
-  symbol: string;
-  channel: string;
-}
 
 class BitunixWebSocketService {
   // Trade Listeners
@@ -463,7 +451,9 @@ class BitunixWebSocketService {
         }
       };
 
-      ws.onerror = (error) => { };
+      // Deliberately silent: onclose fires straight after and drives the
+      // reconnect, so logging here would only duplicate it.
+      ws.onerror = () => {};
     } catch {
       this.scheduleReconnect("public");
     }
@@ -489,7 +479,11 @@ class BitunixWebSocketService {
         this.wsPrivate.readyState === WebSocket.OPEN ||
         this.wsPrivate.readyState === WebSocket.CONNECTING
       ) {
-        return;
+        // `force` was accepted and then ignored here, so connect(force: true)
+        // reconnected the public socket and silently left the private one
+        // alone — the authenticated stream carrying order and position updates.
+        // Same shape as connectPublic: when forced, fall through and rebuild.
+        if (!force) return;
       }
       this.cleanup("private");
     }
@@ -572,9 +566,9 @@ class BitunixWebSocketService {
         }
       };
 
-      ws.onerror = (error) => {
-          // [HYBRID FIX] Quietly handle connection errors
-          // logger.warn("network", "[BitunixWS] Private connection error", error);
+      ws.onerror = () => {
+          // [HYBRID FIX] Quietly handle connection errors — onclose drives the
+          // reconnect. Left silent on purpose; see the public handler.
       };
     } catch (e) {
       // Catch synchronous errors (e.g. invalid URL or browser blocking)
@@ -837,10 +831,9 @@ class BitunixWebSocketService {
 
   private handleMessage(message: BitunixWSMessage, type: "public" | "private") {
     try {
-      const rawDataStr = JSON.stringify(message);
-      const dataSize = rawDataStr.length;
-      const messageType = message.event || message.op || message.ch || message.topic || 'unknown';
-      
+      // A JSON.stringify of every inbound message used to live here, purely to
+      // measure a length nobody read. On a market-data socket that is a full
+      // serialisation per tick, discarded.
       if (type === "public") {
         this.awaitingPongPublic = false;
         this.missedPongsPublic = 0;
@@ -901,10 +894,13 @@ class BitunixWebSocketService {
                     }
 
                     if (!this.shouldThrottle(`${symbol}:price`)) {
+                        // The safeString results above, not the raw fields: that is
+                        // what the hardening block exists for, and it was computing
+                        // them and then reading `data.*` anyway.
                         marketState.updateSymbol(symbol, {
-                          indexPrice: data.ip ? new Decimal(data.ip) : undefined,
-                          fundingRate: data.fr ? new Decimal(data.fr) : undefined,
-                          nextFundingTime: data.nft ? String(data.nft) : undefined
+                          indexPrice: ip ? new Decimal(ip) : undefined,
+                          fundingRate: fr ? new Decimal(fr) : undefined,
+                          nextFundingTime: nft
                         });
                     }
                     return;
@@ -973,7 +969,12 @@ class BitunixWebSocketService {
                     const asks = sData.a as [string, string][];
 
                     if (!this.shouldThrottle(`${symbol}:depth`)) {
-                      marketState.updateDepth(symbol, { bids: data.b, asks: data.a });
+                      // sData, not data. The schema's SafeString transform is what
+                      // normalises numeric levels to strings; passing the raw
+                      // `data.b` / `data.a` here skipped it entirely, so an
+                      // orderbook level the exchange sent as a number reached
+                      // marketState as a number while the type said string.
+                      marketState.updateDepth(symbol, { bids, asks });
                     }
                     return;
                   } catch (fastPathError) {
@@ -1028,7 +1029,7 @@ class BitunixWebSocketService {
                           // [SYNTHETIC] Dynamic Support
                           // Iterate active synthetic subscriptions to see if any depend on this update
                           if (this.syntheticSubs) {
-                              for (const [key, count] of this.syntheticSubs.entries()) {
+                              for (const key of this.syntheticSubs.keys()) {
                                   // key format: "SYMBOL:TF"
                                   const parts = key.split(":");
                                   if (parts.length !== 2) continue;

--- a/src/services/bitunixWs_force_reconnect.test.ts
+++ b/src/services/bitunixWs_force_reconnect.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { bitunixWs } from "./bitunixWs";
+import { marketState } from "../stores/market.svelte";
+
+vi.mock("./mdaService", () => ({
+  mdaService: { normalizeTicker: vi.fn(), normalizeKlines: vi.fn(() => []) },
+}));
+
+vi.mock("./logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), log: vi.fn(), debug: vi.fn() },
+}));
+
+// connectPrivate returns early without credentials, before it ever looks at the
+// socket — so the force path is only reachable with keys configured.
+vi.mock("../stores/settings.svelte", () => ({
+  settingsState: {
+    apiKeys: { bitunix: { key: "test-key", secret: "test-secret" } },
+    capabilities: { marketData: true },
+    enableNetworkLogs: false,
+  },
+}));
+
+vi.mock("../stores/market.svelte", () => ({
+  marketState: {
+    updateSymbol: vi.fn(),
+    updateDepth: vi.fn(),
+    updateSymbolKlines: vi.fn(),
+    updateTelemetry: vi.fn(),
+    connectionStatus: "connected",
+  },
+}));
+
+/**
+ * Two defects found through `no-unused-vars` warnings while burning down the
+ * lint backlog (roadmap item 21). Both are the case the roadmap warned about:
+ * a variable assigned and never read can equally mean a leftover or a value
+ * someone forgot to use, and the linter cannot tell them apart.
+ */
+
+type WsInternals = {
+  connectPrivate: (force?: boolean) => void;
+  handleMessage: (message: unknown, type: "public" | "private") => void;
+  cleanup: (which: "public" | "private") => void;
+  wsPrivate: unknown;
+  isDestroyed: boolean;
+  throttleMap?: Map<string, number>;
+};
+
+const ws = bitunixWs as unknown as WsInternals;
+
+describe("connectPrivate honours force", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ws.isDestroyed = false;
+    ws.throttleMap?.clear();
+  });
+
+  /** Stands in for a live authenticated socket. */
+  const openSocket = () => ({ readyState: 1 /* OPEN */ });
+
+  it("leaves an open private socket alone when not forced", () => {
+    ws.wsPrivate = openSocket();
+    const cleanup = vi.spyOn(ws, "cleanup");
+
+    ws.connectPrivate(false);
+
+    expect(cleanup).not.toHaveBeenCalled();
+    cleanup.mockRestore();
+  });
+
+  it("tears down an open private socket when forced", () => {
+    // The defect: `force` was accepted and then ignored, so this path returned
+    // early no matter what. connect(force: true) rebuilt the public socket and
+    // silently left the authenticated one — the stream carrying order and
+    // position updates — running as it was.
+    ws.wsPrivate = openSocket();
+    const cleanup = vi.spyOn(ws, "cleanup");
+
+    ws.connectPrivate(true);
+
+    expect(cleanup).toHaveBeenCalledWith("private");
+    cleanup.mockRestore();
+  });
+});
+
+describe("depth updates carry the schema-normalised values", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ws.throttleMap?.clear();
+  });
+
+  it("passes orderbook levels on as strings even when the exchange sends numbers", () => {
+    // The defect: the handler validated the payload, bound the normalised
+    // arrays, and then passed the *raw* data.b / data.a to marketState — so the
+    // SafeString transform that exists to keep levels as strings was skipped.
+    ws.handleMessage(
+      {
+        ch: "depth_book5",
+        symbol: "BTCUSDT",
+        data: {
+          b: [[43567.89, 1.5]],
+          a: [[43568.12, 2.25]],
+        },
+      },
+      "public",
+    );
+
+    expect(marketState.updateDepth).toHaveBeenCalledTimes(1);
+    const [, payload] = vi.mocked(marketState.updateDepth).mock.calls[0] as [
+      string,
+      { bids: unknown[][]; asks: unknown[][] },
+    ];
+
+    expect(payload.bids[0][0]).toBe("43567.89");
+    expect(payload.asks[0][0]).toBe("43568.12");
+    expect(typeof payload.bids[0][1]).toBe("string");
+  });
+});


### PR DESCRIPTION
Roadmap item **21, second pass**: 1124 → 1107 warnings. Two of them were real bugs.

This is the pass the first one predicted: an *"assigned but never used"* warning looks identical whether it is a leftover or **a value someone forgot to use**, and only reading the code separates them. `bitunixWs.ts` had 17, and two were the second kind.

## 1. `connectPrivate(force)` accepted the parameter and ignored it

Its sibling `connectPublic(force)` uses it in three places, including *"when already connected, do not return early — rebuild"*. `connectPrivate` returned unconditionally:

```ts
if (this.wsPrivate) {
  if (OPEN || CONNECTING) {
    return;          // ← force never consulted
  }
  this.cleanup("private");
}
```

So `connect(force: true)` rebuilt the public socket and silently left the **authenticated** one — the stream carrying order and position updates — exactly as it was. A forced reconnect never reached it.

## 2. The depth handler validated the payload, then threw the result away

```ts
const bids = sData.b as [string, string][];   // Zod-parsed, SafeString applied
const asks = sData.a as [string, string][];
...
marketState.updateDepth(symbol, { bids: data.b, asks: data.a });   // ← raw
```

`SafeString` (`z.union([z.string(), z.number()]).transform(String)`) exists precisely to keep orderbook levels as strings. The comment directly above the binding said the transform had already normalised them. Passing the raw fields skipped it, so a level the exchange sent as a number arrived as a number while the declared type said string.

The price handler had the same shape: it computed `safeString` results for index price and funding rate — the block whose entire purpose is the precision warning — and then read `data.*` anyway. Now it uses them.

## Verified as genuine guards

`bitunixWs_force_reconnect.test.ts` covers both. Reverting each fix fails its test; restoring it passes:

```
--- with the bugs put back ---
 × tears down an open private socket when forced
 × passes orderbook levels on as strings even when the exchange sends numbers
      Tests  2 failed | 1 passed (3)
--- restored ---
      Tests  3 passed (3)
```

The first draft of the force test failed for a different reason, which is worth recording: `connectPrivate` returns early without API credentials, before it ever looks at the socket. The test setup was incomplete, not the fix.

## Also in this file

- A `JSON.stringify` of **every inbound message** whose only consumer was an unused `.length` — a full serialisation per tick on a market-data socket, discarded.
- Six dead imports and one dead interface.
- Two `ws.onerror` handlers keep their deliberate silence and only lose the unused parameter. The private one shows the logging was commented out on purpose — `onclose` fires straight after and drives the reconnect. Not a place to "fix" by restoring noise.

## Verification

| Check | Result |
| --- | --- |
| `npm run check` | 1922 files, **0 errors** |
| `npx eslint . --max-warnings 1107` | 0 errors, exit 0 |
| `npm test` | **850 passing, 0 failing** (+3) |

Ratchet lowered 1124 → 1107.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5vSy9CtNVZhXngc9tcB5b)_