### PR TITLE
fix: align develop version above main release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cachy-app",
-  "version": "1.0.0-beta.9",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cachy-app",
-      "version": "1.0.0-beta.9",
+      "version": "1.1.0-beta.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cachy-app",
-  "version": "1.0.0-beta.9",
+  "version": "1.1.0-beta.1",
   "description": "Local-first position size and risk management calculator for crypto traders.",
   "license": "AGPL-3.0-or-later",
   "private": true,


### PR DESCRIPTION
## Summary

Fixed version mismatch between `develop` and `main` branches. 

- **main**: v1.0.2 (stable)
- **develop**: ~~v1.0.0-beta.9~~ → v1.1.0-beta.1 (development)

The beta version was semantically older than the stable release, violating semantic versioning conventions. Bumped `develop` to v1.1.0-beta.1 to properly reflect the next minor version in development.

## Changes

- Updated `package.json` version from v1.0.0-beta.9 to v1.1.0-beta.1
- Synced `package-lock.json` accordingly

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgeqhjWKhvs3T7cSZYLK93)_