### PR TITLE
fix: remove old Matomo URL from CSP connect-src

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -69,7 +69,6 @@ const config = {
         "connect-src": [
           "self",
           "https://s.cachy.app",
-          "https://stat.ufjdn.com",
           "https://bam.nr-data.net",
           "https://bam.eu01.nr-data.net",
           "wss://fapi.bitunix.com",


### PR DESCRIPTION
## Summary

- Removes the stale `https://stat.ufjdn.com` entry from the `connect-src` Content-Security-Policy in `svelte.config.js`
- The replacement URL `https://s.cachy.app` was already present in the same list
- `src/app.html` and the privacy docs were already using the new URL — no changes needed there

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpHfBNjV8nUNjZ6Bvb9gZR)_