### PR TITLE
Fix: Live price reactivity freeze

### DIFF
--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -47,8 +47,7 @@ import { logger } from "./logger";
 
 const calculatorService = new CalculatorService(calculator, uiState);
 
-let marketStoreUnsubscribe: (() => void) | null = null;
-let tradeStoreUnsubscribe: (() => void) | null = null;
+let realtimeUpdatesCleanup: (() => void) | null = null;
 let isInitialized = false;
 let saveJournalTask: Promise<void> | null = null;
 let pendingJournalData: JournalEntry[] | null = null;
@@ -163,98 +162,102 @@ export const app = {
     let lastProvider = settingsState.apiProvider || "";
     let lastKeys = settingsState.apiKeys ? computeKeys(settingsState) : "";
 
-    settingsState.subscribe((s: Settings) => {
-      untrack(() => {
-        if (!s || !s.apiKeys) return;
-
-        const currentKeys = computeKeys(s);
-        const providerChanged = s.apiProvider !== lastProvider;
-        const keysChanged = currentKeys !== lastKeys;
-
-        if (providerChanged || keysChanged) {
-          lastKeys = currentKeys;
-          lastProvider = s.apiProvider;
-          // Route exclusively through ConnectionManager, the single owner of
-          // provider connect/destroy, so old and new provider are switched
-          // atomically instead of two services independently tearing each
-          // other down.
-          connectionManager.switchProvider(s.apiProvider || "bitunix", { force: true });
-        }
-      });
-    });
-
-    if (tradeStoreUnsubscribe) {
-      tradeStoreUnsubscribe();
-      tradeStoreUnsubscribe = null;
+    if (realtimeUpdatesCleanup) {
+      realtimeUpdatesCleanup();
+      realtimeUpdatesCleanup = null;
     }
 
     let currentWatchedSymbol: string | null = null;
     let symbolDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-    tradeStoreUnsubscribe = tradeState.subscribe((state) => {
-      // Canonical (Bitunix-style) form: marketWatcher.register()/unregister()
-      // re-normalize with "bitunix" internally regardless of what's passed
-      // in, and normalizeSymbol never strips a "_UMCBL" suffix for a
-      // non-bitget provider - so normalizing by the active provider here
-      // would, under Bitget, permanently bake the suffix into the request
-      // key marketWatcher tracks for the main trading symbol.
-      const newSymbol = state.symbol
-        ? normalizeSymbol(state.symbol, "bitunix")
-        : "";
+    realtimeUpdatesCleanup = $effect.root(() => {
+      // 1. Settings / Connection Manager
+      $effect(() => {
+        const s = settingsState;
+        const provider = s.apiProvider;
+        const keys = s.apiKeys;
 
-      if (symbolDebounceTimer) clearTimeout(symbolDebounceTimer);
+        untrack(() => {
+          if (!keys) return;
 
-      symbolDebounceTimer = setTimeout(() => {
-        if (newSymbol && newSymbol !== currentWatchedSymbol) {
-          if (currentWatchedSymbol) {
-            marketWatcher.unregister(currentWatchedSymbol, "price");
-            marketWatcher.unregister(currentWatchedSymbol, "ticker");
+          const currentKeys = computeKeys(s);
+          const providerChanged = provider !== lastProvider;
+          const keysChanged = currentKeys !== lastKeys;
+
+          if (providerChanged || keysChanged) {
+            lastKeys = currentKeys;
+            lastProvider = provider || "";
+            // Route exclusively through ConnectionManager
+            connectionManager.switchProvider(provider || "bitunix", { force: true });
           }
-          // Subscribe to BOTH Price (Funding/Index) and Ticker (Last/Vol/Change)
-          marketWatcher.register(newSymbol, "price");
-          marketWatcher.register(newSymbol, "ticker");
-          currentWatchedSymbol = newSymbol;
-        } else if (!newSymbol && currentWatchedSymbol) {
-          marketWatcher.unregister(currentWatchedSymbol, "price");
-          marketWatcher.unregister(currentWatchedSymbol, "ticker");
-          currentWatchedSymbol = null;
+        });
+      });
+
+      // 2. Trade State Symbol -> Market Watcher Registration
+      $effect(() => {
+        const currentSymbol = tradeState.symbol;
+        untrack(() => {
+          const newSymbol = currentSymbol
+            ? normalizeSymbol(currentSymbol, "bitunix")
+            : "";
+
+          if (symbolDebounceTimer) clearTimeout(symbolDebounceTimer);
+
+          symbolDebounceTimer = setTimeout(() => {
+            if (newSymbol && newSymbol !== currentWatchedSymbol) {
+              if (currentWatchedSymbol) {
+                marketWatcher.unregister(currentWatchedSymbol, "price");
+                marketWatcher.unregister(currentWatchedSymbol, "ticker");
+              }
+              marketWatcher.register(newSymbol, "price");
+              marketWatcher.register(newSymbol, "ticker");
+              currentWatchedSymbol = newSymbol;
+            } else if (!newSymbol && currentWatchedSymbol) {
+              marketWatcher.unregister(currentWatchedSymbol, "price");
+              marketWatcher.unregister(currentWatchedSymbol, "ticker");
+              currentWatchedSymbol = null;
+            }
+          }, 500);
+        });
+      });
+
+      // 3. Market State Data -> Trade State Entry Price
+      $effect(() => {
+        const currentSymbol = tradeState.symbol;
+        if (currentSymbol) {
+          const normSymbol = normalizeSymbol(currentSymbol, "bitunix");
+          const marketData = marketState.data[normSymbol];
+          
+          if (marketData && marketData.lastPrice) {
+            // Register dependency on the specific property
+            const lastPrice = marketData.lastPrice;
+            
+            untrack(() => {
+              app.currentMarketPrice = lastPrice;
+
+              if (settingsState.autoUpdatePriceInput) {
+                const newPrice = new Decimal(lastPrice).toString();
+                if (tradeState.entryPrice !== newPrice) {
+                  tradeState.entryPrice = newPrice;
+                }
+              }
+            });
+          }
         }
-      }, 500);
-    });
+      });
 
-    if (marketStoreUnsubscribe) marketStoreUnsubscribe();
-    marketStoreUnsubscribe = marketState.subscribe((data) => {
-      const state = tradeState;
-      const settings = settingsState;
-
-      if (state.symbol) {
-        // marketState.data is always keyed by the canonical (Bitunix-style)
-        // symbol regardless of active provider (see MarketOverview.svelte).
-        const normSymbol = normalizeSymbol(state.symbol, "bitunix");
-        const marketData = data[normSymbol];
-
-        if (marketData && marketData.lastPrice) {
-          app.currentMarketPrice = marketData.lastPrice;
-
-          if (settings.autoUpdatePriceInput) {
-            const newPrice = new Decimal(marketData.lastPrice).toString();
-            if (state.entryPrice !== newPrice) {
-              tradeState.update((s) => ({ ...s, entryPrice: newPrice }));
+      // 4. Market State Status
+      $effect(() => {
+        const status = marketState.connectionStatus;
+        untrack(() => {
+          if (status === "disconnected" || status === "reconnecting") {
+            const settings = settingsState;
+            if (settings.autoUpdatePriceInput) {
+              // Fallback handled by marketWatcher polling
             }
           }
-        }
-      }
-    });
-
-    marketState.subscribeStatus((status) => {
-      if (status === "disconnected" || status === "reconnecting") {
-        const settings = settingsState;
-        if (
-          settings.autoUpdatePriceInput
-        ) {
-          // Fallback handled by marketWatcher polling
-        }
-      }
+        });
+      });
     });
   },
 

--- a/src/stores/market.svelte.ts
+++ b/src/stores/market.svelte.ts
@@ -129,7 +129,6 @@ interface RawKlineWsMessage {
 export class MarketManager {
   data = $state<Record<string, MarketData>>({});
   connectionStatus = $state<WSStatus>("disconnected");
-  tick = $state(0);
 
   // Telemetry Metrics
   telemetry = $state({
@@ -152,8 +151,6 @@ export class MarketManager {
   private cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
   private flushIntervalId: ReturnType<typeof setInterval> | null = null;
   private telemetryIntervalId: ReturnType<typeof setInterval> | null = null;
-  private notifyTimer: ReturnType<typeof setTimeout> | null = null;
-  private statusNotifyTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     if (browser) {
@@ -336,9 +333,6 @@ export class MarketManager {
         this.pendingKlineUpdates.clear();
       }
     });
-
-    this.tick++;
-
     this.enforceCacheLimit();
   }
 
@@ -892,63 +886,7 @@ export class MarketManager {
     this.enforceCacheLimit();
   }
 
-  subscribe(fn: (value: Record<string, MarketData>) => void) {
-    fn(this.data);
-    const cleanup = $effect.root(() => {
-      $effect(() => {
-        // Track.
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- bare read registers the $effect dependency
-        this.data;
-        this.tick;
-        untrack(() => {
-          if (this.notifyTimer) clearTimeout(this.notifyTimer);
-          this.notifyTimer = setTimeout(() => {
-            fn(this.data);
-            this.notifyTimer = null;
-          }, 10);
-        });
-      });
-    });
-    return () => {
-      // The subscription helper returns either an unsubscribe function or an
-      // object with .stop(), depending on the path taken. Naming that union
-      // beats casting to any twice.
-      const stoppable = cleanup as (() => void) | { stop?: () => void } | null;
-      if (typeof stoppable === 'function') {
-        stoppable();
-      } else if (stoppable && typeof stoppable.stop === 'function') {
-        stoppable.stop();
-      }
-    };
-  }
 
-  subscribeStatus(fn: (value: WSStatus) => void) {
-    fn(this.connectionStatus);
-    const cleanup = $effect.root(() => {
-      $effect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- bare read registers the $effect dependency
-        this.connectionStatus; // Track
-        untrack(() => {
-          if (this.statusNotifyTimer) clearTimeout(this.statusNotifyTimer);
-          this.statusNotifyTimer = setTimeout(() => {
-            fn(this.connectionStatus);
-            this.statusNotifyTimer = null;
-          }, 10);
-        });
-      });
-    });
-    return () => {
-      // The subscription helper returns either an unsubscribe function or an
-      // object with .stop(), depending on the path taken. Naming that union
-      // beats casting to any twice.
-      const stoppable = cleanup as (() => void) | { stop?: () => void } | null;
-      if (typeof stoppable === 'function') {
-        stoppable();
-      } else if (stoppable && typeof stoppable.stop === 'function') {
-        stoppable.stop();
-      }
-    };
-  }
 }
 
 export const marketState = new MarketManager();

--- a/src/stores/market.svelte.ts
+++ b/src/stores/market.svelte.ts
@@ -129,6 +129,7 @@ interface RawKlineWsMessage {
 export class MarketManager {
   data = $state<Record<string, MarketData>>({});
   connectionStatus = $state<WSStatus>("disconnected");
+  tick = $state(0);
 
   // Telemetry Metrics
   telemetry = $state({
@@ -335,6 +336,8 @@ export class MarketManager {
         this.pendingKlineUpdates.clear();
       }
     });
+
+    this.tick++;
 
     this.enforceCacheLimit();
   }
@@ -896,6 +899,7 @@ export class MarketManager {
         // Track.
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- bare read registers the $effect dependency
         this.data;
+        this.tick;
         untrack(() => {
           if (this.notifyTimer) clearTimeout(this.notifyTimer);
           this.notifyTimer = setTimeout(() => {

--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -878,9 +878,7 @@ export class SettingsManager {
     // "custom" touches nothing, user decides
   }
   // Private state
-  private effectActive = false; // Controls whether $effect should trigger saves
-  private listeners: Set<(value: Settings) => void> = new Set();
-  private notifyTimer: ReturnType<typeof setTimeout> | null = null;
+  private effectActive = false;
   private saveTimer: ReturnType<typeof setTimeout> | null = null;
   private saveLock = false; // Prevents concurrent saves
 
@@ -938,7 +936,6 @@ export class SettingsManager {
             if (this.saveTimer) clearTimeout(this.saveTimer);
             this.saveTimer = setTimeout(() => {
               this.save();
-              this.notifyListeners();
             }, 500);
           });
         });
@@ -1776,23 +1773,6 @@ export class SettingsManager {
       enableDockingCentered: this.enableDockingCentered,
       dockingPosition: this.dockingPosition,
     };
-  }
-
-  subscribe(fn: (value: Settings) => void): () => void {
-    fn(this.toJSON());
-    this.listeners.add(fn);
-    return () => {
-      this.listeners.delete(fn);
-    };
-  }
-
-  private notifyListeners() {
-    if (this.notifyTimer) clearTimeout(this.notifyTimer);
-    this.notifyTimer = setTimeout(() => {
-      const snapshot = this.toJSON();
-      this.listeners.forEach((fn) => fn(snapshot));
-      this.notifyTimer = null;
-    }, 50);
   }
 
   update(fn: (s: Settings) => Partial<Settings>) {


### PR DESCRIPTION
This PR resolves an issue where the live price froze due to Svelte 5 `$effect` not picking up changes deep within the legacy `.subscribe` pattern. Replaced legacy state subscriptions with Svelte 5 `$effect.root` in `app.ts` and removed legacy compat layers.