### PR TITLE
fix(pwa): drop desktop-only display_override entry from manifest

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -858,23 +858,27 @@ well-formed: `background_color` and `theme_color` are both `#0f172a`, a valid
 512×512 icon exists, and two `shortcuts` entries are declared with valid
 icons. Nothing in the file accounts for those two symptoms.
 
-`git log` cannot help: this working copy is a **shallow clone**, so
-`manifest.json` shows as "new file" in every commit that touches it and no
-bisect is possible. That has to happen on a full clone.
+`git log` still can't help: a full unshallow was attempted from this
+environment (`git fetch --unshallow`, then a bounded `--depth=1000` deepen)
+and both timed out against the sandboxed network. That has to happen on a
+full clone outside this environment.
 
-**What would move this forward, in order:**
+**Done since:** `display_override` reduced to `["standalone"]` —
+`window-controls-overlay` removed. It was a desktop-only mode sitting ahead of
+the one Android uses; per spec a browser skips an unsupported value, so this
+*should* have been harmless, but it was the only field whose first entry
+didn't apply to the platform where the symptoms appear, and a grep confirmed
+nothing in the app reads a WCO-specific layout, so removing it costs nothing.
+This is a precaution, not a confirmed fix.
+
+**What would still move this forward, in order:**
 
 1. On a full clone, `git log -p -- static/manifest.json src/app.html` to find
    what actually changed when it broke.
-2. Test with `display_override` reduced to `["standalone"]`. It currently
-   reads `["window-controls-overlay", "standalone"]`, and
-   `window-controls-overlay` is a desktop-only mode sitting ahead of the one
-   Android uses. Per spec a browser skips an unsupported value, so this
-   *should* be harmless — but it is the only field in the file whose first
-   entry does not apply to the platform where the symptoms appear, and it
-   costs nothing to rule out.
-3. Verify on a real device and record which device and launcher — nothing here
-   can be confirmed from a terminal.
+2. Verify on a real device and record which device and launcher — nothing here
+   can be confirmed from a terminal. Check whether removing
+   `window-controls-overlay` alone resolved the splash/shortcuts symptoms, or
+   whether they persist and need further investigation.
 
 ## 25. `IframeWindow`/`WindowManager.openIframe()` appear to be unreachable
 

--- a/docs/backlog/bugs/BUG-0038-android-manifest-regressions.md
+++ b/docs/backlog/bugs/BUG-0038-android-manifest-regressions.md
@@ -73,12 +73,15 @@ and two `shortcuts` entries are declared with valid icons. So the cause of
 those two is still unknown, and this item does not pretend otherwise.
 
 One untested suspicion worth checking first, recorded as a lead rather than a
-finding: `display_override` is `["window-controls-overlay", "standalone"]`,
+finding: `display_override` was `["window-controls-overlay", "standalone"]`,
 and `window-controls-overlay` is a desktop-only display mode listed ahead of
 the one Android actually uses. Per spec a browser should skip an unsupported
 value and fall through to `standalone`, so this *should* be harmless — but it
-is the one field in the file whose first entry is inapplicable to the platform
-where the symptoms appear, and it costs nothing to test with it removed.
+was the one field in the file whose first entry is inapplicable to the
+platform where the symptoms appear, and it cost nothing to test with it
+removed. `grep -rn "window-controls-overlay\|display_override" src` turned up
+no CSS or JS depending on the WCO layout (no `titlebar-area-*` env() usage
+anywhere), so removing it changes nothing else.
 
 ## Fix
 
@@ -99,12 +102,22 @@ where the symptoms appear, and it costs nothing to test with it removed.
   four image files are kept in `static/screenshots/` — re-enabling is
   re-adding the key. The test validates the block if it returns and skips it
   while absent.
+- `display_override` is now `["standalone"]` — `window-controls-overlay`
+  removed. Nothing in the codebase reads a WCO-specific layout (checked via
+  grep, see above), so this has no other effect either way. This is a
+  precaution, not a confirmed fix: it has not been verified on-device, and a
+  full `git log -p` to find what actually changed when the regression landed
+  was attempted and is still not possible from this environment (`git fetch
+  --unshallow` and a bounded `--depth=1000` deepen both timed out against the
+  sandboxed network — not merely "no tooling," an actual attempt was made and
+  failed). That step still needs a full clone.
 
 **Still open:**
 
 - Root-cause symptoms 1 and 3 (splash background, long-press shortcuts) on a
-  real device. Start by testing `display_override` without
-  `window-controls-overlay`.
+  real device, now that `display_override` no longer lists a desktop-only
+  mode first. Needs on-device verification — nothing here confirms it fixed
+  anything, only that it removes one plausible cause.
 - If screenshots are wanted back, produce real PNGs at a portrait aspect ratio
   rather than the current 640×640 squares, which are an odd shape for a phone
   install dialog.
@@ -118,7 +131,8 @@ where the symptoms appear, and it costs nothing to test with it removed.
       verified on-device and the device/launcher noted here
 - [ ] Long-pressing the installed icon shows both declared shortcuts —
       verified on-device
-- [ ] `display_override` is confirmed as cause or ruled out
+- [x] `display_override`'s desktop-only entry removed as a precaution (not yet
+      confirmed as the actual cause — needs on-device verification, see above)
 
 ## Out of scope
 

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -7,7 +7,7 @@
   "dir": "ltr",
   "start_url": "/?pwa=true",
   "display": "standalone",
-  "display_override": ["window-controls-overlay", "standalone"],
+  "display_override": ["standalone"],
   "background_color": "#0f172a",
   "theme_color": "#0f172a",
   "orientation": "portrait",


### PR DESCRIPTION
## Summary

Continues BUG-0038 (the screenshot-mislabelling fix already landed in `d0d9158`). Two symptoms are still unexplained: the Android splash-screen background and the long-press home-screen shortcuts. This PR removes the one lead that was cheap to test:

- `static/manifest.json`: `display_override` reduced from `["window-controls-overlay", "standalone"]` to `["standalone"]`. `window-controls-overlay` is a desktop-only display mode and was the only field in the manifest whose first entry doesn't apply to Android, where the symptoms show up. Per spec a browser should skip an unsupported value and fall through, so this *should* be harmless either way — `grep -rn "window-controls-overlay|display_override" src` confirms nothing in the app reads a WCO-specific layout (no `titlebar-area-*` env() usage), so removing it changes nothing else.
- This is a **precaution, not a confirmed fix** — it has not been verified on a real Android device.
- A full `git log -p -- static/manifest.json src/app.html` was attempted to find when the regression actually landed, but this environment's working copy is a shallow clone and both `git fetch --unshallow` and a bounded `--depth=1000` deepen timed out against the sandboxed network. That step still needs a full clone outside this environment.
- `docs/backlog/bugs/BUG-0038-android-manifest-regressions.md` and `docs/TODO.md` updated to record the attempt and what's still open.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx vitest run src/tests/manifest_assets.test.ts` — 15/15 passed
- [x] `npm test` (full suite) — 978 passed, 6 skipped
- [ ] Splash screen shows `background_color` on a real Android device — still needs on-device verification
- [ ] Long-pressing the installed icon shows both shortcuts — still needs on-device verification

---
_Generated by [Claude Code](https://claude.ai/code/session_019XNsogQj69KDiSHR77R1uC)_