### PR TITLE
fix: WS init race and Bitget symbol-key mismatch causing empty market tiles

### DIFF
--- a/src/actions/burn.ts
+++ b/src/actions/burn.ts
@@ -117,8 +117,10 @@ class BurnColorResolver {
             // 2. Automatic Price Trend (Like Market Tiles Border)
             const symbol = inputSymbol || tradeState.symbol;
             if (symbol) {
-                const provider = settingsState.apiProvider;
-                const key = normalizeSymbol(symbol, provider);
+                // marketState.data is always keyed by the canonical
+                // (Bitunix-style) symbol regardless of active provider
+                // (see MarketOverview.svelte).
+                const key = normalizeSymbol(symbol, "bitunix");
                 const data = marketState.data[key];
 
                 // Cache colors if needed

--- a/src/components/shared/FlashCard.svelte
+++ b/src/components/shared/FlashCard.svelte
@@ -34,7 +34,10 @@
     const symbol = tradeState.symbol;
     if (!symbol) return "var(--accent-color)";
 
-    const key = normalizeSymbol(symbol, settingsState.apiProvider);
+    // marketState.data is always keyed by the canonical (Bitunix-style)
+    // symbol regardless of active provider - see MarketOverview.svelte for
+    // the same fix and why normalizing by provider here would miss Bitget.
+    const key = normalizeSymbol(symbol, "bitunix");
     const data = marketState.data[key];
 
     if (!data || !data.priceChangePercent) return "var(--accent-color)";

--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -79,15 +79,22 @@
   let baseAsset = $derived(symbol.toUpperCase().replace(/USDT(\.P|P)?$/, ""));
 
   // Market Data Access
+  //
+  // marketState.data is always keyed by the canonical (Bitunix-style,
+  // unsuffixed) symbol - that's what MarketWatcher/apiService write under
+  // regardless of the active provider (see marketWatcher.ts's register()).
+  // Normalizing with the active `provider` here would key Bitget lookups by
+  // e.g. "BTCUSDT_UMCBL", which nothing ever writes to, leaving the tile
+  // stuck on its loading state.
   let wsData = $derived.by(() => {
     if (!symbol) return null;
-    const key = normalizeSymbol(symbol, provider);
+    const key = normalizeSymbol(symbol, "bitunix");
     return marketState.data[key] || null;
   });
 
   // Ticker Data (Fallback)
   let tickerData = $derived(
-    marketState.data[normalizeSymbol(symbol, provider)],
+    marketState.data[normalizeSymbol(symbol, "bitunix")],
   );
 
   let currentPrice = $derived.by(() => {

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -192,9 +192,14 @@ export const app = {
     let symbolDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
     tradeStoreUnsubscribe = tradeState.subscribe((state) => {
-      const provider = settingsState.apiProvider;
+      // Canonical (Bitunix-style) form: marketWatcher.register()/unregister()
+      // re-normalize with "bitunix" internally regardless of what's passed
+      // in, and normalizeSymbol never strips a "_UMCBL" suffix for a
+      // non-bitget provider - so normalizing by the active provider here
+      // would, under Bitget, permanently bake the suffix into the request
+      // key marketWatcher tracks for the main trading symbol.
       const newSymbol = state.symbol
-        ? normalizeSymbol(state.symbol, provider)
+        ? normalizeSymbol(state.symbol, "bitunix")
         : "";
 
       if (symbolDebounceTimer) clearTimeout(symbolDebounceTimer);
@@ -223,7 +228,9 @@ export const app = {
       const settings = settingsState;
 
       if (state.symbol) {
-        const normSymbol = normalizeSymbol(state.symbol, settings.apiProvider);
+        // marketState.data is always keyed by the canonical (Bitunix-style)
+        // symbol regardless of active provider (see MarketOverview.svelte).
+        const normSymbol = normalizeSymbol(state.symbol, "bitunix");
         const marketData = data[normSymbol];
 
         if (marketData && marketData.lastPrice) {

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -148,45 +148,37 @@ export const app = {
   setupRealtimeUpdates: () => {
     if (!browser) return;
 
-    let lastKeys = "";
+    const computeKeys = (s: Settings) =>
+      s.apiProvider === "bitget"
+        ? `${s.apiKeys.bitget.key}:${s.apiKeys.bitget.secret}:${s.apiKeys.bitget.passphrase}`
+        : `${s.apiKeys.bitunix.key}:${s.apiKeys.bitunix.secret}`;
+
+    // Seed from the current settings snapshot so the synchronous initial
+    // emit below (store.subscribe() calls the listener immediately) is a
+    // no-op. The first connection is owned exclusively by app.init()'s
+    // explicit connectionManager.switchProvider() call further down; without
+    // this seed, this callback fired its own switchProvider() one step
+    // earlier in the same tick and raced it, destroying the socket before it
+    // finished opening.
     let lastProvider = settingsState.apiProvider || "";
+    let lastKeys = settingsState.apiKeys ? computeKeys(settingsState) : "";
 
     settingsState.subscribe((s: Settings) => {
       untrack(() => {
         if (!s || !s.apiKeys) return;
 
-        const currentKeys = s.apiProvider === "bitget"
-          ? `${s.apiKeys.bitget.key}:${s.apiKeys.bitget.secret}:${s.apiKeys.bitget.passphrase}`
-          : `${s.apiKeys.bitunix.key}:${s.apiKeys.bitunix.secret}`;
-
+        const currentKeys = computeKeys(s);
         const providerChanged = s.apiProvider !== lastProvider;
         const keysChanged = currentKeys !== lastKeys;
 
-        if (s.apiProvider === "bitget") {
-          // Ensure Bitunix is dead
-          if (bitunixWs) bitunixWs.destroy();
-
-          if (providerChanged || keysChanged) {
-            lastKeys = currentKeys;
-            lastProvider = s.apiProvider;
-            if (browser) {
-              // Ensure we start fresh
-              (bitgetWs as unknown as { isDestroyed: boolean }).isDestroyed = false;
-              bitgetWs.connect(true);
-            }
-          }
-        } else {
-          // Ensure Bitget is dead
-          if (bitgetWs) bitgetWs.destroy();
-
-          if (providerChanged || keysChanged) {
-            lastKeys = currentKeys;
-            lastProvider = s.apiProvider;
-            if (browser) {
-              (bitunixWs as unknown as { isDestroyed: boolean }).isDestroyed = false;
-              bitunixWs.connect();
-            }
-          }
+        if (providerChanged || keysChanged) {
+          lastKeys = currentKeys;
+          lastProvider = s.apiProvider;
+          // Route exclusively through ConnectionManager, the single owner of
+          // provider connect/destroy, so old and new provider are switched
+          // atomically instead of two services independently tearing each
+          // other down.
+          connectionManager.switchProvider(s.apiProvider || "bitunix", { force: true });
         }
       });
     });

--- a/src/services/app_bitgetSymbolKey.test.ts
+++ b/src/services/app_bitgetSymbolKey.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// setupRealtimeUpdates() is gated behind `if (!browser) return`. Vitest's
+// default test environment resolves $app/environment's `browser` to false,
+// so without this mock the function under test would silently no-op.
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+vi.mock("./connectionManager", () => ({
+  connectionManager: {
+    registerProvider: vi.fn(),
+    registerPolling: vi.fn(),
+    switchProvider: vi.fn(),
+    onProviderConnected: vi.fn(),
+    onProviderDisconnected: vi.fn(),
+  },
+}));
+
+import { app } from "./app";
+import { settingsState } from "../stores/settings.svelte";
+import { tradeState } from "../stores/trade.svelte";
+import { marketState } from "../stores/market.svelte";
+import { Decimal } from "decimal.js";
+
+describe("app.setupRealtimeUpdates - Bitget symbol-key parity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("updates the price input from live market data, keyed canonically, while Bitget is active", () => {
+    settingsState.apiProvider = "bitget";
+    settingsState.autoUpdatePriceInput = true;
+    tradeState.update((s) => ({ ...s, symbol: "BTCUSDT", entryPrice: "0" }));
+
+    const subscribeSpy = vi.spyOn(marketState, "subscribe");
+    app.setupRealtimeUpdates();
+
+    const marketListener = subscribeSpy.mock.calls[0]?.[0];
+    expect(marketListener).toBeTypeOf("function");
+
+    // Regression test: every writer (MarketWatcher's REST polling via
+    // apiService, which is the only live data path for Bitget market data
+    // today) keys marketState.data by normalizeSymbol(symbol, "bitunix")
+    // regardless of the active provider. Before the fix, this callback
+    // looked the price up under normalizeSymbol(symbol, "bitget")
+    // ("BTCUSDT_UMCBL") instead, which nothing ever writes to - so the price
+    // input silently never updated while Bitget was the active provider.
+    marketListener!({
+      BTCUSDT: { lastPrice: new Decimal("65000") },
+    });
+
+    expect(tradeState.entryPrice).toBe("65000");
+  });
+});

--- a/src/services/app_realtimeUpdates.test.ts
+++ b/src/services/app_realtimeUpdates.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// setupRealtimeUpdates() (like most of app.ts) is gated behind `if (!browser)
+// return`. Vitest's default test environment resolves $app/environment's
+// `browser` to false, so without this mock the function under test - and
+// settingsState's own constructor - would both silently no-op.
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+vi.mock("./connectionManager", () => ({
+  connectionManager: {
+    registerProvider: vi.fn(),
+    registerPolling: vi.fn(),
+    switchProvider: vi.fn(),
+    onProviderConnected: vi.fn(),
+    onProviderDisconnected: vi.fn(),
+  },
+}));
+
+import { app } from "./app";
+import { connectionManager } from "./connectionManager";
+import { settingsState, type Settings } from "../stores/settings.svelte";
+
+// settingsState's pub/sub is a plain listener Set behind subscribe()/toJSON(),
+// separate from the reactive $effect that normally drives notifyListeners()
+// on a 500ms debounce. setupRealtimeUpdates() never unsubscribes, so calling
+// it once per test would otherwise leave every previous test's listener
+// registered too. Capturing only the listener this call just added - and
+// invoking it directly - keeps each test isolated without needing to reset
+// settingsState's shared internal state.
+type SettingsInternals = {
+  listeners: Set<(value: Settings) => void>;
+};
+
+function registerAndCaptureListener(register: () => void): (value: Settings) => void {
+  const internals = settingsState as unknown as SettingsInternals;
+  const before = new Set(internals.listeners);
+  register();
+  for (const listener of internals.listeners) {
+    if (!before.has(listener)) return listener;
+  }
+  throw new Error("register() did not add a settings listener");
+}
+
+function emit(listener: (value: Settings) => void) {
+  listener(settingsState.toJSON());
+}
+
+describe("app.setupRealtimeUpdates - init race", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    settingsState.apiProvider = "bitunix";
+    settingsState.apiKeys = {
+      bitunix: { key: "", secret: "" },
+      bitget: { key: "", secret: "", passphrase: "" },
+    };
+  });
+
+  it("does not call switchProvider on the initial synchronous subscribe emit", () => {
+    // Regression test: app.init() connects exactly once via its own explicit
+    // connectionManager.switchProvider() call. Before this fix,
+    // setupRealtimeUpdates()'s settings subscription always saw a change on
+    // its first (synchronous) emit - lastKeys started as "" instead of the
+    // real current keys - and fired a second, competing switchProvider call
+    // in the same tick, racing the first and closing the socket before it
+    // finished opening.
+    registerAndCaptureListener(() => app.setupRealtimeUpdates());
+
+    expect(connectionManager.switchProvider).not.toHaveBeenCalled();
+  });
+
+  it("calls switchProvider exactly once when the provider actually changes", () => {
+    const listener = registerAndCaptureListener(() => app.setupRealtimeUpdates());
+
+    settingsState.apiProvider = "bitget";
+    emit(listener);
+
+    expect(connectionManager.switchProvider).toHaveBeenCalledTimes(1);
+    expect(connectionManager.switchProvider).toHaveBeenCalledWith("bitget", { force: true });
+  });
+
+  it("calls switchProvider exactly once when only the API keys change", () => {
+    const listener = registerAndCaptureListener(() => app.setupRealtimeUpdates());
+
+    settingsState.apiKeys = {
+      bitunix: { key: "new-key", secret: "new-secret" },
+      bitget: { key: "", secret: "", passphrase: "" },
+    };
+    emit(listener);
+
+    expect(connectionManager.switchProvider).toHaveBeenCalledTimes(1);
+    expect(connectionManager.switchProvider).toHaveBeenCalledWith("bitunix", { force: true });
+  });
+
+  it("does not call switchProvider again when nothing relevant changed", () => {
+    const listener = registerAndCaptureListener(() => app.setupRealtimeUpdates());
+
+    emit(listener);
+    emit(listener);
+
+    expect(connectionManager.switchProvider).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -418,9 +418,6 @@ class BitunixWebSocketService {
         marketState.connectionStatus = "connected";
         marketState.updateTelemetry({ activeConnections: (marketState.telemetry.activeConnections || 0) + 1 });
 
-        // Notify Manager
-        connectionManager.onProviderConnected("bitunix");
-
         // [HYBRID FIX] Reset Backoff on successful connection
         this.backoffDelay = 1000;
         this.isReconnectingPublic = false;
@@ -429,8 +426,19 @@ class BitunixWebSocketService {
         this.startHeartbeat(ws, "public");
         this.resetWatchdog("public", ws);
 
-        // [HYBRID] Flush Buffer on Connect
+        // [HYBRID] Flush Buffer on Connect. Must run before notifying
+        // ConnectionManager below: it sends whatever subscriptions were
+        // already queued while the socket was still CONNECTING. Notifying
+        // ConnectionManager afterwards (which triggers MarketWatcher.resync())
+        // then only needs to (re-)subscribe channels still missing after this
+        // flush, so the two don't both send the same channel moments apart.
         this.flushPendingSubscriptions();
+
+        // Notify Manager. Also triggers MarketWatcher.resync(), which
+        // restores any subscriptions this instance's own buffer lost across
+        // a prior destroy() (pendingSubscriptions is cleared there, but
+        // MarketWatcher's own registered interest is not).
+        connectionManager.onProviderConnected("bitunix");
       };
 
       ws.onmessage = (event) => {

--- a/src/services/connectionManager.test.ts
+++ b/src/services/connectionManager.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../stores/market.svelte", () => ({
+  marketState: {
+    connectionStatus: "disconnected",
+  },
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { connectionManager } from "./connectionManager";
+import type { ManagedService, PollingService } from "./connectionManager";
+
+function makeProvider() {
+  return {
+    connect: vi.fn(),
+    destroy: vi.fn(),
+  } satisfies ManagedService;
+}
+
+function makePolling() {
+  return {
+    stopPolling: vi.fn(),
+    resumePolling: vi.fn(),
+    resync: vi.fn(),
+  } satisfies PollingService;
+}
+
+describe("ConnectionManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("kills the old provider before connecting the new one on switchProvider", async () => {
+    const bitunix = makeProvider();
+    const bitget = makeProvider();
+    connectionManager.registerProvider("bitunix", bitunix);
+    connectionManager.registerProvider("bitget", bitget);
+
+    await connectionManager.switchProvider("bitunix", { force: true });
+    expect(bitunix.connect).toHaveBeenCalledTimes(1);
+    expect(bitget.destroy).toHaveBeenCalledTimes(1); // killAll() tears down every registered provider
+
+    vi.mocked(bitunix.destroy).mockClear();
+    vi.mocked(bitget.destroy).mockClear();
+
+    await connectionManager.switchProvider("bitget", { force: true });
+
+    expect(bitunix.destroy).toHaveBeenCalledTimes(1);
+    expect(bitget.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("resyncs subscriptions instead of stopping the polling fallback when a provider connects", async () => {
+    const bitunix = makeProvider();
+    const polling = makePolling();
+    connectionManager.registerProvider("bitunix", bitunix);
+    connectionManager.registerPolling(polling);
+
+    await connectionManager.switchProvider("bitunix", { force: true });
+    // switchProvider's own killAll()/resumePolling() bridge already touched
+    // these mocks; clear them so the assertions below only see what
+    // onProviderConnected itself does.
+    vi.mocked(polling.resumePolling).mockClear();
+    vi.mocked(polling.stopPolling).mockClear();
+
+    connectionManager.onProviderConnected("bitunix");
+
+    expect(polling.resync).toHaveBeenCalledTimes(1);
+    expect(polling.stopPolling).not.toHaveBeenCalled();
+  });
+
+  it("destroys a late connection report from a provider that is no longer active", async () => {
+    const bitunix = makeProvider();
+    const bitget = makeProvider();
+    connectionManager.registerProvider("bitunix", bitunix);
+    connectionManager.registerProvider("bitget", bitget);
+
+    await connectionManager.switchProvider("bitget", { force: true });
+    vi.mocked(bitunix.destroy).mockClear();
+
+    // A stale onopen from the provider we just switched away from.
+    connectionManager.onProviderConnected("bitunix");
+
+    expect(bitunix.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes polling when the active provider disconnects", async () => {
+    const bitunix = makeProvider();
+    const polling = makePolling();
+    connectionManager.registerProvider("bitunix", bitunix);
+    connectionManager.registerPolling(polling);
+
+    await connectionManager.switchProvider("bitunix", { force: true });
+    vi.mocked(polling.resumePolling).mockClear();
+
+    connectionManager.onProviderDisconnected("bitunix");
+
+    expect(polling.resumePolling).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/connectionManager.ts
+++ b/src/services/connectionManager.ts
@@ -33,6 +33,9 @@ export interface ManagedService {
 export interface PollingService {
     stopPolling: () => void;
     resumePolling: () => void;
+    // Reconciles desired subscriptions against the live connection. Optional
+    // so lightweight test doubles for PollingService don't need to implement it.
+    resync?: () => void;
 }
 
 class ConnectionManager {
@@ -134,10 +137,18 @@ class ConnectionManager {
 
         logger.log("governance", `[ConnectionManager] Provider ${name} is ACTIVE and CONNECTED.`);
 
-        // Successfully connected? Stop Polling redundant data.
-        if (this.pollingService) {
-            this.pollingService.stopPolling();
-        }
+        // Re-sync desired subscriptions immediately. A provider's own
+        // subscription buffer does not survive its destroy()/connect() cycle,
+        // but the polling service's registered interest does — without this,
+        // a reconnect can leave the socket open yet subscribed to nothing.
+        this.pollingService?.resync?.();
+
+        // Deliberately NOT stopping the polling fallback here anymore: it
+        // would kill the safety net before we know any data actually
+        // arrived. The polling service already skips REST calls per-symbol
+        // once its own WS data is fresh, so leaving the loop running is a
+        // cheap, continuous safety net rather than a one-shot check at
+        // connect time.
     }
 
     /**

--- a/src/services/marketWatcher.ts
+++ b/src/services/marketWatcher.ts
@@ -260,6 +260,20 @@ class MarketWatcher {
     this.startPolling();
   }
 
+  /**
+   * Force an immediate reconciliation of desired subscriptions (`this.requests`,
+   * the watcher's own source of truth) against the live provider connection.
+   * Called by ConnectionManager right after a provider reports a successful
+   * (re)connect: the provider's subscription buffer is wiped on every
+   * destroy()/connect() cycle, so without an explicit resync here, tiles can
+   * end up subscribed to nothing after a reconnect even though `this.requests`
+   * still lists them as wanted.
+   */
+  public resync() {
+    this._subscriptionsDirty = false;
+    this.syncSubscriptions();
+  }
+
   private pruneOrphanedSubscriptions() {
     for (const [symbol, channels] of this.requests) {
       for (const [channel, reqs] of channels) {

--- a/src/services/marketWatcher_resync.test.ts
+++ b/src/services/marketWatcher_resync.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { marketWatcher } from "./marketWatcher";
+import { bitunixWs } from "./bitunixWs";
+
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
+
+vi.mock("./apiService", () => ({
+  apiService: {
+    fetchTicker24h: vi.fn(),
+    fetchBitunixKlines: vi.fn(),
+    fetchBitgetKlines: vi.fn(),
+  },
+}));
+
+vi.mock("../stores/settings.svelte", () => ({
+  settingsState: {
+    apiProvider: "bitunix",
+    capabilities: { marketData: true },
+    chartHistoryLimit: 1000,
+  },
+}));
+
+vi.mock("../stores/market.svelte", () => ({
+  marketState: {
+    data: {},
+    connectionStatus: "connected",
+    updateSymbol: vi.fn(),
+    updateSymbolKlines: vi.fn(),
+  },
+}));
+
+vi.mock("./bitunixWs", () => ({
+  bitunixWs: {
+    pendingSubscriptions: new Map<string, number>(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  },
+}));
+
+interface MarketWatcherInternals {
+  requests: Map<string, Map<string, Map<string, number>>>;
+}
+
+const watcher = marketWatcher as unknown as MarketWatcherInternals;
+const pending = bitunixWs.pendingSubscriptions as Map<string, number>;
+
+describe("MarketWatcher.resync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    watcher.requests.clear();
+    pending.clear();
+  });
+
+  it("restores a subscription the provider forgot across a destroy()/connect() cycle", () => {
+    // A tile registers interest; the live socket records the subscription.
+    marketWatcher.register("BTCUSDT", "price");
+    expect(bitunixWs.subscribe).toHaveBeenCalledWith("BTCUSDT", "price");
+    vi.mocked(bitunixWs.subscribe).mockClear();
+
+    // Simulate ConnectionManager tearing the provider down and reconnecting
+    // it (e.g. app.init()'s initial switchProvider race). destroy() wipes the
+    // provider's own subscription buffer, but MarketWatcher never
+    // unregistered BTCUSDT:price - a tile is still relying on this data.
+    pending.clear();
+
+    marketWatcher.resync();
+
+    expect(bitunixWs.subscribe).toHaveBeenCalledWith("BTCUSDT", "price");
+  });
+
+  it("does not re-subscribe a channel the provider already has", () => {
+    marketWatcher.register("BTCUSDT", "price");
+    // Simulate the provider having actually recorded the subscription.
+    pending.set("price:BTCUSDT", 1);
+    vi.mocked(bitunixWs.subscribe).mockClear();
+
+    marketWatcher.resync();
+
+    expect(bitunixWs.subscribe).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes a channel the provider still has but nothing wants anymore", () => {
+    pending.set("price:STALEUSDT", 1);
+
+    marketWatcher.resync();
+
+    expect(bitunixWs.unsubscribe).toHaveBeenCalledWith("STALEUSDT", "price");
+  });
+});


### PR DESCRIPTION
## Summary

Root-caused two independent bugs behind the browser console errors and empty market tiles the user reported.

### 1. WS init race (`app.init()` connecting twice)

`app.init()` connected the WebSocket provider **twice** on startup: once via `setupRealtimeUpdates()`'s settings subscription — whose initial synchronous emit always looked like a key change, because `lastKeys` started as `""` instead of the real current keys — and once via its own explicit `connectionManager.switchProvider()` call. The second call's `killAll()` destroyed the socket the first call had just opened, which is exactly what produced the "WebSocket is closed before the connection is established" console messages. `bitunixWs.destroy()` also wipes `pendingSubscriptions` on every teardown, but `MarketWatcher`'s own registered interest (`this.requests`) survives untouched, and nothing reconciled the two afterwards — so subscriptions were silently lost and tiles never received data until a click triggered a direct REST fetch. The REST polling fallback couldn't cover that gap either, since `ConnectionManager.onProviderConnected()` stopped it the instant the socket opened, before any data had arrived.

- `setupRealtimeUpdates()` seeds its provider/key comparison from the current settings snapshot (so its initial emit is a no-op) and routes every subsequent change through `connectionManager.switchProvider()` instead of calling `bitunixWs`/`bitgetWs` `connect()`/`destroy()` directly — `ConnectionManager` becomes the single owner of the connection lifecycle.
- `MarketWatcher` gains a `resync()` that reconciles its subscription requests against the live connection. `ConnectionManager` calls it whenever a provider reports a successful (re)connect, restoring subscriptions the provider's own buffer lost across a `destroy()`/`connect()` cycle.
- `ConnectionManager` no longer stops the polling fallback on connect (only triggers a resync) — `performPollingCycle()` already skips REST calls per-symbol once WS data is fresh, so leaving the loop running is a cheap, continuous safety net instead of a one-shot check made before any data could possibly have arrived.
- Reordered `bitunixWs`'s `onopen` handler so the existing buffer flush runs before the new resync notification, so the two don't send the same subscription twice moments apart.

### 2. Bitget symbol-key mismatch

Every writer of `marketState.data` (MarketWatcher's REST polling via `apiService`, the Bitunix WS handler) keys it by `normalizeSymbol(symbol, "bitunix")` — the codebase's established canonical form, used consistently in `marketWatcher.ts`, `bitunixWs.ts`, `CandleChartView.svelte`, `dataRepairService.ts`, etc. — regardless of which provider is active. Five read sites instead keyed their lookup by `normalizeSymbol(symbol, settingsState.apiProvider)`, which is a no-op under Bitunix but produces a `"_UMCBL"`-suffixed key under Bitget that nothing ever writes to. Under Bitget this silently broke: market tiles (`MarketOverview.svelte`), the flashcard price-trend color, the burning-border price-trend effect, MarketWatcher's own request key for the currently selected trading symbol, and the auto-updating price input.

Fixed all five call sites (`MarketOverview.svelte`, `FlashCard.svelte`, `burn.ts`, and two spots in `app.ts`) to normalize with `"bitunix"` for store lookups, matching every writer. Left the remaining provider-parameterized `normalizeSymbol()` calls alone (`apiService.ts`'s URL-building, `dataRepairService.ts`'s REST fetches, `trade.svelte.ts`'s `setSymbol()`, `mdaService.ts`'s `normalizeTicker()`) since they either legitimately need the provider-specific wire format or are never invoked with `"bitget"` today.

Not in scope for this PR (flagged to the user separately): the `/api/*` 401s (deployment config, `APP_ACCESS_TOKEN`) and the `THREE.Clock` deprecation warnings.

## Test plan

- [x] `npm run check` (via `svelte-check --output human-verbose`, since the default machine-output mode was unreliable in this sandbox) — 0 errors, 0 warnings
- [x] `npx vitest run` — full suite: 161 files passed, 862 tests passed (2 skipped files / 6 skipped tests, pre-existing and unrelated)
- [x] Added `connectionManager.test.ts`, `marketWatcher_resync.test.ts`, `app_realtimeUpdates.test.ts`, `app_bitgetSymbolKey.test.ts` — all fail against the pre-fix code and pass against the fix, confirming they exercise the actual regressions
