### PR TITLE
fix(deploy): capture start command output instead of discarding it

### DIFF
--- a/.deploy.conf.example
+++ b/.deploy.conf.example
@@ -26,6 +26,14 @@ STABLE_ENVIRONMENT="cachy.app"
 STABLE_PORT=3001
 # Command that starts the Node process. deploy.sh runs it after a graceful
 # shutdown, then waits for the health check.
+#
+# aaPanel names this script after the Node project's name (Website > Node
+# project), not after a "prod"/"dev" convention — verify the real filename
+# with `ls /www/server/nodejs/vhost/scripts/` before pasting a path here. A
+# mismatch here fails silently: the command exits immediately (exit 127, file
+# not found) and the health check just burns its full wait for a process that
+# was never started. This exact failure is why a server move can break
+# deploys even though the build still succeeds.
 STABLE_START_COMMAND="sudo -u www bash /path/to/start-production.sh"
 
 # ---------------------------------------------------------------------------
@@ -34,6 +42,8 @@ STABLE_START_COMMAND="sudo -u www bash /path/to/start-production.sh"
 
 BETA_ENVIRONMENT="dev.cachy.app"
 BETA_PORT=3002
+# Same filename caveat as STABLE_START_COMMAND above — check the actual
+# script name for this Node project too, it is independent of the prod one.
 BETA_START_COMMAND="sudo -u www bash /path/to/start-staging.sh"
 
 # ---------------------------------------------------------------------------

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -149,7 +149,9 @@ Features:
 6. **Build in a shadow directory** - copies the tree to `.deploy_work`, runs `npm ci --legacy-peer-deps && npm run build` there. **A failed build aborts without touching the running deployment.**
 7. **Validate build** - checks that `build/index.js` exists
 8. **Swap** - `chown www:www`, `chmod 755`, move the old `build/` aside as `build_old_<timestamp>`, move the new one in
-9. **Graceful restart** - SIGTERM, then SIGKILL after a grace period, then `START_COMMAND` from `.deploy.conf`
+9. **Graceful restart** - SIGTERM, then SIGKILL after a grace period, then `START_COMMAND` from `.deploy.conf`.
+   Its output is captured to `logs/start_<timestamp>.log` rather than discarded, and an immediate exit of the
+   start command (e.g. a bad path) is flagged before the health check even begins.
 10. **Health check** - verify the service responds at `/api/health`
 11. **Auto-rollback** - restore the backup if the health check fails
 
@@ -344,6 +346,14 @@ _Note: `ORIGIN` is important behind a reverse proxy — SvelteKit uses it to res
    - Check aaPanel Node project status
    - Verify port is not in use: `lsof -i :3001`
    - Check service logs in aaPanel
+   - **Verify `STABLE_START_COMMAND` / `BETA_START_COMMAND` in `.deploy.conf` point at a script that actually
+     exists.** aaPanel names the vhost start script after the Node project's name (e.g. `cachyapp.sh`), not
+     after a fixed `prod`/`dev` convention — confirm with `ls /www/server/nodejs/vhost/scripts/`. This is a
+     common failure after a server move: the project gets recreated under a new name in aaPanel, but
+     `.deploy.conf` still points at the old script path. The command then exits immediately (exit 127) and
+     the health check waits its full timeout for a process that was never started — with `deploy.sh`'s
+     start-command logging (see above), this now shows up as `bash: .../<name>.sh: No such file or
+     directory` in `logs/start_*.log` instead of failing silently.
 
 2. **Endpoint not responding:**
    - Verify service is running: `curl http://localhost:3001/api/health`

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -340,6 +340,19 @@ _Note: `ORIGIN` is important behind a reverse proxy — SvelteKit uses it to res
    - The build runs in `.deploy_work`, so a failure leaves the live deployment untouched
    - Try manually: `npm ci --legacy-peer-deps && npm run build`
 
+4. **`fatal: detected dubious ownership in repository`:**
+   - Git refuses to run `git` commands in a working tree owned by a different user than the one running
+     them (a security check, not a `deploy.sh` bug). Common on aaPanel when the repo was cloned as `root`
+     (or created by the panel) but `deploy.sh` is run as another shell user.
+   - Fix once per user/directory:
+     ```bash
+     git config --global --add safe.directory /www/wwwroot/cachy.app
+     git config --global --add safe.directory /www/wwwroot/dev.cachy.app
+     ```
+   - If this comes up, also double-check that the user running `deploy.sh` actually owns (or can write to)
+     the project directory — the same mismatch can later make `rsync`/`mv`/`chown` in the build-swap step
+     fail too.
+
 ### Health Check Fails
 
 1. **Service not starting:**

--- a/deploy.sh
+++ b/deploy.sh
@@ -439,11 +439,32 @@ rm -rf "$WORK_DIR_TMP"
 # 5. Restart & Health
 log "${CYAN}[HEALTH]${NC} Restarting service and health check..."
 graceful_shutdown "$PORT"
-eval "$START_CMD > /dev/null 2>&1 &"
+
+# START_CMD's output used to go to /dev/null, so a command that fails before
+# the Node process ever binds the port (e.g. sudo refusing without a TTY, or a
+# stale interpreter path left over from a server move) was indistinguishable
+# from "still starting up" — the health check just burned its full 90s with
+# nothing to show for it. Capture it instead, and flag immediately if the
+# process behind START_CMD has already died by the time we start polling.
+START_LOG="$LOG_DIR/start_$(date +%Y%m%d_%H%M%S).log"
+eval "$START_CMD" > "$START_LOG" 2>&1 &
+START_PID=$!
+log "Start command launched (PID $START_PID, output: $START_LOG)"
 sleep 2
+
+if ! kill -0 "$START_PID" 2>/dev/null; then
+    log "${RED}Start command already exited before health check began — it likely never started the app.${NC}"
+    if [[ -s "$START_LOG" ]]; then
+        log "${GREY}--- last lines of $START_LOG ---${NC}"
+        while IFS= read -r line; do log "${GREY}  $line${NC}"; done < <(tail -n 20 "$START_LOG")
+    else
+        log "${GREY}  $START_LOG is empty — the command produced no output at all.${NC}"
+    fi
+fi
 
 if ! health_check "$(echo "$HEALTH_CHECK_URL" | sed "s/{{PORT}}/$PORT/")"; then
     notify_health_check_failed "$ENVIRONMENT" 2>/dev/null || true
+    log "${GREY}Start command log: $START_LOG${NC}"
     error_exit "Service is not responding after restart"
 fi
 


### PR DESCRIPTION
## Summary

- `deploy.sh` redirected `START_CMD`'s stdout/stderr to `/dev/null`, so a startup failure that happens *before* the Node process binds its port (e.g. `sudo` refusing without a TTY, or a stale interpreter path left over from a server move) was indistinguishable from "still starting up" — the health check just burned its full 90s wait with nothing to show for it.
- The start command's output is now captured to `logs/start_<timestamp>.log`, and the script checks whether the backgrounded process behind `START_CMD` has already died before health polling even begins, logging the tail of that file immediately when it has.
- On a failed health check, the path to the start-command log is logged alongside the existing error, so the next investigation starts with real evidence instead of a silent 90-second timeout.

## Context

Reported after a server move to a new aaPanel host: the build always succeeds, but the health check regularly times out — until the service is started manually via the aaPanel UI mid-poll, at which point the in-flight health check picks it up and the deploy reports success. That pattern points at `START_CMD` failing silently (most likely `sudo -u www …` needing a password/TTY that isn't available non-interactively, or a hardcoded Node path that no longer resolves post-migration) rather than the app actually being slow to start. This change doesn't fix the underlying server-side cause (which needs to be diagnosed on the server itself), but it makes the next occurrence self-diagnosing instead of silent.

## Test plan

- [x] `bash -n deploy.sh` — syntax check passes
- [ ] Run `./deploy.sh --beta` (or `./deploy.sh`) against a real aaPanel deployment and confirm `logs/start_*.log` is created with the start command's actual output
- [ ] Reproduce a broken `START_CMD` (e.g. temporarily point it at a nonexistent script) and confirm the "Start command already exited" warning and log tail appear before the 90s health-check timeout completes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Np2WXDoKRqpHTNiKUHZ33h)_