### PR TITLE
fix: 401 Unauthorized on guarded API routes (missing app access token header)

### DIFF
--- a/src/components/inputs/PortfolioInputs.svelte
+++ b/src/components/inputs/PortfolioInputs.svelte
@@ -29,6 +29,7 @@
   import { uiState } from "../../stores/ui.svelte";
   import { safeJsonParse } from "../../utils/safeJson";
   import { mapApiErrorToLabel } from "../../utils/errorUtils";
+  import { appFetch } from "../../lib/appAuth";
 
   interface Props {
     accountSize: string | null;
@@ -156,7 +157,7 @@
 
     isFetchingBalance = true;
     try {
-      const res = await fetch("/api/balance", {
+      const res = await appFetch("/api/balance", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/shared/PositionsSidebar.svelte
+++ b/src/components/shared/PositionsSidebar.svelte
@@ -24,6 +24,7 @@
   import { _ } from "../../locales/i18n";
   import { tradeService } from "../../services/tradeService";
   import { getDisplayMessage } from "../../utils/errorUtils";
+  import { appFetch } from "../../lib/appAuth";
   import type { OMSPosition } from "../../services/omsTypes";
   import type { NormalizedOrder } from "../../types/bitunix";
   import type { TranslationKey } from "../../locales/schema";
@@ -125,7 +126,7 @@
     loadingPositions = true;
     errorPositions = "";
     try {
-      const response = await fetch("/api/positions", {
+      const response = await appFetch("/api/positions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -167,7 +168,7 @@
     }
 
     try {
-      const response = await fetch("/api/orders", {
+      const response = await appFetch("/api/orders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -202,7 +203,7 @@
     if (!keys?.key || !keys?.secret) return;
 
     try {
-      const response = await fetch("/api/account", {
+      const response = await appFetch("/api/account", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/lib/appAuth.test.ts
+++ b/src/lib/appAuth.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { settingsState } from "../stores/settings.svelte";
+import { appAuthHeaders, appFetch } from "./appAuth";
+
+describe("appAuthHeaders", () => {
+  const originalToken = settingsState.appAccessToken;
+
+  afterEach(() => {
+    settingsState.appAccessToken = originalToken;
+  });
+
+  it("attaches x-app-access-token when a token is configured", () => {
+    settingsState.appAccessToken = "secret-token";
+    expect(appAuthHeaders()["x-app-access-token"]).toBe("secret-token");
+  });
+
+  it("omits the header rather than sending it empty", () => {
+    settingsState.appAccessToken = "";
+    expect(appAuthHeaders()).not.toHaveProperty("x-app-access-token");
+  });
+
+  it("merges with caller-provided headers instead of replacing them", () => {
+    settingsState.appAccessToken = "secret-token";
+    const headers = appAuthHeaders({ "Content-Type": "application/json" });
+    expect(headers).toEqual({
+      "Content-Type": "application/json",
+      "x-app-access-token": "secret-token",
+    });
+  });
+});
+
+describe("appFetch", () => {
+  const originalToken = settingsState.appAccessToken;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    settingsState.appAccessToken = "secret-token";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("{}"));
+  });
+
+  afterEach(() => {
+    settingsState.appAccessToken = originalToken;
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sends the token header while preserving method and body", async () => {
+    await appFetch("/api/balance", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ exchange: "bitunix" }),
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/balance",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ exchange: "bitunix" }),
+        headers: {
+          "Content-Type": "application/json",
+          "x-app-access-token": "secret-token",
+        },
+      }),
+    );
+  });
+});

--- a/src/lib/appAuth.ts
+++ b/src/lib/appAuth.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { settingsState } from "../stores/settings.svelte";
+
+/**
+ * The single way client code reaches an API route guarded by `checkAppAuth`.
+ *
+ * Since ADR-0002 those routes fail closed: without the `x-app-access-token`
+ * header they answer 401, and the app cannot talk to its own backend. The
+ * header was previously spelled out at each call site, which is how several of
+ * them ended up never sending it at all — see `src/tests/security/
+ * app_auth_headers.test.ts`, which fails the build if a raw `fetch` reappears.
+ *
+ * The token is Class A data under ADR-0001. It lives in `localStorage` (as part
+ * of the encrypted settings blob) and travels only to this app's own proxy, as
+ * the credential of a user-initiated request.
+ */
+
+/**
+ * Headers for a request to a guarded route, merged over `extra`.
+ *
+ * The token is omitted when empty rather than sent as an empty string. An empty
+ * header is not a credential, and `settingsState` holds `""` both before the
+ * user has configured a token and while the settings are locked — neither is a
+ * request worth labelling as authenticated.
+ */
+export function appAuthHeaders(
+  extra?: HeadersInit,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  // Normalise Headers / [key, value][] / Record alike, so callers can pass
+  // whatever shape they already had.
+  if (extra) {
+    new Headers(extra).forEach((value, key) => {
+      headers[key] = value;
+    });
+  }
+
+  const token = settingsState.appAccessToken;
+  if (token) {
+    headers["x-app-access-token"] = token;
+  }
+
+  return headers;
+}
+
+/**
+ * `fetch` with the app access token attached.
+ *
+ * A drop-in replacement: everything else in `init` — method, body, signal —
+ * is passed through untouched.
+ */
+export function appFetch(
+  input: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return fetch(input, { ...init, headers: appAuthHeaders(init.headers) });
+}

--- a/src/locales/locales/de.json
+++ b/src/locales/locales/de.json
@@ -1536,7 +1536,9 @@
     "invalidAmount": "Invalid order amount",
     "syncIncomplete": "Sync incomplete (Timeout).",
     "syncNoNewData": "No new positions found.",
-    "syncFailed": "Sync failed: {error}"
+    "syncFailed": "Sync failed: {error}",
+    "unauthorized": "Nicht autorisiert. Prüfe den App-Zugangstoken unter Einstellungen → Verbindungen.",
+    "tooManyRequests": "Zu viele Anfragen. Bitte kurz warten und erneut versuchen."
   },
   "bitunixErrors": {
     "10001": "Network Error",

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -1505,7 +1505,9 @@
     "invalidAmount": "Invalid order amount",
     "syncIncomplete": "Sync incomplete (Timeout).",
     "syncNoNewData": "No new positions found.",
-    "syncFailed": "Sync failed: {error}"
+    "syncFailed": "Sync failed: {error}",
+    "unauthorized": "Unauthorized. Check the App Access Token under Settings → Connections.",
+    "tooManyRequests": "Too many requests. Please wait a moment and try again."
   },
   "chartPatterns": {
     "title": "Chart Patterns Academy",

--- a/src/locales/schema.d.ts
+++ b/src/locales/schema.d.ts
@@ -1321,6 +1321,8 @@ export type TranslationKey =
   | "apiErrors.syncIncomplete"
   | "apiErrors.syncNoNewData"
   | "apiErrors.syncFailed"
+  | "apiErrors.unauthorized"
+  | "apiErrors.tooManyRequests"
   | "chartPatterns.title"
   | "chartPatterns.searchPlaceholder"
   | "chartPatterns.description"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -64,7 +64,14 @@ import { afterNavigate } from "$app/navigation";
     const shouldEnable =
       settingsState.enableNetworkLogs || import.meta.env.DEV || isDevDomain;
 
-    if (shouldEnable) {
+    // No admin token, no stream: the server denies every request without one
+    // (LOG_STREAM_KEY is unset by default, ADR-0002 fails closed), and nothing
+    // in this app ever writes "cachy_admin_token" to localStorage — it is set
+    // manually via devtools when an operator wants to watch logs. Without it,
+    // connecting is a guaranteed 401/403 on every page load.
+    const adminToken = localStorage.getItem("cachy_admin_token") || "";
+
+    if (shouldEnable && adminToken) {
       abortController = new AbortController();
 
       const connectStream = async () => {
@@ -73,8 +80,6 @@ import { afterNavigate } from "$app/navigation";
 
         while (!abortController?.signal.aborted) {
           try {
-            const adminToken = localStorage.getItem("cachy_admin_token") || "";
-
             const response = await fetch("/api/stream-logs", {
               headers: {
                 "Authorization": `Bearer ${adminToken}` // i18n-ignore

--- a/src/services/cmcService.ts
+++ b/src/services/cmcService.ts
@@ -8,6 +8,7 @@
  */
 
 import { settingsState } from "../stores/settings.svelte";
+import { appFetch } from "../lib/appAuth";
 
 interface CacheEntry<T> {
   data: T;
@@ -56,7 +57,7 @@ class CmcService {
     const query = new URLSearchParams(params);
     query.append("endpoint", endpoint);
 
-    const res = await fetch(`/api/external/cmc?${query.toString()}`, {
+    const res = await appFetch(`/api/external/cmc?${query.toString()}`, {
       headers: {
         "x-cmc-api-key": apiKey,
       },

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 import CryptoJS from "crypto-js";
 import { safeJsonParse } from "../utils/safeJson";
 import { CryptoPanicResponseSchema, NewsApiResponseSchema } from "../types/newsSchemas";
+import { appFetch } from "../lib/appAuth";
 
 const isBrowser = typeof window !== "undefined";
 
@@ -231,10 +232,9 @@ export const newsService = {
 
             let res;
             try {
-              res = await fetch("/api/external/news", {
+              res = await appFetch("/api/external/news", {
                 method: "POST",
                 headers: {
-                  "x-app-access-token": settingsState.appAccessToken || "",
                   "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
@@ -289,10 +289,9 @@ export const newsService = {
 
             let res;
             try {
-              res = await fetch("/api/external/news", {
+              res = await appFetch("/api/external/news", {
                 method: "POST",
                 headers: {
-                  "x-app-access-token": settingsState.appAccessToken || "",
                   "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
@@ -451,7 +450,7 @@ export const newsService = {
         const timeoutId = setTimeout(() => controller.abort(), 20000); // 20s for AI
 
         // Secure Server-Side Execution
-        const response = await fetch("/api/sentiment", {
+        const response = await appFetch("/api/sentiment", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),

--- a/src/services/rssParserService.ts
+++ b/src/services/rssParserService.ts
@@ -9,6 +9,7 @@
 
 import type { NewsItem } from "./newsService";
 import { logger } from "./logger";
+import { appFetch } from "../lib/appAuth";
 
 interface RawRssItem {
   title: string;
@@ -25,7 +26,7 @@ export const rssParserService = {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 15000); // 15s client timeout
 
-      const response = await fetch("/api/rss-fetch", {
+      const response = await appFetch("/api/rss-fetch", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -27,6 +27,7 @@ import { get } from "svelte/store";
 import { _ } from "../locales/i18n";
 import type { TranslationKey } from "../locales/schema";
 import { trackCustomEvent } from "./trackingService";
+import { appFetch } from "../lib/appAuth";
 import { browser } from "$app/environment";
 import { calculator } from "../lib/calculator";
 import { StorageHelper } from "../utils/storageHelper";
@@ -191,7 +192,7 @@ export const syncService = {
 
     try {
       // 1. Fetch History Positions
-      const historyResponse = await fetch("/api/sync/positions-history", {
+      const historyResponse = await appFetch("/api/sync/positions-history", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -206,7 +207,7 @@ export const syncService = {
       const historyPositions = historyResult.data;
 
       // 2. Fetch Pending Positions
-      const pendingResponse = await fetch("/api/sync/positions-pending", {
+      const pendingResponse = await appFetch("/api/sync/positions-pending", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -221,7 +222,7 @@ export const syncService = {
         : [];
 
       // 3. Fetch Orders
-      const orderResponse = await fetch("/api/sync/orders", {
+      const orderResponse = await appFetch("/api/sync/orders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/services/tradeService.ts
+++ b/src/services/tradeService.ts
@@ -36,6 +36,7 @@ import { tradeState } from "../stores/trade.svelte";
 import { safeJsonParse } from "../utils/safeJson";
 import { PositionRawSchema } from "../types/apiSchemas";
 import type { OMSOrderSide } from "./omsTypes";
+import { appAuthHeaders, appFetch } from "../lib/appAuth";
 
 export interface TpSlOrder {
     orderId: string;
@@ -102,14 +103,13 @@ class TradeService {
             throw new Error("apiErrors.missingCredentials");
         }
 
-        const headers: Record<string, string> = {
+        const headers = appAuthHeaders({
             "Content-Type": "application/json",
             "X-Provider": provider,
-            ...(settingsState.appAccessToken ? { "x-app-access-token": settingsState.appAccessToken } : {}),
             "X-Api-Key": keys.key,
             "X-Api-Secret": keys.secret,
             ...(keys.passphrase ? { "X-Api-Passphrase": keys.passphrase } : {})
-        };
+        });
 
         // Deep serialize Decimals to strings before JSON.stringify
         const serializedPayload = this.serializePayload(payload);
@@ -361,11 +361,10 @@ class TradeService {
             const keys = settingsState.apiKeys[provider];
             if (!keys?.key || !keys?.secret) return;
 
-            const pendingResponse = await fetch("/api/sync/positions-pending", {
+            const pendingResponse = await appFetch("/api/sync/positions-pending", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    ...(settingsState.appAccessToken ? { "x-app-access-token": settingsState.appAccessToken } : {}),
                     "X-Api-Key": keys.key,
                     "X-Api-Secret": keys.secret
                 },

--- a/src/stores/ai.svelte.ts
+++ b/src/stores/ai.svelte.ts
@@ -25,6 +25,7 @@ import { newsService } from "../services/newsService";
 import { getRelativeTimeString } from "../lib/utils/timeUtils";
 import { parseAiValue } from "../utils/utils";
 import { logger } from "../services/logger";
+import { appFetch } from "../lib/appAuth";
 import type { JournalEntry } from "./types";
 import type { Position } from "./account.svelte";
 
@@ -361,7 +362,7 @@ BEFORE SENDING YOUR RESPONSE (Chain-of-Thought Verification):
 
       while (attempt < MAX_RETRIES) {
         try {
-          res = await fetch(endpoint, {
+          res = await appFetch(endpoint, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/src/tests/security/app_auth_headers.test.ts
+++ b/src/tests/security/app_auth_headers.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment node
+//
+// This test walks the source tree from disk. Under the happy-dom default set in
+// vite.config.ts, import.meta.url is not a file:// URL and readFileSync rejects
+// it. No DOM is needed here, so pin the node environment.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+/**
+ * Keeps the client in step with `checkAppAuth`.
+ *
+ * Since ADR-0002 authentication fails closed: every route that calls
+ * `checkAppAuth` answers 401 unless the caller sends `x-app-access-token`. That
+ * makes a plain `fetch("/api/orders", …)` a silent breakage — it compiles, it
+ * type-checks, and it fails only in the browser of whoever deployed it.
+ *
+ * It has already happened twice. `chat.svelte.ts` never sent the header
+ * (docs/ROADMAP.md, item 12), and the balance, account, positions and orders
+ * call sites did not either. Both were found from console output rather than
+ * from CI.
+ *
+ * So: client code reaches guarded routes through `appFetch` from
+ * `$lib/appAuth`, and this test fails the build when a raw `fetch` slips back
+ * in.
+ */
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+/** Directories holding code that runs in the browser. */
+const CLIENT_DIRS = ["src/components", "src/services", "src/stores", "src/routes"];
+
+/** `+server.ts` files are the routes themselves, not clients of them. */
+function collectClientFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === "node_modules" || entry === ".svelte-kit") continue;
+      collectClientFiles(path, found);
+      continue;
+    }
+    if (!/\.(ts|js|svelte)$/.test(entry)) continue;
+    if (/\.(test|spec|bench)\.(ts|js)$/.test(entry)) continue;
+    if (entry === "+server.ts" || entry === "+server.js") continue;
+    found.push(path);
+  }
+  return found;
+}
+
+/** Every `src/routes/api/**\/+server.ts` that calls `checkAppAuth`. */
+function collectGuardedRoutes(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      collectGuardedRoutes(path, found);
+      continue;
+    }
+    if (entry !== "+server.ts") continue;
+    if (!/\bcheckAppAuth\s*\(/.test(readFileSync(path, "utf-8"))) continue;
+
+    // src/routes/api/sync/orders/+server.ts -> /api/sync/orders
+    const route = path
+      .slice(join(repoRoot, "src/routes").length)
+      .replace(/[/\\]\+server\.ts$/, "")
+      .replace(/\\/g, "/");
+    found.push(route);
+  }
+  return found;
+}
+
+/**
+ * Call sites of the global `fetch` with a literal `/api/...` path, as
+ * `fetch("/api/x"`, `fetch(`/api/x`` or `await fetch('/api/x'`. Deliberately
+ * literal-only: a computed URL cannot be resolved statically, and guessing at
+ * one would trade a useful signal for false alarms.
+ *
+ * `appFetch(...)` does not match — the pattern requires `fetch` to start the
+ * identifier, so the helper's own call sites pass.
+ */
+function rawApiFetches(source: string): string[] {
+  const paths: string[] = [];
+  for (const [, path] of source.matchAll(
+    /(?<![.\w])fetch\s*\(\s*[`'"](\/api\/[^`'"?\s]*)/g,
+  )) {
+    paths.push(path);
+  }
+  return paths;
+}
+
+describe("client callers of guarded API routes send the app access token", () => {
+  const guardedRoutes = collectGuardedRoutes(join(repoRoot, "src/routes/api"));
+
+  const clientFiles = CLIENT_DIRS.flatMap((dir) =>
+    collectClientFiles(join(repoRoot, dir)),
+  );
+
+  it("finds the routes and files it is supposed to be checking", () => {
+    // Guards the scanner itself: a regex that silently matches nothing would
+    // make every assertion below pass vacuously.
+    expect(guardedRoutes).toContain("/api/orders");
+    expect(guardedRoutes).toContain("/api/balance");
+    expect(guardedRoutes.length).toBeGreaterThan(10);
+    expect(clientFiles.length).toBeGreaterThan(20);
+  });
+
+  it("recognises a raw fetch when it sees one", () => {
+    // The scanner is the whole test. If `rawApiFetches` stopped matching, the
+    // audit below would report a clean bill of health for any codebase at all.
+    expect(rawApiFetches('await fetch("/api/orders", { method: "POST" })')).toEqual([
+      "/api/orders",
+    ]);
+    expect(rawApiFetches("fetch(`/api/tickers?${q}`)")).toEqual(["/api/tickers"]);
+    expect(rawApiFetches('appFetch("/api/orders")')).toEqual([]);
+  });
+
+  it("routes every guarded call through appFetch", () => {
+    const offenders: string[] = [];
+
+    for (const file of clientFiles) {
+      const source = readFileSync(file, "utf-8");
+      for (const path of rawApiFetches(source)) {
+        if (!guardedRoutes.includes(path)) continue;
+        offenders.push(`${file.slice(repoRoot.length)} -> ${path}`);
+      }
+    }
+
+    expect(
+      offenders,
+      "These call plain fetch() on a route guarded by checkAppAuth, so the " +
+        "server answers 401. Use appFetch from $lib/appAuth instead:\n" +
+        offenders.map((o) => `  ${o}`).join("\n"),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `401 Unauthorized` errors reported on `dev.cachy.app` for `/api/balance`, `/api/account`, `/api/positions` and `/api/orders`, plus the latent `403` on `/api/stream-logs`.

- **Root cause:** since ADR-0002, `checkAppAuth` fails closed and requires the `x-app-access-token` header on 17 guarded routes. Several client call sites used a raw `fetch()` and never attached it — 4 of them are the ones seen in the console, 5 more (`syncService`, `cmcService`, `rssParserService`, `newsService` sentiment, `ai.svelte.ts`) had the same latent bug and would fail 401 as soon as used. This is the second time this exact bug has shipped (see `docs/ROADMAP.md` on `chat.svelte.ts`).
- Added `src/lib/appAuth.ts` (`appAuthHeaders` / `appFetch`) as the single path to a guarded route, and moved every call site onto it — including the two that already worked, so there is exactly one pattern left.
- Added a static guard test (`src/tests/security/app_auth_headers.test.ts`) that fails the build if a raw `fetch()` on a `checkAppAuth`-guarded route reappears.
- `mapApiErrorToLabel` mapped 401/429 to i18n keys (`apiErrors.unauthorized`, `apiErrors.tooManyRequests`) that didn't exist in `de.json`/`en.json` — added in both languages, pointing at Settings → Connections for the token case.
- `+layout.svelte` auto-connected to `/api/stream-logs` on `dev.*` domains with an admin token that nothing in the app ever sets — now skipped when no token is present in `localStorage`.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx vitest run src/tests/security/app_auth_headers.test.ts` — guard test red before the header fix, green after
- [x] `npx vitest run src/lib/appAuth.test.ts src/lib/server/auth.test.ts src/tests/env_documentation.test.ts` — passing
- [x] `npm test` (full suite) — 163 files / 869 tests passed, 2 files / 6 tests skipped (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01VgmSnFdgxqxJL1aQCHWjsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgmSnFdgxqxJL1aQCHWjsE)_