### PR TITLE
fix: Bitget WS account sync field name mapping (BUG-0001)

### DIFF
--- a/src/services/bitgetWs.test.ts
+++ b/src/services/bitgetWs.test.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { accountState } from "../stores/account.svelte";
+import { bitgetWs } from "./bitgetWs";
+
+describe("Bitget WebSocket", () => {
+  beforeEach(() => {
+    // Clear account state before each test
+    accountState.reset();
+    // Reset authentication state on the singleton
+    const wsService = bitgetWs as any;
+    wsService.isAuthenticated = false;
+  });
+
+  describe("Login authentication", () => {
+    it("should authenticate on login acknowledgement with event=login and code=00000", () => {
+      // Create a minimal Bitget instance to access private handleMessage
+      const wsService = bitgetWs as any;
+      wsService.isAuthenticated = false;
+
+      const message = {
+        event: "login",
+        code: "00000"
+      };
+
+      // Call the private handleMessage method via reflection
+      wsService.handleMessage(message);
+      expect(wsService.isAuthenticated).toBe(true);
+    });
+
+    it("should not authenticate on login failure with code 30001", () => {
+      const wsService = bitgetWs as any;
+      wsService.isAuthenticated = false;
+
+      const message = {
+        event: "login",
+        code: "30001"
+      };
+
+      wsService.handleMessage(message);
+      expect(wsService.isAuthenticated).toBe(false);
+    });
+  });
+
+  describe("Position updates normalization", () => {
+    it("should add a position from Bitget WS payload with correct field mapping", () => {
+      const wsService = bitgetWs as any;
+
+      // Simulate a Bitget position push message
+      const message = {
+        action: "snapshot",
+        arg: {
+          channel: "positions",
+          instId: "default",
+          instType: "mc"
+        },
+        data: [
+          {
+            instId: "BTCUSDT_UMCBL",
+            total: "1.5",
+            openPriceAvg: "50000",
+            marginMode: "crossed",
+            leverage: "10",
+            unrealizedPL: "500.25",
+            holdSide: "long"
+          }
+        ]
+      };
+
+      // First authenticate
+      wsService.isAuthenticated = true;
+
+      // Process the position update
+      wsService.handleMessage(message);
+
+      // Verify position was added with correct data
+      expect(accountState.positions.length).toBe(1);
+      const position = accountState.positions[0];
+      expect(position.symbol).toBe("BTCUSDT_UMCBL");
+      expect(position.size.toFixed(1)).toBe("1.5");
+      expect(position.entryPrice.toFixed(0)).toBe("50000");
+      expect(position.marginMode).toBe("crossed");
+      expect(position.leverage.toFixed(0)).toBe("10");
+      expect(position.unrealizedPnl.toFixed(2)).toBe("500.25");
+      expect(position.side).toBe("long");
+    });
+
+    it("should handle multiple positions without overwriting", () => {
+      const wsService = bitgetWs as any;
+      wsService.isAuthenticated = true;
+
+      // Add first position
+      const message1 = {
+        action: "snapshot",
+        arg: {
+          channel: "positions",
+          instId: "default",
+          instType: "mc"
+        },
+        data: [
+          {
+            instId: "BTCUSDT_UMCBL",
+            total: "1.0",
+            openPriceAvg: "50000",
+            marginMode: "crossed",
+            leverage: "10",
+            unrealizedPL: "100",
+            holdSide: "long"
+          }
+        ]
+      };
+
+      wsService.handleMessage(message1);
+      expect(accountState.positions.length).toBe(1);
+
+      // Add second position with different symbol
+      const message2 = {
+        action: "snapshot",
+        arg: {
+          channel: "positions",
+          instId: "default",
+          instType: "mc"
+        },
+        data: [
+          {
+            instId: "ETHUSDT_UMCBL",
+            total: "2.0",
+            openPriceAvg: "2000",
+            marginMode: "crossed",
+            leverage: "5",
+            unrealizedPL: "200",
+            holdSide: "short"
+          }
+        ]
+      };
+
+      wsService.handleMessage(message2);
+
+      // Both positions should exist
+      expect(accountState.positions.length).toBe(2);
+
+      const btcPos = accountState.positions.find(p => p.symbol === "BTCUSDT_UMCBL");
+      const ethPos = accountState.positions.find(p => p.symbol === "ETHUSDT_UMCBL");
+
+      expect(btcPos).toBeDefined();
+      expect(ethPos).toBeDefined();
+      expect(btcPos?.size.toFixed(1)).toBe("1.0");
+      expect(ethPos?.size.toFixed(1)).toBe("2.0");
+      expect(btcPos?.side).toBe("long");
+      expect(ethPos?.side).toBe("short");
+    });
+  });
+
+  describe("Order updates normalization", () => {
+    it("should add an order from Bitget WS payload with correct field mapping", () => {
+      const wsService = bitgetWs as any;
+      wsService.isAuthenticated = true;
+
+      const message = {
+        action: "snapshot",
+        arg: {
+          channel: "orders",
+          instId: "default",
+          instType: "mc"
+        },
+        data: [
+          {
+            orderId: "order123",
+            instId: "BTCUSDT_UMCBL",
+            status: "live",
+            price: "51000",
+            accFillSize: "0.5"
+          }
+        ]
+      };
+
+      wsService.handleMessage(message);
+
+      expect(accountState.openOrders.length).toBe(1);
+      const order = accountState.openOrders[0];
+      expect(order.orderId).toBe("order123");
+      expect(order.symbol).toBe("BTCUSDT_UMCBL");
+      expect(order.status).toBe("live");
+      expect(order.price.toFixed(0)).toBe("51000");
+      expect(order.filled.toFixed(1)).toBe("0.5");
+    });
+  });
+
+  describe("Field name mapping", () => {
+    it("should correctly map Bitget position fields to internal format", () => {
+      const wsService = bitgetWs as any;
+
+      const bitgetPosition = {
+        instId: "BTCUSDT_UMCBL",
+        total: "1.5",
+        openPriceAvg: "50000",
+        marginMode: "crossed",
+        leverage: "10",
+        unrealizedPL: "500.25",
+        holdSide: "long"
+      };
+
+      const normalized = wsService.normalizePositionData(bitgetPosition);
+
+      // Check that all expected fields are mapped
+      expect(normalized.symbol).toBe("BTCUSDT_UMCBL");
+      expect(normalized.qty).toBe("1.5");
+      expect(normalized.averagePrice).toBe("50000");
+      expect(normalized.avgOpenPrice).toBe("50000");
+      expect(normalized.marginMode).toBe("crossed");
+      expect(normalized.leverage).toBe("10");
+      expect(normalized.unrealizedPNL).toBe("500.25");
+      expect(normalized.side).toBe("long");
+    });
+
+    it("should correctly map Bitget order fields to internal format", () => {
+      const wsService = bitgetWs as any;
+
+      const bitgetOrder = {
+        orderId: "order123",
+        instId: "BTCUSDT_UMCBL",
+        status: "live",
+        price: "51000",
+        accFillSize: "0.5"
+      };
+
+      const normalized = wsService.normalizeOrderData(bitgetOrder);
+
+      expect(normalized.orderId).toBe("order123");
+      expect(normalized.symbol).toBe("BTCUSDT_UMCBL");
+      expect(normalized.orderStatus).toBe("live");
+      expect(normalized.price).toBe("51000");
+      expect(normalized.qty).toBe("0.5");
+      expect(normalized.dealAmount).toBe("0.5");
+    });
+  });
+});

--- a/src/services/bitgetWs.test.ts
+++ b/src/services/bitgetWs.test.ts
@@ -7,23 +7,30 @@
  * (at your option) any later version.
  */
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { accountState } from "../stores/account.svelte";
 import { bitgetWs } from "./bitgetWs";
+
+interface BitgetWSService {
+  isAuthenticated: boolean;
+  handleMessage(message: Record<string, unknown>): void;
+  normalizeOrderData(order: Record<string, string | undefined>): Record<string, unknown>;
+  normalizePositionData(position: Record<string, string | undefined>): Record<string, unknown>;
+}
 
 describe("Bitget WebSocket", () => {
   beforeEach(() => {
     // Clear account state before each test
     accountState.reset();
     // Reset authentication state on the singleton
-    const wsService = bitgetWs as any;
+    const wsService = bitgetWs as unknown as BitgetWSService;
     wsService.isAuthenticated = false;
   });
 
   describe("Login authentication", () => {
     it("should authenticate on login acknowledgement with event=login and code=00000", () => {
       // Create a minimal Bitget instance to access private handleMessage
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
       wsService.isAuthenticated = false;
 
       const message = {
@@ -37,7 +44,7 @@ describe("Bitget WebSocket", () => {
     });
 
     it("should not authenticate on login failure with code 30001", () => {
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
       wsService.isAuthenticated = false;
 
       const message = {
@@ -52,7 +59,7 @@ describe("Bitget WebSocket", () => {
 
   describe("Position updates normalization", () => {
     it("should add a position from Bitget WS payload with correct field mapping", () => {
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
 
       // Simulate a Bitget position push message
       const message = {
@@ -94,7 +101,7 @@ describe("Bitget WebSocket", () => {
     });
 
     it("should handle multiple positions without overwriting", () => {
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
       wsService.isAuthenticated = true;
 
       // Add first position
@@ -161,7 +168,7 @@ describe("Bitget WebSocket", () => {
 
   describe("Order updates normalization", () => {
     it("should add an order from Bitget WS payload with correct field mapping", () => {
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
       wsService.isAuthenticated = true;
 
       const message = {
@@ -196,7 +203,7 @@ describe("Bitget WebSocket", () => {
 
   describe("Field name mapping", () => {
     it("should correctly map Bitget position fields to internal format", () => {
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
 
       const bitgetPosition = {
         instId: "BTCUSDT_UMCBL",
@@ -222,7 +229,7 @@ describe("Bitget WebSocket", () => {
     });
 
     it("should correctly map Bitget order fields to internal format", () => {
-      const wsService = bitgetWs as any;
+      const wsService = bitgetWs as unknown as BitgetWSService;
 
       const bitgetOrder = {
         orderId: "order123",

--- a/src/services/bitgetWs.ts
+++ b/src/services/bitgetWs.ts
@@ -24,20 +24,12 @@ import {
 } from "../types/bitgetValidation";
 import { Decimal } from "decimal.js";
 
-// Bitget's login acknowledgement — see the NOTE at its one use site.
-interface BitgetLoginResponse {
-  event?: string;
-  code?: string;
-}
-
 // [ts, open, high, low, close, volume] — Bitget candle array entry.
 type BitgetCandleTuple = [string, string, string, string, string, string];
 
 // Raw fields read off the "orders" / "positions" private WS channels, as
 // opposed to BitgetOrder (types/bitget.ts), which models the REST shape.
-// NOTE: forwarded to accountState.updateOrderFromWs/updatePositionFromWs,
-// which read Bitunix's field names (qty, positionId, orderStatus, ...) —
-// see docs/TODO.md item 3, not fixed here.
+// These are normalized to RawWsOrder/RawWsPosition before passing to accountState.
 interface BitgetWSOrderData {
   orderId?: string;
   instId?: string;
@@ -54,6 +46,7 @@ interface BitgetWSPositionData {
   marginMode?: string;
   leverage?: string;
   unrealizedPL?: string;
+  holdSide?: string;
 }
 
 const WS_URL = "wss://ws.bitget.com/mix/v1/stream";
@@ -403,18 +396,7 @@ class BitgetWebSocketService {
 
     const msg = validated.data;
 
-    if (msg.action === "login") { // Assuming action is login for response? Or separate event?
-      // Bitget sends event: "login", code: 00000 on success.
-      // My schema uses 'action'. Bitget usually sends { event: "login", code: ... }
-      // I might need to adjust schema for event messages vs data messages.
-    }
-    // Check event response
-    //
-    // NOTE: msg is validated.data from BitgetWSMessageSchema.safeParse(), a
-    // schema that requires `action` and does not declare `event`/`code` and
-    // is not .passthrough() — so a real Bitget login ack shaped this way may
-    // never reach here in practice. See docs/TODO.md item 3.
-    if ((msg as BitgetLoginResponse).event === "login" && (msg as BitgetLoginResponse).code === "00000") {
+    if (msg.event === "login" && msg.code === "00000") {
       this.isAuthenticated = true;
       if (settingsState.enableNetworkLogs) logger.log("network", "[WS-Bitget] Login success");
       this.subscribePrivate();
@@ -509,21 +491,8 @@ class BitgetWebSocketService {
       // Handle order updates
       if (Array.isArray(msg.data)) {
         msg.data.forEach((o: BitgetWSOrderData) => {
-          // Map to internal format
-          //
-          // NOTE: these field names (status, filled, avgPrice) don't match
-          // what updateOrderFromWs actually reads (orderStatus, dealAmount,
-          // price/qty) — cast preserves the existing (buggy) behavior rather
-          // than silently "fixing" it here. See docs/TODO.md item 3.
-          accountState.updateOrderFromWs({
-            orderId: o.orderId,
-            symbol: o.instId,
-            status: o.status,
-            filled: o.accFillSize, // executed qty
-            price: o.price,
-            avgPrice: o.priceAvg,
-            // etc
-          } as RawWsOrder);
+          const normalized = this.normalizeOrderData(o);
+          accountState.updateOrderFromWs(normalized);
         });
       }
     }
@@ -531,19 +500,8 @@ class BitgetWebSocketService {
     else if (channel === "positions") {
       if (Array.isArray(msg.data)) {
         msg.data.forEach((p: BitgetWSPositionData) => {
-          // NOTE: no positionId, and these field names (size, marginType,
-          // unrealizedPnl) don't match what updatePositionFromWs actually
-          // reads (qty, positionId, marginMode, unrealizedPNL) — cast
-          // preserves the existing (buggy) behavior rather than silently
-          // "fixing" it here. See docs/TODO.md item 3.
-          accountState.updatePositionFromWs({
-            symbol: p.instId,
-            size: p.total, // or available? total usually
-            entryPrice: p.openPriceAvg,
-            marginType: p.marginMode,
-            leverage: p.leverage,
-            unrealizedPnl: p.unrealizedPL
-          } as RawWsPosition);
+          const normalized = this.normalizePositionData(p);
+          accountState.updatePositionFromWs(normalized);
         });
       }
     }
@@ -687,6 +645,34 @@ class BitgetWebSocketService {
       // Best effort subscribe/unsubscribe. If the socket is not writable
       // the reconnect handler replays subscriptions.
     }
+  }
+
+  private normalizeOrderData(order: BitgetWSOrderData): RawWsOrder {
+    return {
+      orderId: order.orderId,
+      symbol: order.instId,
+      orderStatus: order.status,
+      price: order.price,
+      qty: order.accFillSize,
+      dealAmount: order.accFillSize,
+      ctime: undefined,
+    };
+  }
+
+  private normalizePositionData(position: BitgetWSPositionData): RawWsPosition {
+    return {
+      positionId: position.instId,
+      symbol: position.instId,
+      qty: position.total,
+      leverage: position.leverage,
+      marginMode: position.marginMode,
+      unrealizedPNL: position.unrealizedPL,
+      averagePrice: position.openPriceAvg,
+      avgOpenPrice: position.openPriceAvg,
+      side: position.holdSide,
+      event: undefined,
+      margin: undefined,
+    };
   }
 }
 

--- a/src/types/bitgetValidation.ts
+++ b/src/types/bitgetValidation.ts
@@ -22,11 +22,16 @@ export const BitgetWSArgSchema = z.object({
  * Schema for Bitget WebSocket Message
  */
 export const BitgetWSMessageSchema = z.object({
-  action: z.string(),
-  arg: BitgetWSArgSchema,
+  action: z.string().optional(),
+  arg: BitgetWSArgSchema.optional(),
   data: z.array(z.any()).optional(),
   ts: z.number().optional(),
-});
+  event: z.string().optional(),
+  code: z.string().optional(),
+}).refine(
+  (msg) => msg.action || msg.event,
+  "Message must have either 'action' or 'event' field"
+);
 
 /**
  * Schema for Bitget Ticker Data (WS)


### PR DESCRIPTION
## Summary

Fixes BUG-0001 where Bitget WebSocket account sync was silently failing to update positions and orders due to field name mismatches and authentication issues.

## Changes

### Schema Validation Fix
- Updated `BitgetWSMessageSchema` to accept `event`/`code` fields in addition to `action`
- Login messages from Bitget now pass validation (previously were rejected)

### Field Name Normalization
Added `normalizeOrderData()` and `normalizePositionData()` methods that map Bitget's WS payload field names to the format expected by `accountState`:

**Positions:**
- `instId` → `symbol` (also used as `positionId`)
- `total` → `qty` (position size)
- `openPriceAvg` → `averagePrice`/`avgOpenPrice`
- `holdSide` → `side` (long/short)
- `unrealizedPL` → `unrealizedPNL`

**Orders:**
- `instId` → `symbol`
- `status` → `orderStatus`
- `accFillSize` → `qty`/`dealAmount` (filled quantity)

### Removed Type Casts
Eliminated `as RawWsOrder` / `as RawWsPosition` casts that were preserving buggy behavior. All mappings now properly typed through normalization functions.

## Fixes

- ✅ Login authentication now succeeds with Bitget WS responses
- ✅ Positions are no longer treated as closed due to missing `qty`
- ✅ Multiple positions can coexist (using symbol as unique key instead of undefined positionId)
- ✅ Order updates have properly mapped field names

## Testing

- Added comprehensive test suite in `bitgetWs.test.ts` covering:
  - Login authentication success/failure
  - Position creation from Bitget WS payload
  - Multi-symbol position handling
  - Field name mapping for both positions and orders
- Verified Bitunix WS behavior unchanged (existing tests pass)
- Type checking clean (npm run check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThtV1yDyRbEesRyMiPKt28)_