### PR TITLE
docs: enforce PR workflow for develop and main branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,9 @@ npm run test:e2e     # Playwright-E2E-Tests (tests/e2e)
 ## Commits
 
 Conventional Commits (semantic-release): `feat:` (Minor), `fix:` (Patch), `refactor:` (kein Release), `BREAKING CHANGE:` im Footer für Major.
+
+## Branch-Workflow
+
+- **Niemals direkt auf `develop` oder `main` pushen.** Jede Änderung läuft über einen Feature-Branch und einen Pull Request.
+- Der Conventional-Commits-Check (`commit-lint.yml`) läuft nur auf `pull_request`-Events — direktes Pushen auf `develop` umgeht ihn. PRs sind die einzige Möglichkeit, den Check vor dem Merge zu erzwingen.
+- Target-Branch für PRs ist immer **`develop`**, nie `main`.


### PR DESCRIPTION
## Summary

- Adds a **Branch-Workflow** section to `CLAUDE.md`
- Documents that direct pushes to `develop` or `main` are forbidden
- Explains why: the Conventional Commits check only triggers on `pull_request` events, so direct pushes silently bypass it
- Establishes `develop` as the mandatory PR target branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpHfBNjV8nUNjZ6Bvb9gZR)_