### PR TITLE
fix: bound upstream exchange fetch with a timeout in /api/klines

### DIFF
--- a/src/routes/api/klines/+server.ts
+++ b/src/routes/api/klines/+server.ts
@@ -48,6 +48,28 @@ interface BitunixRawKline {
 // [timestamp, open, high, low, close, volume, quoteVol]
 type BitgetCandleTuple = [string | number, string | number, string | number, string | number, string | number, string | number, (string | number)?];
 
+const UPSTREAM_TIMEOUT_MS = 8000;
+
+// Bounds the exchange fetch so a slow/unreachable upstream fails fast with a
+// proper JSON error instead of letting the reverse proxy in front of this
+// server time out first and return a raw 502 to the client.
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (e) {
+    if (e instanceof Error && e.name === "AbortError") {
+      const error = new Error("Upstream exchange API timed out") as ApiError;
+      error.status = 504;
+      throw error;
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export const GET: RequestHandler = async ({ url }) => {
   const symbol = url.searchParams.get("symbol");
   const interval = url.searchParams.get("interval") || "1d";
@@ -128,13 +150,13 @@ async function fetchBitunixKlines(
   const queryString = new URLSearchParams(params).toString();
   const fullUrl = `${baseUrl}${path}?${queryString}`;
 
-  const response = await fetch(fullUrl, {
+  const response = await fetchWithTimeout(fullUrl, {
     headers: {
       "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
       Accept: "application/json, text/plain, */*",
       "Accept-Language": "en-US,en;q=0.9",
     },
-  });
+  }, UPSTREAM_TIMEOUT_MS);
 
   if (!response.ok) {
     const text = await response.text();
@@ -247,7 +269,7 @@ async function fetchBitgetKlines(
 
   const queryString = new URLSearchParams(params).toString();
 
-  const response = await fetch(`${baseUrl}${path}?${queryString}`);
+  const response = await fetchWithTimeout(`${baseUrl}${path}?${queryString}`, {}, UPSTREAM_TIMEOUT_MS);
 
   if (!response.ok) {
     throw new Error(`Bitget API error: ${response.status}`);

--- a/src/routes/api/klines/klines.test.ts
+++ b/src/routes/api/klines/klines.test.ts
@@ -114,6 +114,32 @@ describe('GET /api/klines', () => {
     expect(json[0].open).toBe("0.0000001");
     // If it was Decimal(x).toString(), it would likely be "1e-7"
   });
+  it('should return a 504 instead of hanging when the upstream never responds', async () => {
+    vi.useFakeTimers();
+    vi.mocked(global.fetch).mockImplementation((_url, init) => {
+      const signal = (init as RequestInit | undefined)?.signal;
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const url = new URL('http://localhost/api/klines?symbol=BTCUSDT&provider=bitunix');
+    const responsePromise = GET({ url } as unknown as Parameters<typeof GET>[0]);
+
+    await vi.advanceTimersByTimeAsync(8000);
+
+    const response = await responsePromise;
+    const json = await response.json();
+
+    expect(response.status).toBe(504);
+    expect(json.error).toMatch(/timed out/i);
+    vi.useRealTimers();
+  });
+
   it('should handle Bitget array format', async () => {
     // [[timestamp, open, high, low, close, volume, quoteVol], ...]
     const mockKlines = [


### PR DESCRIPTION
## Summary

Fixes a `502 Bad Gateway` seen in production on `GET /api/klines?provider=bitunix&...` right after a redeploy.

## Root cause

`src/routes/api/klines/+server.ts`'s server-side fetches to the Bitunix and Bitget REST APIs had no timeout or `AbortController`. If the upstream exchange API is slow, briefly unreachable, or DNS/egress hiccups right after a fresh deploy, the outbound `fetch()` call can hang indefinitely. The reverse proxy in front of the app then times out first and returns a raw `502 Bad Gateway` to the browser — before this route's own try/catch ever gets a chance to return a clean JSON error.

The client-side symptom matches exactly:
```
GET https://dev.cachy.app/api/klines?provider=bitunix&symbol=BTCUSDT&interval=15m... 502 (Bad Gateway)
fetchBitunixKlines error for BTCUSDT Error: apiErrors.klineError
```

## Fix

- Added `fetchWithTimeout()` (8s timeout via `AbortController`), the same pattern already used in `src/routes/api/rss-fetch/+server.ts`.
- Both `fetchBitunixKlines` and `fetchBitgetKlines` now use it.
- A timed-out upstream now surfaces as a clean `504` JSON error (`{ error: "Upstream exchange API timed out" }`) instead of an opaque gateway-level `502`.

## Testing

- Added a test that mocks a `fetch` that never resolves until the abort signal fires, and asserts the route returns `504` with a "timed out" message instead of hanging — fails without the fix (the promise never resolves under fake timers otherwise).
- All existing `klines.test.ts` tests (Bitunix/Bitget success paths) still pass unchanged.
- `npm run check` clean, `npm run lint` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThtV1yDyRbEesRyMiPKt28)_