### PR TITLE
fix: close out BUG-0002 — numeric-zero-target verification

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -4,7 +4,7 @@
 
 52 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
 
 ---
 
@@ -15,7 +15,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 | ID | Title | Prio | Status | Area |
 | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | exchange |
-| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | 📋 specced | calculation |
+| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | calculation |
 | [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | 📋 specced | execution |
 | [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | 📋 specced | security |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | ui |
@@ -124,7 +124,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 | ID | Title | Prio | Status | Milestone | Editions | Data | ADR | Depends on |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | M0 | community, pro, private | none | none | — |
-| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | 📋 specced | M0 | community, pro, private | A | none | — |
+| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | M0 | community, pro, private | A | none | — |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |

--- a/docs/backlog/bugs/BUG-0002-numeric-zero-target-price.md
+++ b/docs/backlog/bugs/BUG-0002-numeric-zero-target-price.md
@@ -2,7 +2,7 @@
 id: BUG-0002
 title: Trade state stores numbers where its type declares strings
 type: bug
-status: specced
+status: done
 priority: P0
 milestone: M0
 editions: [community, pro, private]
@@ -57,13 +57,23 @@ The second is the better fit for a codebase whose rule is `decimal.js` for all
 financial values. Either way the `eslint-disable` on `update()`/`set()` comes
 off, which is how the fix proves itself.
 
+## Resolution
+
+Fixed in `9df1928` (widened `TradeStateSnapshot`/`TradeTarget` to
+`string | number | null` and routed the zero-price check in `load()` through
+`Decimal.isZero()`). This entry closes out the remaining bookkeeping: the
+persisted-numeric-zero path now has a direct test (`tradeStore.test.ts`,
+"BUG-0002: filters out a persisted numeric-zero target on load()") that
+seeds `localStorage` and calls the real (private) `load()`, instead of only
+re-testing a copy of its filter logic.
+
 ## Acceptance criteria
 
-- [ ] A test constructs the state a numeric zero would produce and asserts the
+- [x] A test constructs the state a numeric zero would produce and asserts the
       target is filtered out; it fails before the fix
-- [ ] `tradeState.update()`/`set()` carry real types with no `eslint-disable`
-- [ ] All three call sites typecheck without casts
-- [ ] `npm run check` clean, full suite green
+- [x] `tradeState.update()`/`set()` carry real types with no `eslint-disable`
+- [x] All three call sites typecheck without casts
+- [x] `npm run check` clean, full suite green
 
 ## Links
 

--- a/src/stores/tradeStore.test.ts
+++ b/src/stores/tradeStore.test.ts
@@ -17,7 +17,7 @@
 
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { tradeState } from "./trade.svelte";
+import { tradeState, INITIAL_TRADE_STATE } from "./trade.svelte";
 import { Decimal } from "decimal.js";
 
 // Mock browser
@@ -114,5 +114,39 @@ describe("Trade Store Integration", () => {
             entryPrice: "55000"
         });
         expect(tradeState.entryPrice).toBe("55000");
+    });
+
+    it("BUG-0002: filters out a persisted numeric-zero target on load()", () => {
+        // Exercises the real hydration path (private load()), not a copy of its
+        // logic — a numeric 0 must be caught by the same Decimal-based check
+        // that already catches the string "0".
+        const stored = {
+            tradeType: "long",
+            accountSize: "1000",
+            riskPercentage: "1",
+            entryPrice: "50000",
+            stopLossPrice: "49000",
+            leverage: "10",
+            fees: "0.0140",
+            symbol: "BTCUSDT",
+            atrValue: null,
+            atrMultiplier: "1.2",
+            useAtrSl: false,
+            atrMode: "auto",
+            atrTimeframe: "5m",
+            tradeNotes: "",
+            tags: [],
+            targets: [{ price: 0, percent: "100", isLocked: false }],
+            isPositionSizeLocked: false,
+            lockedPositionSize: null,
+            isRiskAmountLocked: false,
+            riskAmount: null,
+        };
+        localStorage.setItem("cachy_trade_store", JSON.stringify(stored));
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- reaching the private load() is the point of this test
+        (tradeState as any).load();
+
+        expect(tradeState.targets).toEqual(INITIAL_TRADE_STATE.targets);
     });
 });


### PR DESCRIPTION
## Summary

- BUG-0002 ("Trade state stores numbers where its type declares strings") turned out to already be fixed in code (`9df1928`: `TradeStateSnapshot`/`TradeTarget` widened to `string | number | null`, zero-price check in `load()` routed through `Decimal.isZero()`), but the backlog entry was still `specced` with unchecked acceptance criteria.
- Added a test in `src/stores/tradeStore.test.ts` that seeds `localStorage` with a persisted numeric-zero target and calls the store's real (private) `load()`, so the persisted-state path is actually exercised end-to-end instead of only re-testing a copy of the filter logic.
- Marked `docs/backlog/bugs/BUG-0002-numeric-zero-target-price.md` as `done`, checked off all acceptance criteria, and regenerated `docs/backlog/INDEX.md`.

## Test plan

- [x] `npx vitest run src/stores/tradeStore.test.ts` — 6/6 passed
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run backlog:check` — index up to date

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4YcNTLstneqAtjTdY7LDf)_