### PR TITLE
fix(ui): align Market Activity sidebar condition on mobile with desktop

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -684,7 +684,7 @@
     {#if settingsState.showSidebars}
       <!-- Mobile MarketOverview position -->
       <div class="xl:hidden mt-8 flex flex-col gap-4">
-        {#if settingsState.isPro}
+        {#if settingsState.effectiveShowSidebarActivity}
           <!-- Add PositionsSidebar for Mobile -->
           <PositionsSidebar />
         {/if}


### PR DESCRIPTION
## Problem

The **Market Activity sidebar (PositionsSidebar)** was visible in the responsive/mobile layout but hidden on the desktop (xl+) breakpoint.

## Root Cause

Two different render guards were used for the same component depending on the breakpoint:

- Desktop (xl:flex): effectiveShowSidebarActivity = isPro && showSidebarActivity
- Mobile (xl:hidden): isPro (only Pro-status, showSidebarActivity ignored)

The mobile fallback ignored the showSidebarActivity setting entirely. When showSidebarActivity was false, the desktop hid the panel correctly but mobile kept showing it.

## Fix

Replace the mobile guard with effectiveShowSidebarActivity — the same condition already used on desktop.

## Changed Files

- src/routes/+page.svelte — 1 line changed