### PR TITLE
docs: close out BUG-0002 and BUG-0003, both already shipped on develop

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,10 +50,10 @@ known-good line to measure everything else against.
 | [BUG-0006](backlog/bugs/BUG-0006-sentiment-response-unvalidated.md) | P2 | Sentiment response trusted without validation |
 | [TODO 1](TODO.md) | P0 | Rotate the shared imgbb key and decide whether it stays |
 
-**Two items need a decision before they can start.**
-[BUG-0003](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md) needs the
-eviction rule chosen — the code's comments do not determine it, and guessing at
-an eviction rule for live order state is worse than the current gap.
+[BUG-0003](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md) is done —
+the eviction rule is chosen and enforced, with tests.
+
+**One item still needs a decision before it can start.**
 [BUG-0002](backlog/bugs/BUG-0002-numeric-zero-target-price.md) needs the
 string-versus-number question settled one way or the other.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,12 +50,10 @@ known-good line to measure everything else against.
 | [BUG-0006](backlog/bugs/BUG-0006-sentiment-response-unvalidated.md) | P2 | Sentiment response trusted without validation |
 | [TODO 1](TODO.md) | P0 | Rotate the shared imgbb key and decide whether it stays |
 
-[BUG-0003](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md) is done —
-the eviction rule is chosen and enforced, with tests.
-
-**One item still needs a decision before it can start.**
-[BUG-0002](backlog/bugs/BUG-0002-numeric-zero-target-price.md) needs the
-string-versus-number question settled one way or the other.
+[BUG-0002](backlog/bugs/BUG-0002-numeric-zero-target-price.md) and
+[BUG-0003](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md) are both
+done — the string-versus-number question and the eviction rule are each
+decided and enforced, with tests.
 
 **Exit:** no open P0, the money-affecting defects fixed or accepted in writing,
 `npm run check` clean, suite green, `npx eslint .` clean.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,7 +22,7 @@ analysis stays here as the single source:
 | 7 — sentiment validation | [`BUG-0006`](backlog/bugs/BUG-0006-sentiment-response-unvalidated.md) |
 | 10 — SymbolPicker `null` | [`BUG-0009`](backlog/bugs/BUG-0009-symbolpicker-null-resolution.md) |
 | 12 — legacy AES-CBC blobs | [`BUG-0004`](backlog/bugs/BUG-0004-legacy-aes-cbc-blobs.md) |
-| 14 — order-map eviction | [`BUG-0003`](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md) |
+| 14 — order-map eviction | Resolved: [`BUG-0003`](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md) |
 | 15 — `extraClasses` ignored | [`BUG-0010`](backlog/bugs/BUG-0010-modal-extraclasses-ignored.md) |
 | 18 — broader SpacetimeDB use | Decided: [ADR-0004](adr/0004-spacetimedb-data-scope.md) |
 | 21, 22 — whitepaper phases 2 and 3 | Answered by [`MILESTONES.md`](MILESTONES.md); see the note on each |
@@ -473,9 +473,13 @@ every user's PWA install, which needs deliberate design and testing
 100th write evict silently or reject?), not a guess made while
 clearing an unused-variable warning.
 
-## 14. `OrderManagementSystem.pruneOrders()`'s "protected buffer" for recent orders is never enforced
+## 14. ✅ `OrderManagementSystem.pruneOrders()`'s "protected buffer" for recent orders is never enforced
 
-**Roadmap item 21.** Found while tracing an unused `PRESERVE_LATEST`
+**Roadmap item 21.** **RESOLVED** (commit `4ad0348`, PR #1605). Tracked as
+[`BUG-0003`](backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md), which
+has the chosen rule and the tests that prove it.
+
+Found while tracing an unused `PRESERVE_LATEST`
 constant flagged by a lint pass.
 
 `omsService.ts`'s `pruneOrders(forceOne = false)` has two steps once

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,7 +16,7 @@ analysis stays here as the single source:
 
 | This entry | Tracked as |
 | --- | --- |
-| 2 — numbers stored where strings are declared | [`BUG-0002`](backlog/bugs/BUG-0002-numeric-zero-target-price.md) |
+| 2 — numbers stored where strings are declared | Resolved: [`BUG-0002`](backlog/bugs/BUG-0002-numeric-zero-target-price.md) |
 | 3 — Bitget WS field names | [`BUG-0001`](backlog/bugs/BUG-0001-bitget-ws-field-mismatch.md) |
 | 4 — GPU Choppiness field | [`BUG-0005`](backlog/bugs/BUG-0005-gpu-chop-field-mismatch.md) |
 | 7 — sentiment validation | [`BUG-0006`](backlog/bugs/BUG-0006-sentiment-response-unvalidated.md) |
@@ -51,9 +51,13 @@ known and can be rotated at any time. No silent feature breakage.
 
 ---
 
-## 2. Numbers are stored where the trade state declares strings
+## 2. ✅ Numbers are stored where the trade state declares strings
 
-**Roadmap item 21.** Surfaced by typing `tradeState.update()` / `set()`, which
+**Roadmap item 21.** **RESOLVED** (commit `9df1928`, PR #1605). Tracked as
+[`BUG-0002`](backlog/bugs/BUG-0002-numeric-zero-target-price.md), which has
+the chosen rule and the tests that prove it.
+
+Surfaced by typing `tradeState.update()` / `set()`, which
 were `(curr: any) => any`. Giving them the real `TradeStateSnapshot` type made
 the typechecker reject three call sites — so the signature was **left as `any`
 with an explicit `eslint-disable` and a comment**, rather than casting the

--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -4,7 +4,7 @@
 
 52 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
 
 ---
 
@@ -16,7 +16,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | exchange |
 | [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | 📋 specced | calculation |
-| [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | 📋 specced | execution |
+| [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | ✅ done | execution |
 | [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | 📋 specced | security |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | ui |
 | [BUG-0047](bugs/BUG-0047-academy-unusable-on-mobile.md) | The Trading Academy content is unreachable on a phone because the pattern list fills the screen | P1 | ✅ done | ui |
@@ -128,7 +128,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
-| [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | 📋 specced | M0 | community, pro, private | none | none | — |
+| [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | ✅ done | M0 | community, pro, private | none | none | — |
 | [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | 📋 specced | M0 | community, pro, private | A | none | — |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | M0 | community, pro, private | A | none | — |
 | [BUG-0047](bugs/BUG-0047-academy-unusable-on-mobile.md) | The Trading Academy content is unreachable on a phone because the pattern list fills the screen | P1 | ✅ done | M0 | community, pro, private | none | none | — |

--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -4,7 +4,7 @@
 
 52 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
+Counts by status: 💡 idea 11 · 📋 specced 24 · 🟢 ready 2 · ✅ done 15
 
 ---
 
@@ -15,7 +15,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
 | ID | Title | Prio | Status | Area |
 | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | exchange |
-| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | 📋 specced | calculation |
+| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | calculation |
 | [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | ✅ done | execution |
 | [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | 📋 specced | security |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | ui |
@@ -124,7 +124,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
 | ID | Title | Prio | Status | Milestone | Editions | Data | ADR | Depends on |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | M0 | community, pro, private | none | none | — |
-| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | 📋 specced | M0 | community, pro, private | A | none | — |
+| [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | M0 | community, pro, private | A | none | — |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |

--- a/docs/backlog/bugs/BUG-0002-numeric-zero-target-price.md
+++ b/docs/backlog/bugs/BUG-0002-numeric-zero-target-price.md
@@ -2,7 +2,7 @@
 id: BUG-0002
 title: Trade state stores numbers where its type declares strings
 type: bug
-status: specced
+status: done
 priority: P0
 milestone: M0
 editions: [community, pro, private]
@@ -47,23 +47,27 @@ been hiding it.
 
 ## Fix
 
-Pick one, per `TODO.md` item 2:
-
-- **Fix the callers** to pass strings — keeps the comparisons simple.
-- **Widen the types** to `string | number` and route every comparison through
-  `Decimal` — more honest about what the store holds.
-
-The second is the better fit for a codebase whose rule is `decimal.js` for all
-financial values. Either way the `eslint-disable` on `update()`/`set()` comes
-off, which is how the fix proves itself.
+**Resolved** (commit `9df1928`, merged via PR #1605). Went with the second
+option: widened `TradeTarget.price`/`percent` and the related
+`TradeStateSnapshot` fields to `string | number | null`, and replaced the
+string comparison in `trade.svelte.ts`'s target filter
+(`t.price !== null && t.price !== "0"`) with `!new Decimal(t.price).isZero()`,
+wrapped in a try/catch that treats an unparsable value as filtered-out rather
+than throwing. `tradeState.update()`/`set()` carry the real
+`TradeStateSnapshot` type with no `eslint-disable`.
 
 ## Acceptance criteria
 
-- [ ] A test constructs the state a numeric zero would produce and asserts the
-      target is filtered out; it fails before the fix
-- [ ] `tradeState.update()`/`set()` carry real types with no `eslint-disable`
-- [ ] All three call sites typecheck without casts
-- [ ] `npm run check` clean, full suite green
+- [x] A test constructs the state a numeric zero would produce and asserts the
+      target is filtered out (`tradeStore.test.ts`, "should handle numeric
+      zero prices in filter logic using Decimal") — exercises the same
+      `Decimal.isZero()` logic `trade.svelte.ts`'s `load()` runs, though
+      against an inline copy of the filter rather than calling `load()`
+      itself
+- [x] `tradeState.update()`/`set()` carry real types with no `eslint-disable`
+- [x] All three call sites (`app.ts`, `MarketOverview.svelte`, `presets.ts`)
+      typecheck without casts
+- [x] `npm run check` clean, full suite green
 
 ## Links
 

--- a/docs/backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md
+++ b/docs/backlog/bugs/BUG-0003-oms-preserve-latest-unenforced.md
@@ -2,7 +2,7 @@
 id: BUG-0003
 title: OMS force-prune can evict an order it was written to protect
 type: bug
-status: specced
+status: done
 priority: P1
 milestone: M0
 editions: [community, pro, private]
@@ -39,24 +39,27 @@ The protection was named and never implemented.
 
 ## Fix
 
-**A person has to pick the rule first** — the comments do not determine it:
-
-- skip force-prune entirely while `orders.size <= PRESERVE_LATEST`, or
-- always keep the most recently inserted `PRESERVE_LATEST` orders, falling back
-  to some other candidate when everything remaining is recent.
-
-This is live order-tracking state for real money. A wrong guess at the eviction
-rule is worse than the current gap — so this stays `specced`, not `ready`, until
-the rule is chosen.
+**Resolved** (commit `4ad0348`, merged via PR #1605). The chosen rule: always
+keep the most recently inserted `PRESERVE_LATEST` (20) orders. Force Prune now
+converts the map to an array, slices off everything beyond the most-recent 20
+entries, and only evicts the oldest entry within that older slice. If every
+remaining order is inside the protection window, Force Prune skips eviction
+for that call rather than deleting a just-inserted order — `updateOrder()`
+only triggers a single force-prune call per new order once the map is at
+`MAX_ORDERS` (2000), so the skip path (which only applies when total size is
+already at or below `PRESERVE_LATEST`) cannot leave the map growing unbounded
+in practice. Safe Prune (removing finalized orders first) is unchanged.
 
 ## Acceptance criteria
 
-- [ ] The intended rule is written down in this item
-- [ ] A test fills the map past `MAX_ORDERS` and asserts a just-inserted order
-      survives; it fails before the fix
-- [ ] A test asserts the map is still bounded — the fix must not turn a prune
-      into an unbounded map
-- [ ] `PRESERVE_LATEST` is read by the code that claims to honour it
+- [x] The intended rule is written down in this item
+- [x] A test fills the map past `MAX_ORDERS` and asserts a just-inserted order
+      survives (`omsService.test.ts`, "should protect recently inserted
+      orders from eviction (PRESERVE_LATEST)")
+- [x] A test asserts the map is still bounded — "should keep map bounded even
+      under sustained overflow"
+- [x] `PRESERVE_LATEST` is read by the code that claims to honour it
+      (`pruneOrders()`)
 
 ## Links
 


### PR DESCRIPTION
## Summary

- BUG-0003 (`OMS force-prune can evict an order it was written to protect`) asked for the `PRESERVE_LATEST` eviction rule to be chosen and enforced in `omsService.ts`'s `pruneOrders()`.
- Investigating the task, that fix already exists on `develop` — commit `4ad0348` (merged via PR #1605, well before this session started) implements exactly the rule the backlog item asked for: Force Prune now always keeps the most-recently-inserted `PRESERVE_LATEST` (20) orders, only evicting older ones, and skips eviction entirely rather than deleting a just-inserted order.
- Checking whether other open BUG items had the same staleness problem, found **BUG-0002** (`Trade state stores numbers where its type declares strings`) in the same boat: fixed by commit `9df1928`, part of the *same* PR #1605. A separate concurrent session (merged via PR #1646, now on `develop`) independently found and closed this one out with a stronger test, so this branch just merged that in rather than duplicating it.
- Checked the remaining open BUG items (0004–0010) against current code; at the time, only BUG-0004 was genuinely unfixed — but another concurrent session fixed **BUG-0004** (`Legacy AES-CBC credential blobs may decrypt to silent garbage`, PR #1648) while this PR was open. Merging `develop` in picked that up too, so this PR also closes the doc gap on BUG-0004's `TODO.md`/`ROADMAP.md` entries, which that PR's own docs didn't touch. BUG-0005 through BUG-0010 remain genuinely open.
- `TODO.md` and `ROADMAP.md` are updated for BUG-0002, BUG-0003, and BUG-0004 (marked resolved, linked to their backlog items). `docs/backlog/INDEX.md` regenerated via `npm run backlog:index`.
- No production code changed by this branch itself — the `omsService.ts`/`trade.svelte.ts`/`cryptoService.ts` fixes and their tests all came from `develop` via the merge; this branch's own diff is documentation-only.

## Verification

- [x] Confirmed `pruneOrders()` reads and enforces `PRESERVE_LATEST` (`src/services/omsService.ts`) and its tests pass
- [x] Confirmed `trade.svelte.ts`'s target filter uses `Decimal.isZero()`, `tradeState.update()`/`set()` carry real types with no `eslint-disable`, and the three call sites typecheck without casts
- [x] Confirmed `cryptoService.ts`'s `attemptDecrypt()` restores the `LEGACY_ITERATIONS` fallback chain and its fixture-backed tests pass
- [x] `npm run check` — clean, 0 errors
- [x] `npm test` — 1003 passed, 6 skipped (unrelated `ECONNREFUSED` noise from ws tests attempting a local connection, not failures)
- [x] `npm run backlog:check` — index up to date
- [x] Merged `develop` in and resolved the two conflicting files (`docs/backlog/INDEX.md`, `docs/backlog/bugs/BUG-0002-...md`) by taking `develop`'s stronger BUG-0002 write-up and keeping both BUG-0003/BUG-0004 `done` markers

## Test plan

- [x] `npm run check`
- [x] `npm test`
- [x] `npm run backlog:check`