### PR TITLE
fix: wait for secret decryption before sending guarded API requests

### DIFF
--- a/src/lib/appAuth.test.ts
+++ b/src/lib/appAuth.test.ts
@@ -79,4 +79,40 @@ describe("appFetch", () => {
       }),
     );
   });
+
+  it("waits for the secrets to be decrypted before sending", async () => {
+    // The regression: the token is restored from localStorage by an async
+    // decryption, while the account/positions/orders/balance fetches all run
+    // from onMount. Firing before the decryption lands meant an empty token
+    // and a 401 on every page load.
+    let releaseSecrets!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseSecrets = resolve;
+    });
+
+    const readySpy = vi
+      .spyOn(settingsState, "secretsReady", "get")
+      .mockReturnValue(gate);
+
+    settingsState.appAccessToken = "";
+    const pending = appFetch("/api/balance", { method: "POST" });
+
+    // Still gated: nothing may go out while the token is unresolved.
+    await Promise.resolve();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    // Decryption lands, then the request goes out carrying the token.
+    settingsState.appAccessToken = "secret-token";
+    releaseSecrets();
+    await pending;
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/balance",
+      expect.objectContaining({
+        headers: { "x-app-access-token": "secret-token" },
+      }),
+    );
+
+    readySpy.mockRestore();
+  });
 });

--- a/src/lib/appAuth.ts
+++ b/src/lib/appAuth.ts
@@ -65,10 +65,18 @@ export function appAuthHeaders(
  *
  * A drop-in replacement: everything else in `init` — method, body, signal —
  * is passed through untouched.
+ *
+ * Waits for `settingsState.secretsReady` first. The token is restored from
+ * localStorage by an asynchronous decryption, so a request fired during
+ * startup — the account, positions, orders and balance fetches all run from
+ * `onMount` — would otherwise read an empty token and take a 401 that a later,
+ * hand-clicked retry of the same request does not. The headers are built after
+ * the await, never before.
  */
-export function appFetch(
+export async function appFetch(
   input: string,
   init: RequestInit = {},
 ): Promise<Response> {
+  await settingsState.secretsReady;
   return fetch(input, { ...init, headers: appAuthHeaders(init.headers) });
 }

--- a/src/services/tradeService.ts
+++ b/src/services/tradeService.ts
@@ -36,7 +36,7 @@ import { tradeState } from "../stores/trade.svelte";
 import { safeJsonParse } from "../utils/safeJson";
 import { PositionRawSchema } from "../types/apiSchemas";
 import type { OMSOrderSide } from "./omsTypes";
-import { appAuthHeaders, appFetch } from "../lib/appAuth";
+import { appFetch } from "../lib/appAuth";
 
 export interface TpSlOrder {
     orderId: string;
@@ -103,18 +103,18 @@ class TradeService {
             throw new Error("apiErrors.missingCredentials");
         }
 
-        const headers = appAuthHeaders({
+        const headers: Record<string, string> = {
             "Content-Type": "application/json",
             "X-Provider": provider,
             "X-Api-Key": keys.key,
             "X-Api-Secret": keys.secret,
             ...(keys.passphrase ? { "X-Api-Passphrase": keys.passphrase } : {})
-        });
+        };
 
         // Deep serialize Decimals to strings before JSON.stringify
         const serializedPayload = this.serializePayload(payload);
 
-        const response = await fetch(endpoint, {
+        const response = await appFetch(endpoint, {
             method,
             headers,
             body: JSON.stringify(serializedPayload)

--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -877,8 +877,35 @@ export class SettingsManager {
   isEncrypted = $state(false);
   isLocked = $state(false);
 
+  /**
+   * Resolves once `load()` has restored the encrypted secrets into memory.
+   *
+   * Decrypting them is asynchronous — it needs the device key from IndexedDB
+   * and then WebCrypto — while the auto-fetches on mount are not. Without this
+   * gate they raced the decryption and went out with an empty
+   * `appAccessToken`, so every `checkAppAuth`-guarded route answered 401 on
+   * page load while the very same request succeeded once clicked by hand.
+   *
+   * `appFetch` awaits this before sending. It always settles: in
+   * master-password mode there is nothing to wait for (the vault is locked and
+   * stays locked until the user unlocks it), and a failed decryption resolves
+   * too rather than blocking every request forever.
+   */
+  readonly secretsReady: Promise<void>;
+  private resolveSecretsReady: () => void = () => {};
+
   constructor() {
-    if (browser) {
+    this.secretsReady = new Promise((resolve) => {
+      this.resolveSecretsReady = resolve;
+    });
+
+    if (!browser) {
+      // Server-side render: no localStorage to restore from.
+      this.resolveSecretsReady();
+      return;
+    }
+
+    {
       // 1. Load settings synchronously (effectActive is false, so no saves)
       this.load();
 
@@ -1106,6 +1133,11 @@ export class SettingsManager {
   }
 
   private load() {
+    // Set when the background decryption below takes over responsibility for
+    // resolving `secretsReady`. Every other path through load() resolves it
+    // itself, so a caller awaiting it is never left hanging.
+    let secretsPending = false;
+
     try {
       const d = localStorage.getItem(CONSTANTS.LOCAL_STORAGE_SETTINGS_KEY);
       if (!d) {
@@ -1216,7 +1248,8 @@ export class SettingsManager {
         if (!this.isEncrypted) {
           // We need to trigger this async but load is sync.
           // We'll launch a background decryption.
-          (async () => {
+          secretsPending = true;
+          void (async () => {
             try {
               const deviceKey = await this.getDeviceKey();
               const entries = Object.entries(this.encryptedSecrets || {});
@@ -1244,6 +1277,11 @@ export class SettingsManager {
                 "[Settings] Failed to initialize background decryption",
                 e,
               );
+            } finally {
+              // Release waiters even when decryption failed — a request without
+              // the token gets a clean 401, a request that never fires hangs
+              // the UI.
+              this.resolveSecretsReady();
             }
           })();
         }
@@ -1461,6 +1499,9 @@ export class SettingsManager {
       }
       // Save defaults to fix corrupted localStorage
       this.save();
+    } finally {
+      // The background decryption resolves this itself once it is done.
+      if (!secretsPending) this.resolveSecretsReady();
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1598. That PR made every client call site attach `x-app-access-token`; this one fixes *when* it is attached.

- The token is restored from `localStorage` by an **asynchronous** decryption — device key from IndexedDB, then WebCrypto. On the affected deployment this takes roughly **4 seconds**.
- The account, positions, orders and balance fetches all run from `onMount` and did not wait for it. They went out with an empty `appAccessToken`, `appFetch` correctly omitted the header, and every guarded route answered 401 — while the identical request triggered by hand a moment later succeeded. That asymmetry is what made this look like a server misconfiguration for so long.
- Adds `settingsState.secretsReady`, resolved once `load()` has restored the secrets, and awaits it in `appFetch` before building the headers. Gating the single choke point covers every call site at once, including future ones.
- The promise **always settles** — on decryption failure, in master-password mode, and during SSR — so a missing token yields a clean 401 rather than a request that never fires.
- `tradeService.signedRequest` now goes through `appFetch` too; it was building headers via `appAuthHeaders` and calling `fetch` directly, which would have kept racing.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] New regression test in `src/lib/appAuth.test.ts`: asserts nothing is sent while the decryption gate is unresolved, and that the request carries the token once it lands. Fails against the previous synchronous `appFetch`.
- [x] `npm test` (full suite) — 163 files / 870 tests passed, 2 files / 6 tests skipped (pre-existing, unrelated)

## Verifying on a deployment

Load the app with the console open. The 401 burst on `/api/balance`, `/api/account`, `/api/positions` and `/api/orders` should be gone; the requests now leave a few seconds later, carrying the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgmSnFdgxqxJL1aQCHWjsE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgmSnFdgxqxJL1aQCHWjsE)_