### PR TITLE
docs: document the orphaned Render.com integration in TODO.md

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -688,3 +688,40 @@ properly, or soften/remove the whitepaper claim. Whoever resolves this
 should probably resolve items 21 and 22 together, since they're the
 same open question (is the whitepaper's roadmap real?) about two
 different phases.
+
+## 23. Orphaned Render.com integration still auto-deploys and fails
+
+**Roadmap item 24**'s scripts audit already flagged half of this
+(`docs/ROADMAP.md`: *"`render_build.sh` targets Render.com, while the
+project deploys to aaPanel through `deploy.sh`. Nothing references
+it."*) — surfaced again because a live Render deployment attached to
+this repo actually failed on `develop`/PR #1593, which needs a person
+with account access, not just a file cleanup.
+
+Two pieces of dead-looking config, confirmed via `grep` that neither is
+referenced by `package.json`, any `.github/workflows/*.yml`, or
+`deploy.sh`:
+
+- `render.yaml` — Render's Infrastructure-as-Code file, which is what
+  keeps a connected Render service auto-building every push.
+- `scripts/render_build.sh` — installs Rust/the `wasm32-unknown-unknown`
+  target and runs `npm run build`; superseded by `scripts/build_wasm.sh`
+  (used by `npm run dev`/`npm run build` locally and presumably by
+  whatever the aaPanel deploy path uses).
+
+**Consequence:** the project migrated its real deployment to aaPanel
+(`deploy.sh`, `dev.cachy.app` / `cachy.app`) at some point, but a Render
+service is still connected to this GitHub repo and keeps attempting
+(and failing) a build on every push — visible as a "failed deployment"
+notice on PRs, unrelated to and not gating the actual required CI
+checks (`audit.yml`, `release.yml`, `commit-lint.yml`).
+
+**The decision:** disconnect/delete the Render service from the Render
+dashboard (needs whoever owns that account — not something reachable
+from this repo or GitHub alone), then remove `render.yaml` and
+`scripts/render_build.sh` once nothing is deploying from them anymore.
+Left in place and not deleted yet per this repo's defensive-deletion
+rule: removing the files first would silence Render's failure without
+addressing the still-connected service, which would keep failing
+silently (or worse, keep half-succeeding) with no repo-side visibility
+left to notice it.


### PR DESCRIPTION
## Summary

Follow-up to #1588 (merged) — same branch, restarted from `develop`'s tip since #1588 already landed.

A Render.com deployment is still connected to this repo and auto-attempts (and fails) a build on every push — visible on PR #1593 (`develop` → `main`) as a "1 failed deployment" notice. `docs/ROADMAP.md`'s scripts audit (item 24) had already flagged half of this — `render_build.sh` targets Render.com while the project actually deploys to aaPanel via `deploy.sh`, and nothing references it — but the *live, still-connected* Render service is new information from this failure.

Adds `docs/TODO.md` item 23: documents that `render.yaml` and `scripts/render_build.sh` are confirmed unreferenced (grep across `package.json`, `.github/workflows/*.yml`, `deploy.sh`), and that disconnecting the Render service itself needs someone with account access — not something fixable from the repo alone. Files are kept in place until that happens, per this repo's defensive-deletion convention: deleting them first would silence the failure without addressing the still-connected service.

## Test plan

- Docs-only change, no code touched.
- [x] Confirmed via `grep` that `render.yaml` / `render_build.sh` are unreferenced anywhere else in the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5vSy9CtNVZhXngc9tcB5b)_