### PR TITLE
fix(security): restore legacy PBKDF2 fallback for AES-CBC credential blobs

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -4,7 +4,7 @@
 
 52 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
+Counts by status: 💡 idea 11 · 📋 specced 24 · 🟢 ready 2 · ✅ done 15
 
 ---
 

--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -4,7 +4,7 @@
 
 52 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 14
 
 ---
 
@@ -17,7 +17,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | exchange |
 | [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | 📋 specced | calculation |
 | [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | 📋 specced | execution |
-| [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | 📋 specced | security |
+| [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | ✅ done | security |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | ui |
 | [BUG-0047](bugs/BUG-0047-academy-unusable-on-mobile.md) | The Trading Academy content is unreachable on a phone because the pattern list fills the screen | P1 | ✅ done | ui |
 | [FEAT-0041](features/FEAT-0041-window-layer-contract.md) | Give every floating surface its z-index from one layer contract | P1 | 📋 specced | ui |
@@ -129,7 +129,7 @@ Counts by status: 💡 idea 11 · 📋 specced 26 · 🟢 ready 2 · ✅ done 13
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | 📋 specced | M0 | community, pro, private | none | none | — |
-| [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | 📋 specced | M0 | community, pro, private | A | none | — |
+| [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | ✅ done | M0 | community, pro, private | A | none | — |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | M0 | community, pro, private | A | none | — |
 | [BUG-0047](bugs/BUG-0047-academy-unusable-on-mobile.md) | The Trading Academy content is unreachable on a phone because the pattern list fills the screen | P1 | ✅ done | M0 | community, pro, private | none | none | — |
 | [BUG-0052](bugs/BUG-0052-app-access-token-blocks-public-byok-users.md) | APP_ACCESS_TOKEN blocks BYOK users who have no way to know it | P1 | ✅ done | none | community, pro, private | none | ADR-0002 | — |

--- a/docs/backlog/bugs/BUG-0004-legacy-aes-cbc-blobs.md
+++ b/docs/backlog/bugs/BUG-0004-legacy-aes-cbc-blobs.md
@@ -2,7 +2,7 @@
 id: BUG-0004
 title: Legacy AES-CBC credential blobs may decrypt to silent garbage
 type: bug
-status: specced
+status: done
 priority: P1
 milestone: M0
 editions: [community, pro, private]
@@ -51,16 +51,54 @@ legacy blob, not a guess at the missing fallback's shape.
 
 ## Acceptance criteria
 
-- [ ] A fixture blob is produced at the legacy parameters and committed as test
+- [x] A fixture blob is produced at the legacy parameters and committed as test
       data
-- [ ] A test decrypts it and fails against the current implementation
-- [ ] The fix makes it pass, and AES-GCM blobs are unaffected
-- [ ] Garbage output is detectable rather than silently returned — decide and
+- [x] A test decrypts it and fails against the current implementation
+- [x] The fix makes it pass, and AES-GCM blobs are unaffected
+- [x] Garbage output is detectable rather than silently returned — decide and
       implement a plaintext sanity check for the CBC path
-- [ ] If the alternative is chosen instead, this item records the evidence that
-      no legacy blob remains, and both constants are removed
+- [ ] ~~If the alternative is chosen instead, this item records the evidence
+      that no legacy blob remains, and both constants are removed~~ — not
+      taken; the retry was restored instead
+
+## Resolution
+
+Restored the `LEGACY_ITERATIONS` retry that commit `560a15c7` dropped.
+`attemptDecrypt()` now takes an `iterations` parameter (default
+`STRONG_ITERATIONS`), and `decrypt()`'s `AES-CBC` branch loops through the
+same three PBKDF2 configurations the old CryptoJS implementation tried, in
+the same order: `{STRONG_ITERATIONS, SHA-256}` → `{STRONG_ITERATIONS,
+SHA-1}` → `{LEGACY_ITERATIONS, SHA-1}`, returning on the first one that
+succeeds.
+
+Also closed the silent-garbage gap named in the acceptance criteria:
+`attemptDecrypt()` decodes the decrypted buffer with `new
+TextDecoder("utf-8", { fatal: true })` and rethrows as an `OperationError`
+on failure. AES-CBC's PKCS7 padding check alone lets roughly 1 in 256 wrong
+keys through undetected; every plaintext this service ever produces is
+`TextEncoder`-encoded UTF-8, so a fatal decode catches that remainder
+without needing to know anything about the plaintext's shape (JSON vs. a
+raw string).
+
+Fixture: `src/services/__fixtures__/legacy-aes-cbc-blob.json`, a blob
+encrypted directly with `crypto.subtle` at `LEGACY_ITERATIONS` (10000) and
+SHA-1 — the oldest configuration the pre-rewrite fallback chain used, and
+the one most likely to still be silently mis-decrypted. Verified by
+`src/services/cryptoService.test.ts` ("legacy AES-CBC blobs (BUG-0004)"):
+one test decrypts the fixture and asserts the exact plaintext, one asserts
+a wrong password on the same blob throws rather than resolving, one
+round-trips an `AES-GCM` blob through the same password-based path to show
+it's unaffected, and one mocks `subtle.decrypt` to return non-UTF-8 bytes
+to exercise the sanity check directly, independent of AES padding luck.
+Confirmed the first two tests fail against the pre-fix code (`bad decrypt`
+and a silently-resolved `'����'` respectively) before
+applying the fix. `npm run check` and the full `cryptoService`/
+`backupService`/`settings.security` test files pass afterward.
 
 ## Links
 
 - [`docs/TODO.md`](../../TODO.md) item 12
-- `src/services/cryptoService.ts` — `attemptDecrypt()`
+- `src/services/cryptoService.ts` — `attemptDecrypt()`, `decrypt()`
+- `src/services/cryptoService.test.ts` — `describe("CryptoService — legacy
+  AES-CBC blobs (BUG-0004)")`
+- `src/services/__fixtures__/legacy-aes-cbc-blob.json`

--- a/src/services/__fixtures__/legacy-aes-cbc-blob.json
+++ b/src/services/__fixtures__/legacy-aes-cbc-blob.json
@@ -1,0 +1,11 @@
+{
+  "description": "Fixture for BUG-0004: a pre-Web-Crypto-rewrite AES-CBC credential blob, encrypted at the oldest legacy PBKDF2 parameters (LEGACY_ITERATIONS = 10000, SHA-1) that the original CryptoJS implementation's fallback chain used, per docs/TODO.md item 12. Generated once with crypto.subtle directly (see PR description), not with cryptoService.encrypt(), which has never produced AES-CBC.",
+  "password": "correct horse battery staple",
+  "plaintext": "{\"apiKey\":\"legacy-api-key-123\",\"apiSecret\":\"legacy-secret-456\"}",
+  "blob": {
+    "ciphertext": "d1JY5yDUWW/0SYggPVoflBXmGuYBqmeHdKs+DuUQpIL3Y3M3VlXMTabWdpF+ylFOpsWcfbFRF4109OPA/QGmfA==",
+    "iv": "1nzS9P6i4vulwt8wcdc+xw==",
+    "salt": "eVaInQKGSLHlS3Y6Bn2TDw==",
+    "method": "AES-CBC"
+  }
+}

--- a/src/services/cryptoService.test.ts
+++ b/src/services/cryptoService.test.ts
@@ -15,8 +15,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { cryptoService } from "./cryptoService";
+import legacyFixture from "./__fixtures__/legacy-aes-cbc-blob.json";
+
+vi.mock("$app/environment", () => ({
+  browser: true,
+}));
 
 // Mock Web Crypto API for tests
 beforeAll(() => {
@@ -87,3 +92,62 @@ describe("CryptoService", () => {
     await expect(cryptoService.decrypt(blob)).rejects.toThrow();
   });
 });
+
+// BUG-0004: legacy AES-CBC credential blobs (pre-Web-Crypto rewrite,
+// commit 560a15c7) were encrypted with PBKDF2 at LEGACY_ITERATIONS (10000)
+// and SHA-1, but attemptDecrypt() always derived at STRONG_ITERATIONS
+// (600000), which for AES-CBC — no authentication tag — can silently
+// return garbage instead of throwing. See docs/TODO.md item 12 and
+// docs/backlog/bugs/BUG-0004-legacy-aes-cbc-blobs.md.
+describe("CryptoService — legacy AES-CBC blobs (BUG-0004)", () => {
+  it("decrypts a pre-rewrite blob encrypted at LEGACY_ITERATIONS/SHA-1", async () => {
+    const decrypted = await cryptoService.decrypt(
+      legacyFixture.blob as EncryptedBlobFixture,
+      legacyFixture.password,
+    );
+    expect(decrypted).toBe(legacyFixture.plaintext);
+  });
+
+  it("rejects the legacy blob with the wrong password instead of returning garbage", async () => {
+    await expect(
+      cryptoService.decrypt(legacyFixture.blob as EncryptedBlobFixture, "not-the-password"),
+    ).rejects.toThrow();
+  });
+
+  it("still round-trips AES-GCM blobs through the same password path", async () => {
+    const original = "current-format-secret";
+    const password = "another-password";
+
+    const blob = await cryptoService.encrypt(original, password);
+    expect(blob.method).toBe("AES-GCM");
+
+    const decrypted = await cryptoService.decrypt(blob, password);
+    expect(decrypted).toBe(original);
+  });
+
+  it("treats a successfully-padded but non-UTF-8 plaintext as garbage, not a result", async () => {
+    // Simulates the case AES-CBC can't prevent on its own: PKCS7 padding
+    // happens to validate under the wrong key, but the recovered bytes
+    // aren't valid UTF-8. attemptDecrypt()'s fatal decode must catch this
+    // rather than returning it (with replacement characters) as if it were
+    // real plaintext.
+    const invalidUtf8 = new Uint8Array([0x80, 0x81, 0x82, 0x83]).buffer;
+    const decryptSpy = vi
+      .spyOn(window.crypto.subtle, "decrypt")
+      .mockResolvedValue(invalidUtf8);
+
+    await expect(
+      cryptoService.decrypt(legacyFixture.blob as EncryptedBlobFixture, legacyFixture.password),
+    ).rejects.toThrow();
+
+    decryptSpy.mockRestore();
+  });
+});
+
+interface EncryptedBlobFixture {
+  ciphertext: string;
+  iv: string;
+  salt: string;
+  method: "AES-GCM" | "AES-CBC";
+  kdfHash?: "SHA-512" | "SHA-256";
+}

--- a/src/services/cryptoService.ts
+++ b/src/services/cryptoService.ts
@@ -24,16 +24,14 @@ import { browser } from "$app/environment";
 
 
 const STRONG_ITERATIONS = 600000;
-// Not read by attemptDecrypt()'s AES-CBC branch, which always uses
-// STRONG_ITERATIONS — see docs/TODO.md item 12: the pre-Web-Crypto
-// implementation retried legacy blobs at this iteration count, and that
-// fallback was lost in the rewrite. Kept, not deleted, until a person
-// confirms no real blob still needs it.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// Iteration count used by the pre-Web-Crypto (CryptoJS) implementation for
+// its oldest AES-CBC blobs. attemptDecrypt()'s legacy fallback retries at
+// this count — see docs/TODO.md item 12 / BUG-0004.
 const LEGACY_ITERATIONS = 10000;
 const SALT_SIZE = 16;
 const IV_SIZE_GCM = 12; // GCM standard
-// See docs/TODO.md item 12, same reasoning as LEGACY_ITERATIONS above.
+// CBC IV size for reference only: legacy AES-CBC blobs always carry their
+// own IV in EncryptedBlob.iv, so this is never used to generate one.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const IV_SIZE_CBC = 16; // CBC standard
 const KEY_SIZE = 256;
@@ -217,7 +215,12 @@ class CryptoServiceImpl {
 
   // --- Decryption ---
 
-  private async attemptDecrypt(blob: EncryptedBlob, password?: string | CryptoKey, hashAlgo: "SHA-512" | "SHA-256" | "SHA-1" = "SHA-512"): Promise<string> {
+  private async attemptDecrypt(
+    blob: EncryptedBlob,
+    password?: string | CryptoKey,
+    hashAlgo: "SHA-512" | "SHA-256" | "SHA-1" = "SHA-512",
+    iterations: number = STRONG_ITERATIONS,
+  ): Promise<string> {
     try {
       const salt = base64ToBuffer(blob.salt);
       const iv = base64ToBuffer(blob.iv);
@@ -248,7 +251,7 @@ class CryptoServiceImpl {
           // Legacy or CBC. Import as CBC key.
           const passwordKey = await this.getPasswordKey(password);
           key = await window.crypto.subtle.deriveKey(
-            { name: "PBKDF2", salt: salt as unknown as BufferSource, iterations: STRONG_ITERATIONS, hash: hashAlgo },
+            { name: "PBKDF2", salt: salt as unknown as BufferSource, iterations, hash: hashAlgo },
             passwordKey,
             { name: "AES-CBC", length: KEY_SIZE },
             false,
@@ -269,7 +272,19 @@ class CryptoServiceImpl {
         ciphertext as unknown as BufferSource
       );
 
-      return new TextDecoder().decode(decryptedBuffer);
+      // AES-CBC has no authentication tag: a wrong key still produces a
+      // buffer whenever the (also key-dependent) PKCS7 padding happens to
+      // validate, silently returning garbage instead of throwing. A fatal
+      // UTF-8 decode catches that case, since every plaintext this service
+      // ever encrypts is TextEncoder-produced UTF-8.
+      try {
+        return new TextDecoder("utf-8", { fatal: true }).decode(decryptedBuffer);
+      } catch {
+        throw new DOMException(
+          "Decrypted plaintext is not valid UTF-8 (wrong key or corrupted blob)",
+          "OperationError"
+        );
+      }
 
     } catch (e) {
       // Fallback logic for legacy strings (not EncryptedBlob objects)? 
@@ -285,11 +300,29 @@ class CryptoServiceImpl {
       return await this.attemptDecrypt(blob, password, blob.kdfHash);
     }
 
-    // AES-CBC blobs are legacy and were never encrypted with SHA-512.
-    // AES-CBC lacks an authentication tag, so decrypting with the wrong key
-    // can silently return garbage instead of throwing. Skip the fallback.
+    // AES-CBC blobs predate the Web Crypto rewrite (commit 560a15c7). The
+    // old CryptoJS implementation tried three PBKDF2 configurations in
+    // order before giving up — restore that exact fallback order via
+    // crypto.subtle.deriveKey (docs/TODO.md item 12 / BUG-0004). AES-CBC
+    // lacks an authentication tag, so a wrong key can otherwise silently
+    // return garbage instead of throwing; attemptDecrypt()'s fatal UTF-8
+    // decode turns that into a thrown error so each attempt below either
+    // succeeds with real plaintext or fails and moves to the next.
     if (blob.method === "AES-CBC") {
-      return await this.attemptDecrypt(blob, password, "SHA-256");
+      const legacyAttempts: Array<{ iterations: number; hash: "SHA-256" | "SHA-1" }> = [
+        { iterations: STRONG_ITERATIONS, hash: "SHA-256" },
+        { iterations: STRONG_ITERATIONS, hash: "SHA-1" },
+        { iterations: LEGACY_ITERATIONS, hash: "SHA-1" }, // for blobs older still
+      ];
+      let lastError: unknown;
+      for (const { iterations, hash } of legacyAttempts) {
+        try {
+          return await this.attemptDecrypt(blob, password, hash, iterations);
+        } catch (e) {
+          lastError = e;
+        }
+      }
+      throw lastError;
     }
 
     // Legacy AES-GCM blobs without kdfHash were always encrypted with SHA-256.


### PR DESCRIPTION
## Summary

Fixes [BUG-0004](docs/backlog/bugs/BUG-0004-legacy-aes-cbc-blobs.md): pre-Web-Crypto-rewrite (`AES-CBC`) credential blobs could silently decrypt to garbage instead of failing.

- `attemptDecrypt()` always derived the key at `STRONG_ITERATIONS` (600000), dropping the `LEGACY_ITERATIONS` (10000) / `SHA-1` retry the old CryptoJS implementation used for its oldest blobs (lost in commit `560a15c7`).
- `decrypt()`'s `AES-CBC` branch now retries the exact three PBKDF2 configurations the legacy code tried, in order: `{STRONG_ITERATIONS, SHA-256}` → `{STRONG_ITERATIONS, SHA-1}` → `{LEGACY_ITERATIONS, SHA-1}`.
- Since AES-CBC has no authentication tag, a wrong key doesn't reliably throw on its own — `attemptDecrypt()` now decodes with a fatal UTF-8 `TextDecoder`, so a key that happens to pass PKCS7 padding but produces garbage still throws instead of silently resolving.

## Test plan

- [x] Added `src/services/__fixtures__/legacy-aes-cbc-blob.json` — a blob encrypted directly with `crypto.subtle` at `LEGACY_ITERATIONS`/SHA-1, the oldest configuration in the fallback chain.
- [x] Added tests in `src/services/cryptoService.test.ts` (`describe("CryptoService — legacy AES-CBC blobs (BUG-0004)")`):
  - decrypts the fixture and asserts the exact plaintext
  - a wrong password on the same blob throws rather than resolving
  - an `AES-GCM` round trip through the same password path is unaffected
  - a mocked `subtle.decrypt` returning non-UTF-8 bytes is rejected (sanity-check path, independent of AES padding luck)
- [x] Confirmed the first two tests fail against the pre-fix code (`bad decrypt`, and a silently-resolved `'����'`) before applying the fix, per `git stash`
- [x] `npm run check` — 0 errors
- [x] `npx eslint src/services/cryptoService.ts src/services/cryptoService.test.ts` — clean
- [x] `npx vitest run` — full suite, 1002 passed / 6 skipped, 0 failed

Data class A (credential decryption); no server code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDrT3861mCqgJ32bua9Zz2)_