### PR TITLE
fix(pwa): resolve BUG-0038, swap Settings shortcut for Market Overview

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -833,145 +833,36 @@ The Render service itself (on the Render dashboard) still needs to be
 disconnected/deleted by whoever owns that account — that step is not
 reachable from this repo or GitHub alone.
 
-## 24. PWA manifest — splash screen and long-press shortcuts still broken on Android
+## 24. ~~PWA manifest — splash screen and long-press shortcuts broken on Android~~ — resolved: device-side ad blocker
 
 **Raised by the maintainer**, August 2026: the installed Android PWA lost its
 splash-screen background, its install-dialog screenshots and its long-press
-context menu. These worked before and regressed.
+context menu.
 
-Tracked as [`BUG-0038`](backlog/bugs/BUG-0038-android-manifest-regressions.md),
-which has the full evidence. Summary of where it stands:
+**Root cause: an ad blocker on the test device was blocking Chrome's own
+connection to Google's WebAPK infrastructure.** Nothing in this repo, this
+server, or the manifest itself was ever the reason — five rounds of
+server-side investigation (documented in
+[`BUG-0038`](backlog/bugs/BUG-0038-android-manifest-regressions.md)) checked
+reachability from *Google's* side (Lighthouse, Googlebot) and never could
+have found a block on the *phone's* side of that connection. Worth
+remembering for any future PWA-install symptom that resists every
+server-side fix: check the installing device's own network stack (ad
+blockers, private DNS, VPNs) before spending more effort on the server.
 
-**Found and fixed.** Both mobile screenshots were **JPEG files with a `.png`
-extension**, declared `"type": "image/png"` in the manifest. A browser
-validates each entry against what it actually fetches and silently drops the
-mismatches — with both `form_factor: "narrow"` entries invalid, the mobile
-install dialog had nothing to show. Files renamed, declarations corrected, and
-`src/tests/manifest_assets.test.ts` now reads the magic bytes of every image
-the manifest declares and fails if a type or size is misdeclared. Screenshots
-have since been **disabled at your request** — the key is removed, the four
-files kept, re-enabling is re-adding the key.
+Real, independent fixes made along the way and kept regardless: the two
+mislabelled JPEG screenshots (now correctly typed), a proper safe-zone-padded
+`maskable` icon pair (fixes a genuine white-splash bug in browsers that don't
+share Chrome's specific issue, e.g. Brave), and HTTP/2 correctly enabled on
+`dev.cachy.app`. A follow-up bug found once shortcuts started rendering —
+empty icon slots in the shortcut menu, traced to a `maskable`-only shortcut
+icon Android's shortcut renderer doesn't handle — was fixed by reverting
+those to a plain `purpose: "any"` icon.
 
-**Not explained by the manifest fields alone.** `background_color` and
-`theme_color` are both `#0f172a`, a valid 512×512 icon exists, and two
-`shortcuts` entries are declared with valid icons — all correct on paper.
-
-**`git log` turned out not to be the dead end it looked like.** The local
-clone is still shallow and still can't help (both `--unshallow` and a bounded
-`--depth=1000` deepen timed out against the sandboxed network again), but the
-**GitHub API has the full history independent of the local clone's depth** —
-`list_commits` with a `path` filter returned every commit that ever touched
-`static/manifest.json`, back to its creation in January. That surfaced
-something this item had missed: **the white-splash symptom already has three
-prior fix attempts on record**, none confirmed as having worked —
-`purpose: "any maskable"` added then reverted an hour later with the opposite
-justification (both January 7th, same bot), and a same-day-adjacent rename to
-`site.webmanifest` to force a re-fetch (January 11th). Worth remembering
-generally: this repo's shallow clone is not the only source of file history
-when GitHub itself is reachable.
-
-**Ruled out on-device this round, not just on paper:** `display_override`
-without `window-controls-overlay` — deployed and tested on both
-`dev.cachy.app` and `cachy.app`, fresh installs after a full Chrome storage
-wipe (not just cache), still white splash and no shortcuts on both. Also
-ruled out: stale caching (storage wipe made no difference), a beta-subdomain
-infra quirk (production shows the identical bug), and Brave-specific behavior
-(reproduced there too). Chrome's own DevTools installability check reports
-zero errors on the manifest — it considers the app fully installable.
-
-**Done and confirmed working (partially):** added a real `maskable` icon pair
-(`icon-192-maskable.png`/`icon-512-maskable.png`, generated at 66% scale on a
-solid `#0f172a` canvas, declared as additional `purpose: "maskable"` entries
-alongside the existing `any` ones) rather than repeating either January
-attempt of toggling `purpose` on the same transparent-to-the-edges icon file.
-**On-device result: the splash background is now correct in Brave** (dark
-background, icon, title — fresh install, Motorola Edge 30). Chrome on the
-same device still shows white — see below for why.
-
-**A real bug turned up chasing your memory of when this last worked — but it
-doesn't actually explain the symptom, and an earlier draft of this note
-wrongly treated it as the leading cause. You caught that immediately.** You
-recalled shortcuts working before screenshots were added. The commit that
-added screenshots (`7f40111`, Feb 9) also — same commit — migrated the
-canonical domain from `www.cachy.app` to bare `cachy.app`. Screenshots were
-already ruled out (removing the key didn't fix anything), which left the
-domain migration worth checking. `curl -Iv` confirmed something real:
-**`www.cachy.app` serves the TLS certificate for a different site**
-(`board.heinze-media.com`, apparently sharing the same server IP) — every
-connection to `www.cachy.app` fails at the TLS handshake. `cachy.app` and
-`dev.cachy.app` are both fine.
-
-That's worth fixing regardless, but it can't be why `dev.cachy.app` shows the
-identical broken WebAPK (blank `Manifest URL`, blank colors, no shortcuts) —
-`dev.cachy.app` has no relationship to `www.cachy.app` at all, there was
-never a `www.dev.cachy.app`, and the February migration only ever touched
-`www` vs. bare `cachy.app`. A cert bug on one hostname doesn't explain an
-unrelated hostname breaking the same way.
-
-So the next lead was what it was before the `www` detour: something
-affecting **both** domains uniformly. Your own aaPanel access-log check found
-no trace either way (only your own IP plus normal Googlebot/scanner traffic —
-inconclusive, since a block below nginx wouldn't show there). What settled
-it instead: asking **Google's own infrastructure directly**, via
-PageSpeed Insights (runs Lighthouse server-side on Google's own servers)
-against `dev.cachy.app` — **no manifest error at all.** Google can fetch and
-parse this manifest cleanly from outside. That rules out reachability,
-firewall, and DNS entirely.
-
-With reachability confirmed and every manifest-content variable exhausted —
-including, at your request, a full revert of `static/manifest.json` to its
-exact 2026-01-15 structure (no `id`, no `display_override`, plain icons, no
-shortcuts) — **the result was identical: still blank `Manifest URL`/colors
-in `about://webapks`, still white splash, still no shortcuts, on the exact
-manifest from the last point you remember everything working.**
-
-**This settles it. The manifest content is not the cause, in any
-configuration this item could construct.** The failure is isolated to the
-Chrome-for-Android WebAPK-minting backend specifically — a narrow Google
-service that doesn't share a code path with Lighthouse, Googlebot, DevTools,
-or Brave, all of which handle this manifest correctly. Since content
-provably doesn't matter, the full-featured manifest (maskable icons +
-shortcuts) has been restored rather than left stripped down — no reason to
-keep it worse for the clients that do read it correctly. (Also confirmed
-along the way: Brave has its own unrelated, already-open upstream bug —
-[brave/brave-browser#56133](https://github.com/brave/brave-browser/issues/56133)
-— installed PWAs on Android never become a real standalone package there, so
-Brave can never show shortcuts regardless of anything here.)
-
-**HTTP/2 tested too — also ruled out. Investigation closed at your request.**
-You enabled HTTP/2 on `dev.cachy.app` (first hit the known nginx quirk where
-the legacy `listen ... http2;` parameter is a shared-socket setting, not
-per-vhost — another site on the same server/IP without `http2` was winning
-that resolution; switching to the newer per-vhost `http2 on;` directive
-fixed the negotiation, confirmed via `curl -Iv --http2` showing `h2` for
-real). Fresh WebAPK install against the now-genuinely-HTTP/2 origin: same
-result — blank colors, blank manifest URL, no shortcuts, white splash. One
-new detail worth recording: `Last Update Completion Time` was populated for
-the first time across every round (previously always stuck at the epoch),
-meaning the update cycle completed cleanly this time — but that didn't
-translate into the manifest's colors or shortcuts actually being picked up.
-
-With manifest content (five configurations across four rounds), reachability
-(Google's own Lighthouse infrastructure), and now transport protocol all
-tested and ruled out, you asked to close this out. **What's left is outside
-this repo:**
-
-1. `www.cachy.app`'s TLS cert is still broken (serves `board.heinze-media.com`'s
-   certificate) — real bug, worth fixing on its own merits, but confirmed
-   **not** related to this item (can't explain `dev.cachy.app` showing the
-   same symptom).
-2. Applying the same `http2 on;` fix to `cachy.app` (only `dev.cachy.app` was
-   switched) — harmless, good practice, not expected to change the outcome.
-3. Testing from a different device/Google account, waiting for whatever may
-   be stuck on Google's side to clear, or filing feedback with
-   Google/Chromium — the evidence gathered here is about as strong a report
-   as this repo can produce without server-side access to Google's systems.
-
-This item is not expected to need further manifest changes unless new
-evidence turns up. `BUG-0038` stays `in-progress` rather than `done` (the
-reported symptoms are genuinely unresolved) or `dropped` (the cause is
-understood and worth revisiting later) — it's just not actionable from this
-repo today.
+Still open, tracked in `BUG-0038`'s acceptance criteria, unrelated to this
+item: `www.cachy.app` still serves the wrong TLS certificate (a real,
+separate infra bug); `cachy.app` hasn't had the `http2 on;` fix applied yet
+(only `dev.cachy.app` was).
 
 ## 25. `IframeWindow`/`WindowManager.openIframe()` appear to be unreachable
 

--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -4,7 +4,7 @@
 
 52 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · 🟡 in-progress 1 · ✅ done 12
+Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 
 ---
 
@@ -106,7 +106,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · 🟡 in-pro
 | [BUG-0052](bugs/BUG-0052-app-access-token-blocks-public-byok-users.md) | APP_ACCESS_TOKEN blocks BYOK users who have no way to know it | P1 | ✅ done | api |
 | [FEAT-0050](features/FEAT-0050-window-manager-test-coverage.md) | Put tests under the window manager before more surfaces depend on it | P1 | ✅ done | ui |
 | [BUG-0009](bugs/BUG-0009-symbolpicker-null-resolution.md) | SymbolPickerWindow resolves with null against a type that excludes it | P2 | 📋 specced | ui |
-| [BUG-0038](bugs/BUG-0038-android-manifest-regressions.md) | PWA splash screen, screenshots and long-press shortcuts regressed on Android | P2 | 🟡 in-progress | pwa |
+| [BUG-0038](bugs/BUG-0038-android-manifest-regressions.md) | PWA splash screen, screenshots and long-press shortcuts regressed on Android | P2 | ✅ done | pwa |
 | [BUG-0051](bugs/BUG-0051-sidepanel-never-rendered.md) | SidePanel.svelte is never rendered, so the "Enable Side Panel" setting does nothing | P2 | ✅ done | ui |
 | [FEAT-0044](features/FEAT-0044-modalframe-through-window-manager.md) | Make ModalFrame an adapter over WindowFrame instead of a second implementation | P2 | ✅ done | ui |
 | [FEAT-0045](features/FEAT-0045-academy-as-window-type.md) | Register the Trading Academy as its own window type | P2 | ✅ done | ui |
@@ -149,7 +149,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · 🟡 in-pro
 | [BUG-0005](bugs/BUG-0005-gpu-chop-field-mismatch.md) | GPU-accelerated Choppiness writes to a field nothing reads | P2 | 📋 specced | M0 | community, pro, private | none | none | — |
 | [BUG-0006](bugs/BUG-0006-sentiment-response-unvalidated.md) | Sentiment cache and AI response are trusted without schema validation | P2 | 📋 specced | M0 | community, pro, private | none | none | — |
 | [BUG-0009](bugs/BUG-0009-symbolpicker-null-resolution.md) | SymbolPickerWindow resolves with null against a type that excludes it | P2 | 📋 specced | none | community, pro, private | none | none | — |
-| [BUG-0038](bugs/BUG-0038-android-manifest-regressions.md) | PWA splash screen, screenshots and long-press shortcuts regressed on Android | P2 | 🟡 in-progress | none | community, pro, private | none | none | — |
+| [BUG-0038](bugs/BUG-0038-android-manifest-regressions.md) | PWA splash screen, screenshots and long-press shortcuts regressed on Android | P2 | ✅ done | none | community, pro, private | none | none | — |
 | [BUG-0043](bugs/BUG-0043-responsive-window-remaximizes.md) | A responsive window restored by hand on mobile re-maximizes on the next resize event | P2 | ✅ done | M0 | community, pro, private | A | none | — |
 | [BUG-0048](bugs/BUG-0048-glass-removes-academy-sidebar-background.md) | Glassmorphism leaves the Academy sidebar without a background and unreadable | P2 | ✅ done | M0 | community, pro, private | none | none | — |
 | [BUG-0049](bugs/BUG-0049-quiz-closes-after-every-answer.md) | The quiz closes after every answer, has no close button and opens behind other windows | P2 | ✅ done | M0 | community, pro, private | A | none | — |

--- a/docs/backlog/bugs/BUG-0038-android-manifest-regressions.md
+++ b/docs/backlog/bugs/BUG-0038-android-manifest-regressions.md
@@ -2,7 +2,7 @@
 id: BUG-0038
 title: PWA splash screen, screenshots and long-press shortcuts regressed on Android
 type: bug
-status: in-progress
+status: done
 priority: P2
 milestone: none
 editions: [community, pro, private]
@@ -24,6 +24,13 @@ Three things that used to work on an installed Android PWA no longer do:
 
 Reported by the maintainer as a regression — these worked at some point and
 broke since.
+
+**Resolved — see Round 6.** The actual cause was a device-side ad blocker on
+the test phone blocking Chrome's own connection to Google's WebAPK
+infrastructure. Nothing in this repo, this server, or this manifest was ever
+the reason symptoms 1 and 3 persisted after symptom 2 (screenshots) was
+fixed — five rounds of server-side investigation below are kept as the
+record of what was checked and ruled out, not as remaining open work.
 
 **Correction to an earlier wrong diagnosis.** An earlier pass on this item
 claimed a missing `maskable` icon was "wrong and ruled out," reasoning only
@@ -281,6 +288,17 @@ Google Cloud IP ranges.
 - **Round 3 (see below): removed `id`, reverted `start_url` to `/`, switched
   shortcut icons to the maskable variant.** Also unverified on-device as of
   this writing.
+- **Round 6 (see below): reverted shortcut icons back to the plain,
+  transparent `icon-192.png` (`purpose: "any"`)** — the Round 3 switch to
+  the maskable variant is the prime suspect for shortcut menu items
+  rendering with no icon at all (empty space) once shortcuts started
+  working. Reasoning: matches the format every other WebAPK on the same
+  device uses for its own shortcut icons (Round 2's `about://webapks`
+  survey), and matches the icon-selection algorithm's normal behaviour
+  (`any` is the default; `maskable` is only picked where the OS specifically
+  asks for it, which a shortcut-icon slot apparently doesn't). **Not yet
+  verified on-device** as of this writing — this is a plausible fix based on
+  solid reasoning, not a confirmed one.
 
 ### Round 3 — firewall logs checked (inconclusive), a third ignored field, and a new experiment
 
@@ -490,6 +508,70 @@ and rather than `dropped` because the cause is understood and worth revisiting
 if new information surfaces (a Chrome update, a different device, a resolved
 Google-side state) — just not something this repo can act on further today.
 
+### Round 6 — the actual cause: a device-side ad blocker. Resolved.
+
+The real cause, once found, made every earlier finding in this item make
+sense in retrospect: **an ad blocker on the test device/network was
+blocking the connection Chrome itself needs to reach Google's WebAPK
+infrastructure.** Disabling it, `about://webapks` populates correctly and
+the installed app shows the correct splash background and the long-press
+shortcuts menu.
+
+This reframes the entire investigation, and it is worth being explicit about
+why five rounds of testing never found it: **every reachability check this
+item ran was from the wrong side.** PageSpeed Insights/Lighthouse (Round 4)
+and Googlebot (Round 3) both check whether *Google's servers* can reach
+*this repo's* server — that path was never broken. The actual broken path
+was the reverse: *the phone's own Chrome* reaching *Google's* WebAPK-minting
+service, over the phone's own network/ad-blocker stack. Nothing server-side
+(this repo, the aaPanel firewall, the `www.cachy.app` TLS bug, HTTP/1.1 vs.
+h2) was ever going to surface a client-side network block, because none of
+those checks route through the device doing the installing. The lesson for
+next time a WebAPK/PWA symptom looks server-side but resists every
+server-side fix: check the installing device's own network stack (ad
+blockers, private DNS, VPNs, firewalls) before spending more effort on the
+server.
+
+**None of the fixes made along the way were wasted, even though none of them
+were *the* fix:**
+
+- The mislabelled JPEG screenshots (Fix, first entry) were a real, separate
+  bug, independent of this one — still correctly fixed.
+- The maskable icon pair fixes a real rendering problem (an unpadded,
+  fully-transparent icon declared `maskable` gives the OS nothing to mask
+  into) and is standard PWA best practice regardless of the ad-blocker issue.
+- The `www.cachy.app` TLS misconfiguration is a real, independent bug, still
+  unresolved and still worth fixing on its own merits (see Acceptance
+  criteria) — just never related to this item.
+- HTTP/2 is generally good practice and now correctly enabled on
+  `dev.cachy.app` (not yet on `cachy.app`).
+- The extensive git-history archaeology (the January `purpose` flip-flop,
+  the `www` domain migration) surfaced real prior art worth knowing about
+  even though neither turned out to be this bug's cause.
+
+**One follow-up bug found once shortcuts finally rendered:** the shortcut
+menu items showed with **no icon** — an empty slot where the icon belongs.
+The shortcuts' `icons` entries pointed at `icon-192-maskable.png` with
+`"purpose": "maskable"` (set in Round 3, itself an untested guess made while
+chasing the wrong theory). Android's shortcut-icon rendering does not appear
+to handle a `maskable`-only shortcut icon the way the main app icon's
+adaptive-icon pipeline does — it does not degrade to *something*, it shows
+nothing. Fixed by reverting the shortcut icons to the plain, transparent
+`icon-192.png` with `"purpose": "any"` — the same file already used for the
+regular app icon, and the format every other WebAPK on the maintainer's
+device (Bitpanda Academy, Tasker Share, Vivid Money) uses for its own
+shortcut icons too, per the `about://webapks` output gathered in Round 2.
+
+The top-level `icons` array keeps its `maskable` entries — they solve a
+real, confirmed problem (Brave's splash rendering, see Round 2) and are
+listed *after* the `purpose: "any"` entries, so per the manifest icon
+selection algorithm they are only ever used where the OS specifically
+requests a maskable icon (e.g. shaping the home-screen icon) — everywhere
+else, including apparently the shortcut-icon renderer, the `any` icon is
+what gets used. That is already exactly the "maskable as a fallback, not the
+default" relationship asked for; nothing needed to change there beyond the
+shortcut icons themselves.
+
 ## Acceptance criteria
 
 - [x] No manifest entry declares a type or size its file does not have
@@ -500,35 +582,32 @@ Google-side state) — just not something this repo can act on further today.
 - [x] A properly safe-zone-padded `maskable` icon pair added, addressing the
       gap an earlier pass in this item wrongly ruled out
 - [x] The splash screen shows `background_color` on a real Android device —
-      **confirmed in Brave** on a fresh install (Motorola Edge 30, Brave for
-      Android). Chrome on the same device still shows white — **root cause
-      identified as the Chrome-for-Android WebAPK-minting backend, external
-      to this repo** (see Round 4). Manifest content exhaustively ruled out.
-- [ ] Long-pressing the installed icon shows both declared shortcuts —
-      not yet achieved in Chrome (the only browser where it's structurally
-      possible; Brave has its own upstream bug, see Round 2). Blocked on the
-      same external cause as the splash symptom above — **not actionable
-      from this repo** until Google's WebAPK-minting backend starts
-      succeeding for this origin again.
+      **confirmed working**, on both Brave (Round 2) and Chrome, once the
+      device-side ad blocker (Round 6) was disabled.
+- [x] Long-pressing the installed icon shows both declared shortcuts —
+      **confirmed working in Chrome** after disabling the ad blocker (Round
+      6). A follow-up bug surfaced at that point: shortcut icons rendered as
+      empty space instead of the icon. Reverted the shortcut icons from the
+      `maskable` variant (Round 3) back to the plain `purpose: "any"` icon
+      as the fix — **not yet re-verified on-device** as of this writing.
 - [ ] `www.cachy.app` has a working vhost (redirect + valid certificate, or
       the DNS record removed) — a real, confirmed infra bug, worth fixing on
-      its own merits, but **confirmed not related** to symptoms 1/3 (it
-      can't explain `dev.cachy.app` showing the identical symptom, since
-      that hostname has no relationship to `www` at all — see Round 2/3).
-      Tracked here only because it surfaced during this investigation; treat
-      as a separate, independent fix.
-- [x] HTTP/2 enabled on `dev.cachy.app` and tested — **confirmed not the
-      cause** either (see Round 5). `cachy.app` not yet switched to the
-      newer `http2 on;` syntax; worth doing for its own sake, not expected
-      to change this item's outcome.
+      its own merits, but **confirmed not related** to symptoms 1/3, and
+      **not part of this item's scope** — tracked here only because it
+      surfaced during the investigation. Left open for a separate fix.
+- [x] HTTP/2 enabled on `dev.cachy.app` — not the cause of this bug, but
+      correctly configured now regardless (Round 5). `cachy.app` not yet
+      switched to the newer `http2 on;` syntax — separate, low-priority
+      follow-up.
 
-**Investigation closed at the maintainer's request (Round 5).** Every lever
-available from this repo — manifest content, reachability, transport
-protocol — has been exhausted with an identical result each time. The
-remaining two acceptance criteria (splash on Chrome, shortcuts) stay
-unchecked because they are genuinely unresolved, not because more work is
-planned here; see Round 5's closing note for why this stays `in-progress`
-rather than `done` or `dropped`.
+**Resolved (Round 6).** The actual cause was a device-side ad blocker
+blocking Chrome's own connection to Google's WebAPK infrastructure — not
+this repo, not this server. See Round 6 for the full explanation, including
+why five rounds of server-side reachability testing could never have found
+a client-side network block. The mislabelled screenshots, the maskable icon
+pair, and HTTP/2 were all real, independent fixes made along the way and are
+kept; the `www.cachy.app` certificate bug remains open as a separate,
+unrelated item.
 
 ## Links
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -349,6 +349,11 @@ import { afterNavigate } from "$app/navigation";
       const newUrl = new URL(window.location.href);
       newUrl.searchParams.delete("action");
       window.history.replaceState({}, "", newUrl.toString());
+    } else if (action === "market") {
+      uiState.toggleMarketDashboardModal(true);
+      const newUrl = new URL(window.location.href);
+      newUrl.searchParams.delete("action");
+      window.history.replaceState({}, "", newUrl.toString());
     }
   });
   // Reactivity for Settings Changes

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -42,14 +42,14 @@
       "short_name": "Journal",
       "description": "View your trading history and performance",
       "url": "/?action=journal",
-      "icons": [{ "src": "/icon-192-maskable.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" }]
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" }]
     },
     {
       "name": "Settings",
       "short_name": "Settings",
       "description": "Configure Cachy app settings",
       "url": "/?action=settings",
-      "icons": [{ "src": "/icon-192-maskable.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" }]
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" }]
     }
   ]
 }

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -6,6 +6,7 @@
   "dir": "ltr",
   "start_url": "/",
   "display": "standalone",
+  "launch_handler": { "client_mode": "navigate-existing" },
   "background_color": "#0f172a",
   "theme_color": "#0f172a",
   "orientation": "portrait",
@@ -45,10 +46,10 @@
       "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" }]
     },
     {
-      "name": "Settings",
-      "short_name": "Settings",
-      "description": "Configure Cachy app settings",
-      "url": "/?action=settings",
+      "name": "Market Overview",
+      "short_name": "Markets",
+      "description": "View live market data and analysis",
+      "url": "/?action=market",
       "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" }]
     }
   ]


### PR DESCRIPTION
## Summary

**BUG-0038 resolved.** The maintainer found the real cause: an ad blocker on the test device was blocking Chrome's own connection to Google's WebAPK infrastructure — not this repo, not the server, not the manifest. Five rounds of prior investigation checked reachability from *Google's* side (Lighthouse, Googlebot) and could never have found a block on the *phone's* side of that connection. Recorded as the closing lesson in `BUG-0038` for next time.

**Fixed a follow-up bug** found once shortcuts started rendering: shortcut menu items showed empty space instead of an icon. Traced to the shortcuts' `icons` pointing at the `maskable` variant (set in Round 3, an untested guess made while chasing the wrong theory) — Android's shortcut-icon rendering doesn't appear to handle a `maskable`-only icon the way the main app icon's adaptive-icon pipeline does. Reverted shortcut icons to the plain, transparent `icon-192.png` (`purpose: "any"`), matching the format every other WebAPK on the same device uses for its own shortcuts.

**Two follow-up manifest improvements**, requested after the bug itself was closed:

- Swapped the "Settings" shortcut for "Market Overview" — Settings is a poor fit for a home-screen shortcut (infrequent, not time-sensitive); Market Overview (`uiState.toggleMarketDashboardModal`, an existing feature) is exactly the kind of quick, frequent check shortcuts are for. Wired a new `?action=market` case into `+layout.svelte`'s PWA action handler alongside the existing `journal`/`settings` ones.
- Added `launch_handler: { "client_mode": "navigate-existing" }` so tapping a shortcut while Cachy is already running navigates the existing window instead of opening a second instance — relevant for a calculator app holding in-progress input state.

`BUG-0038` marked `done` (status + acceptance criteria). `docs/TODO.md` item 24 trimmed to a short resolved summary per this repo's convention, linking to `BUG-0038` instead of duplicating the investigation trail. `docs/backlog/INDEX.md` regenerated for the status change.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx vitest run src/tests/manifest_assets.test.ts` — 21/21 passed
- [x] `npm test` (full suite) — 998 passed, 6 skipped
- [x] `npx eslint src/routes/+layout.svelte` — clean
- [x] `npm run backlog:check` — front matter valid, index up to date
- [x] `npm run docs:links` — 551 links resolve
- [ ] Shortcut icons render correctly, and the new Market Overview shortcut opens the right modal — not yet verified on-device