### PR TITLE
fix(deploy): eliminate double-sudo denial and lock-fd leak in health check

### DIFF
--- a/.deploy.conf.example
+++ b/.deploy.conf.example
@@ -34,6 +34,13 @@ STABLE_PORT=3001
 # not found) and the health check just burns its full wait for a process that
 # was never started. This exact failure is why a server move can break
 # deploys even though the build still succeeds.
+#
+# Only prefix this with `sudo -u www` if deploy.sh itself runs as some OTHER
+# user that needs to elevate to www. If deploy.sh already runs as www (e.g.
+# started via `sudo -u www bash deploy.sh`), leave sudo out entirely — www
+# sudo-ing to itself has no sudoers rule granting it and is always denied,
+# which looks identical to "the app is slow to start" until you check
+# logs/start_*.log. See DEPLOYMENT.md Prerequisites for both cases.
 STABLE_START_COMMAND="sudo -u www bash /path/to/start-production.sh"
 
 # ---------------------------------------------------------------------------

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -11,22 +11,45 @@ about how to invoke `deploy.sh`.
 - A server with **aaPanel** installed.
 - **Node.js Version Manager** (installed via aaPanel App Store). Recommended: Node v18 or v20.
 - Domains pointing to the server IP (e.g., `cachy.app` and `dev.cachy.app`).
-- **Passwordless `sudo` for the deploy user to run the vhost start scripts as `www`.** `deploy.sh` runs
-  `START_COMMAND` non-interactively in the background — no TTY is attached, so `sudo` cannot prompt for a
-  password even if one would normally be accepted. Without a `NOPASSWD` rule the command fails immediately
-  and silently (see Troubleshooting below); the health check then burns its full wait for a process that
-  never started. Set this up once via `visudo`:
+- **`START_COMMAND` must not contain a redundant `sudo -u www` if `deploy.sh` itself already runs as
+  `www`.** There are two valid ways to run `deploy.sh`, and the right `START_COMMAND` depends on which one
+  you use — mixing them up is a real failure mode, not a hypothetical one (it cost a multi-hour investigation
+  on a production instance):
 
-  ```bash
-  sudo visudo -f /etc/sudoers.d/cachy-deploy
-  ```
+  1. **`deploy.sh` runs as an unprivileged operator user** (e.g. via SSH as a personal account), and needs
+     to elevate to `www` to start the app:
+     ```
+     STABLE_START_COMMAND="sudo -u www bash /www/server/nodejs/vhost/scripts/cachyapp.sh"
+     ```
+     This requires a passwordless sudo rule for that operator user, because `deploy.sh` runs
+     `START_COMMAND` non-interactively in the background — no TTY is attached, so `sudo` cannot prompt for
+     a password even if one would normally be accepted:
+     ```bash
+     sudo visudo -f /etc/sudoers.d/cachy-deploy
+     ```
+     ```
+     <operator-user> ALL=(www) NOPASSWD: ALL
+     ```
+     Also check for `Defaults use_pty` in `/etc/sudoers` — it forces every `sudo` invocation to allocate a
+     pseudo-terminal, which is unreliable from a backgrounded, non-interactive job like this one and can
+     deny the command even with a correct `NOPASSWD` rule. If present, add a scoped exception:
+     `Defaults:<operator-user> !use_pty`.
 
-  ```
-  <deploy-user> ALL=(www) NOPASSWD: /bin/bash /www/server/nodejs/vhost/scripts/cachyapp.sh, /bin/bash /www/server/nodejs/vhost/scripts/devcachyapp.sh
-  ```
+  2. **`deploy.sh` runs as `www` itself** (e.g. via aaPanel's own "run as site user" button, or
+     `sudo -u www bash deploy.sh`) — the common case when the project directory is owned by `www` and an
+     unprivileged user can't write to it directly. Here `START_COMMAND` must be plain, with **no** `sudo`
+     prefix at all:
+     ```
+     STABLE_START_COMMAND="bash /www/server/nodejs/vhost/scripts/cachyapp.sh"
+     ```
+     `www` sudo-ing to `www` is not a no-op — it's a privilege escalation with no rule granting it, so it
+     is denied. Because `deploy.sh` swallowed `START_COMMAND`'s output for a long time (fixed below), this
+     failure mode looked identical to "the app is just slow to start": the health check burned its full
+     90s wait every time, and the real cause (`sudo: I'm sorry www. I'm afraid I can't do that`) was
+     invisible until the start-command logging below was added.
 
-  Adjust the script filenames to match what aaPanel actually generated (see the naming note on
-  `START_COMMAND` in `.deploy.conf.example`) and the path to `bash` (`which bash`).
+  Check which case applies by checking who owns the project directory (`ls -ld` on it) and how you
+  actually invoke `deploy.sh` — don't assume based on which user you SSH in as.
 
 ---
 
@@ -384,19 +407,46 @@ _Note: `ORIGIN` is important behind a reverse proxy — SvelteKit uses it to res
      start-command logging (see above), this now shows up as `bash: .../<name>.sh: No such file or
      directory` in `logs/start_*.log` instead of failing silently.
    - **`sudo: I'm sorry <user>. I'm afraid I can't do that` (or a plain password prompt) in
-     `logs/start_*.log`:** the deploy user lacks a `NOPASSWD` sudoers rule for the vhost script — see
-     Prerequisites above. `deploy.sh` runs `START_CMD` in the background with no TTY, so `sudo` cannot
-     prompt; without `NOPASSWD` it fails immediately every time, even though the exact same command typed
-     interactively can appear to "just work" — a recently cached `sudo` credential (the ticket from an
-     earlier password entry, valid for several minutes) papers over the missing rule until it expires. Rule
-     out that false positive before trusting a manual test: run `sudo -k` (drop the cached ticket) right
-     before `sudo -n -u www bash <script> < /dev/null`, and only trust an exit code of `0` under those
-     conditions.
+     `logs/start_*.log`:** three possible causes, roughly in order of likelihood:
+     1. **`START_COMMAND` has `sudo -u www` but `deploy.sh` is already running as `www`.** `www` sudo-ing
+        to itself is a privilege escalation nothing grants, so it's always denied — see the
+        `START_COMMAND` note in Prerequisites above for how to tell which of the two invocation patterns
+        applies and fix the command accordingly. This was the actual cause the one time this was chased
+        down in production; the other two below turned out to be red herrings that first time, but are
+        worth ruling out too.
+     2. **Missing `NOPASSWD` sudoers rule** for the user actually invoking `sudo` (only relevant for the
+        "unprivileged operator user" pattern in Prerequisites). `deploy.sh` runs `START_CMD` in the
+        background with no TTY, so `sudo` cannot prompt; without `NOPASSWD` it fails immediately every
+        time — even though the exact same command typed interactively can appear to "just work", because a
+        recently cached `sudo` credential (the ticket from an earlier password entry, valid for several
+        minutes) papers over the missing rule until it expires. Rule out that false positive before
+        trusting a manual test: run `sudo -k` (drop the cached ticket) right before
+        `sudo -n -u www bash <script> < /dev/null`, and only trust an exit code of `0` under those
+        conditions.
+     3. **`Defaults use_pty`** in `/etc/sudoers` (`grep -rn use_pty /etc/sudoers /etc/sudoers.d/`) forcing
+        pty allocation, which is unreliable for a backgrounded job with no controlling terminal. A quick
+        interactive `sudo -u www id` can succeed while the exact same command run from within a
+        non-interactively-executed script still fails — test through an actual script file
+        (`bash /path/to/test.sh`, not typed at the prompt) to reproduce this faithfully. Fix: a scoped
+        `Defaults:<user> !use_pty`.
 
 2. **Endpoint not responding:**
    - Verify service is running: `curl http://localhost:3001/api/health`
    - Check if build/index.js exists
    - Restart manually via aaPanel
+
+3. **`❌ Another deployment is already running` right after a deploy that just succeeded:** the
+   concurrency-lock file descriptor (fd 200, see "Concurrency lock" in section 3) leaked into the Node
+   server process itself and is now held open for as long as that process runs — i.e. until its next
+   restart, not until some other deploy finishes. `deploy.sh` closes that fd for `START_CMD` now, so a
+   freshly pulled `deploy.sh` won't reproduce this on its *next* run — but that next run still needs to get
+   past the very `flock -n 200` check this is blocking, so the current stuck lock needs breaking by hand
+   once:
+   ```bash
+   rm .deploy.lock
+   ```
+   Safe here specifically because the cause is understood (a live app process, not a second `deploy.sh`
+   genuinely mid-run) — check `ps aux | grep deploy.sh` first if there's any doubt.
 
 ### Rollback Issues
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -11,6 +11,22 @@ about how to invoke `deploy.sh`.
 - A server with **aaPanel** installed.
 - **Node.js Version Manager** (installed via aaPanel App Store). Recommended: Node v18 or v20.
 - Domains pointing to the server IP (e.g., `cachy.app` and `dev.cachy.app`).
+- **Passwordless `sudo` for the deploy user to run the vhost start scripts as `www`.** `deploy.sh` runs
+  `START_COMMAND` non-interactively in the background — no TTY is attached, so `sudo` cannot prompt for a
+  password even if one would normally be accepted. Without a `NOPASSWD` rule the command fails immediately
+  and silently (see Troubleshooting below); the health check then burns its full wait for a process that
+  never started. Set this up once via `visudo`:
+
+  ```bash
+  sudo visudo -f /etc/sudoers.d/cachy-deploy
+  ```
+
+  ```
+  <deploy-user> ALL=(www) NOPASSWD: /bin/bash /www/server/nodejs/vhost/scripts/cachyapp.sh, /bin/bash /www/server/nodejs/vhost/scripts/devcachyapp.sh
+  ```
+
+  Adjust the script filenames to match what aaPanel actually generated (see the naming note on
+  `START_COMMAND` in `.deploy.conf.example`) and the path to `bash` (`which bash`).
 
 ---
 
@@ -367,6 +383,15 @@ _Note: `ORIGIN` is important behind a reverse proxy — SvelteKit uses it to res
      the health check waits its full timeout for a process that was never started — with `deploy.sh`'s
      start-command logging (see above), this now shows up as `bash: .../<name>.sh: No such file or
      directory` in `logs/start_*.log` instead of failing silently.
+   - **`sudo: I'm sorry <user>. I'm afraid I can't do that` (or a plain password prompt) in
+     `logs/start_*.log`:** the deploy user lacks a `NOPASSWD` sudoers rule for the vhost script — see
+     Prerequisites above. `deploy.sh` runs `START_CMD` in the background with no TTY, so `sudo` cannot
+     prompt; without `NOPASSWD` it fails immediately every time, even though the exact same command typed
+     interactively can appear to "just work" — a recently cached `sudo` credential (the ticket from an
+     earlier password entry, valid for several minutes) papers over the missing rule until it expires. Rule
+     out that false positive before trusting a manual test: run `sudo -k` (drop the cached ticket) right
+     before `sudo -n -u www bash <script> < /dev/null`, and only trust an exit code of `0` under those
+     conditions.
 
 2. **Endpoint not responding:**
    - Verify service is running: `curl http://localhost:3001/api/health`

--- a/deploy.sh
+++ b/deploy.sh
@@ -446,6 +446,12 @@ graceful_shutdown "$PORT"
 # from "still starting up" — the health check just burned its full 90s with
 # nothing to show for it. Capture it instead, and flag immediately if the
 # process behind START_CMD has already died by the time we start polling.
+#
+# A quick exit alone isn't proof of failure, though: aaPanel's vhost scripts
+# are fire-and-forget wrappers — they `nohup node ... &` the real process and
+# return immediately once it's launched, so exiting within the first couple
+# of seconds is their *normal*, successful path. Only treat it as a failure
+# when it also left a nonzero exit code or something in the log.
 START_LOG="$LOG_DIR/start_$(date +%Y%m%d_%H%M%S).log"
 eval "$START_CMD" > "$START_LOG" 2>&1 &
 START_PID=$!
@@ -453,12 +459,20 @@ log "Start command launched (PID $START_PID, output: $START_LOG)"
 sleep 2
 
 if ! kill -0 "$START_PID" 2>/dev/null; then
-    log "${RED}Start command already exited before health check began — it likely never started the app.${NC}"
-    if [[ -s "$START_LOG" ]]; then
-        log "${GREY}--- last lines of $START_LOG ---${NC}"
-        while IFS= read -r line; do log "${GREY}  $line${NC}"; done < <(tail -n 20 "$START_LOG")
+    set +e
+    wait "$START_PID" 2>/dev/null
+    START_EXIT=$?
+    set -e
+    if [[ $START_EXIT -ne 0 || -s "$START_LOG" ]]; then
+        log "${RED}Start command exited (code $START_EXIT) before health check began — it may not have started the app.${NC}"
+        if [[ -s "$START_LOG" ]]; then
+            log "${GREY}--- last lines of $START_LOG ---${NC}"
+            while IFS= read -r line; do log "${GREY}  $line${NC}"; done < <(tail -n 20 "$START_LOG")
+        else
+            log "${GREY}  $START_LOG is empty — the command produced no output at all.${NC}"
+        fi
     else
-        log "${GREY}  $START_LOG is empty — the command produced no output at all.${NC}"
+        log "${GREY}Start command exited cleanly (code 0, no output) — likely a fire-and-forget wrapper that already detached the real process.${NC}"
     fi
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -452,8 +452,16 @@ graceful_shutdown "$PORT"
 # return immediately once it's launched, so exiting within the first couple
 # of seconds is their *normal*, successful path. Only treat it as a failure
 # when it also left a nonzero exit code or something in the log.
+#
+# fd 200 (the flock lock, see "Concurrency lock" above) must NOT reach this
+# command: START_CMD's descendants include the long-running Node server
+# itself (aaPanel's vhost script backgrounds it via nohup), and an inherited
+# fd stays open for as long as that process runs — i.e. forever, until the
+# next restart. Left open, every subsequent deploy would find the lock still
+# "held" by the app it's supposed to be replacing, not by another deploy.
+# 200>&- closes it for this command and everything it forks.
 START_LOG="$LOG_DIR/start_$(date +%Y%m%d_%H%M%S).log"
-eval "$START_CMD" > "$START_LOG" 2>&1 &
+eval "$START_CMD" > "$START_LOG" 2>&1 200>&- &
 START_PID=$!
 log "Start command launched (PID $START_PID, output: $START_LOG)"
 sleep 2


### PR DESCRIPTION
## Summary

Verified end to end against a real aaPanel production incident (health check reliably timing out after a
server move). Three fixes, found by walking the actual failure live on the server:

1. **`deploy.sh`: don't flag a clean fire-and-forget start as a failure.** aaPanel's vhost scripts `nohup`
   the real Node process and exit immediately once it's launched — exiting within the first couple of
   seconds is their *normal*, successful path, not a crash. The "already exited" check now only warns when
   the exit code is nonzero or something landed in the log.
2. **`deploy.sh`: close the concurrency-lock fd (200) before `START_CMD`.** It was leaking into
   `START_CMD`'s descendants, including the long-running Node server itself, which then held it open
   forever (until its next restart). Every deploy after the first "successful" one found the lock still
   "held" — by the app it was supposed to be replacing, not by another deploy — producing
   `❌ Another deployment is already running` right after a clean run.
3. **`DEPLOYMENT.md` / `.deploy.conf.example`: correct the `START_COMMAND` guidance.** The actual root
   cause of the original health-check hang was a redundant `sudo -u www` in `START_COMMAND` while
   `deploy.sh` itself was already invoked as `www`. `www` sudo-ing to itself is denied by policy with no
   rule that could grant it — and because `START_CMD`'s output used to be discarded (fixed in #1611), that
   denial was invisible, and the health check just burned its full 90s wait every time, looking exactly
   like "the app is slow to start". The docs now cover both valid invocation patterns (unprivileged
   operator user needing `sudo -u www`, vs. `deploy.sh` already running as `www`) and how to tell them
   apart, plus `Defaults use_pty` and stale-sudo-ticket false positives as the two less likely causes of
   the same symptom.

## Context

This PR started as a narrower NOPASSWD-sudoers doc fix (see original description below), based on the
first failure signature found. Live debugging on the affected server (`ubuntu-8gb-fsn1-1`) went several
rounds deeper and found the NOPASSWD angle was a red herring: `sudo -l` showed the deploy user already had
blanket `(ALL) NOPASSWD: ALL`. The real cause was architectural (double sudo layer), and fixing it exposed
the fd-leak bug as a second-order effect. All three fixes above are confirmed working: `./deploy.sh --beta`
now completes with `Health check passed after 0s (HTTP 200)` instead of failing after a 90s timeout.

Original PR description, kept for the record since the failure signature it documents (`sudo: I'm sorry
<user>...` in `logs/start_*.log`) is still a real, if less common, cause of the same symptom:

> Adds a Prerequisites entry to DEPLOYMENT.md requiring a NOPASSWD sudoers rule for the deploy user to run
> the aaPanel vhost start scripts as www, with the visudo setup command, and a Troubleshooting entry for
> the failure signature and why a manual `sudo -n` test can misleadingly succeed even when the rule is
> missing (a cached sudo credential ticket).

## Test plan

- [x] `bash -n deploy.sh` — syntax check passes
- [x] Verified live on `dev.cachy.app`: `./deploy.sh --beta` completes in ~42s with a passing health check
      (was: reliable 90s timeout before every fix in this PR)
- [ ] Same verification on `cachy.app` (production) once `develop` is promoted to `main`
