### PR TITLE
docs: record device-key loss silently orphaning encrypted secrets as BUG-0053

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-52 items. How to read and add them: [README.md](README.md).
+53 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 24 · 🟢 ready 2 · ✅ done 15
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 15
 
 ---
 
@@ -16,6 +16,7 @@ Counts by status: 💡 idea 11 · 📋 specced 24 · 🟢 ready 2 · ✅ done 15
 | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | exchange |
 | [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | calculation |
+| [BUG-0053](bugs/BUG-0053-device-key-loss-orphans-secrets.md) | A lost or regenerated IndexedDB device key silently orphans every encrypted secret | P0 | 📋 specced | security |
 | [BUG-0003](bugs/BUG-0003-oms-preserve-latest-unenforced.md) | OMS force-prune can evict an order it was written to protect | P1 | 📋 specced | execution |
 | [BUG-0004](bugs/BUG-0004-legacy-aes-cbc-blobs.md) | Legacy AES-CBC credential blobs may decrypt to silent garbage | P1 | ✅ done | security |
 | [BUG-0042](bugs/BUG-0042-window-drag-jumps-on-touch.md) | Dragging a window on a touch device jumps and can leave the window stuck to the finger | P1 | ✅ done | ui |
@@ -125,6 +126,7 @@ Counts by status: 💡 idea 11 · 📋 specced 24 · 🟢 ready 2 · ✅ done 15
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | M0 | community, pro, private | none | none | — |
 | [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | M0 | community, pro, private | A | none | — |
+| [BUG-0053](bugs/BUG-0053-device-key-loss-orphans-secrets.md) | A lost or regenerated IndexedDB device key silently orphans every encrypted secret | P0 | 📋 specced | M0 | community, pro, private | A | none | — |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
@@ -178,4 +180,4 @@ Counts by status: 💡 idea 11 · 📋 specced 24 · 🟢 ready 2 · ✅ done 15
 
 ---
 
-Next free number: **0053**
+Next free number: **0054**

--- a/docs/backlog/bugs/BUG-0053-device-key-loss-orphans-secrets.md
+++ b/docs/backlog/bugs/BUG-0053-device-key-loss-orphans-secrets.md
@@ -1,0 +1,153 @@
+---
+id: BUG-0053
+title: A lost or regenerated IndexedDB device key silently orphans every encrypted secret
+type: bug
+status: specced
+priority: P0
+milestone: M0
+editions: [community, pro, private]
+area: security
+data_class: A
+adr: none
+depends_on: []
+---
+
+# BUG-0053 — A lost or regenerated IndexedDB device key silently orphans every encrypted secret
+
+## Symptom
+
+In "Obfuscation Mode" (no master password), every Class-A secret in
+`SENSITIVE_KEYS` — `openaiApiKey`, `geminiApiKey`, `anthropicApiKey`,
+`discordBotToken`, `newsApiKey`, `cryptoPanicApiKey`, `cmcApiKey`,
+`imgbbApiKey`, `appAccessToken`, `cloudToken` — fails to decrypt at once, each
+logging its own `[Settings] Failed to decrypt secret <key> OperationError` to
+the console. The user gets no in-app message: Settings silently shows the
+fields as empty, and every feature that depends on one of them breaks
+downstream with its own, unrelated-looking symptom — e.g. `/api/sentiment`
+answers 401 because `appAccessToken` decrypted to `""` and
+`appAuthHeaders()` (`src/lib/appAuth.ts`) correctly omits the header for an
+empty token.
+
+## Evidence
+
+**Demonstrated**, from a live browser console on `dev.cachy.app`:
+
+```
+Decryption failed OperationError
+    at J.attemptDecrypt ...
+[Settings] Failed to decrypt secret geminiApiKey OperationError
+Decryption failed OperationError
+[Settings] Failed to decrypt secret newsApiKey OperationError
+Decryption failed OperationError
+[Settings] Failed to decrypt secret cryptoPanicApiKey OperationError
+Decryption failed OperationError
+[Settings] Failed to decrypt secret cmcApiKey OperationError
+Decryption failed OperationError
+[Settings] Failed to decrypt secret imgbbApiKey OperationError
+POST https://dev.cachy.app/api/sentiment 401 (Unauthorized)
+```
+
+Every secret failed in the same page load — not one isolated key. That pattern
+points at the shared dependency all of them decrypt through: the device key.
+
+The mechanism is **derived**, from reading the two places involved, though the
+exact browser event that caused it this time (storage cleared, private window,
+storage eviction, a different profile) was not captured:
+
+- `settings.svelte.ts:1236-1266` — on every load in Obfuscation Mode, the app
+  fetches one device key via `getDeviceKey()` and decrypts *every*
+  `encryptedSecrets` entry with it, independently, inside a
+  `Promise.all`. A per-key failure is caught and only `console.error`'d
+  (`settings.svelte.ts:1259-1264`) — nothing aggregates "N of M secrets failed"
+  into a user-visible state.
+- `cryptoService.ts:318-352` (`getOrGenerateDeviceKey`) tries to load the
+  device key from IndexedDB (`loadKeyFromDB`, line 322) and, if that returns
+  nothing, **silently generates and persists a brand-new random key** — no
+  check for whether `encryptedSecrets` already has entries that only the *old*
+  key could open. IndexedDB and `localStorage` are cleared independently by
+  browsers (differing eviction/ITP policies, "clear site data" behaving
+  inconsistently across storage types, a private window ending). If IndexedDB
+  loses the device key while `localStorage`'s `encryptedSecrets` blob
+  survives, this path runs, mints an unrelated key, and every existing secret
+  becomes permanently unopenable with that key — matching the symptom exactly.
+
+This is the AES-GCM/device-key path, not the AES-CBC path BUG-0004 already
+fixed (`c3157101`) — that fix retried PBKDF2 parameters for legacy blobs and is
+unrelated to a device key going missing.
+
+## Cause
+
+`getOrGenerateDeviceKey()` cannot distinguish "first run, no secrets exist yet"
+from "the device key is gone but encrypted secrets are still sitting in
+`localStorage`." Both look identical from IndexedDB's point of view (empty),
+so both take the same "generate a fresh key" branch — the second case just
+silently strands existing data instead.
+
+## Fix
+
+Not decided yet; options to weigh:
+
+1. **Detect the mismatch before minting a new key.** Store a small canary
+   alongside `encryptedSecrets` (e.g. a fixed known plaintext encrypted with
+   the current device key) so `getOrGenerateDeviceKey()` — or the caller in
+   `settings.svelte.ts` — can tell "no key and no data" apart from "no key but
+   orphaned data" and react differently (e.g. refuse to silently regenerate;
+   surface a recovery prompt instead).
+2. **Make the failure user-visible.** Today the only signal is
+   `console.error`. At minimum, when one or more `SENSITIVE_KEYS` fail to
+   decrypt, Settings should show something a user can act on ("N saved keys
+   could not be read and need to be re-entered") instead of quietly leaving
+   fields blank.
+3. **Reduce how often this can happen.** Investigate whether the device key
+   can be made to survive independently of IndexedDB's eviction policy (e.g.
+   a secondary copy, a different storage API), while keeping ADR-0001's
+   local-only guarantee intact.
+
+Whichever is chosen, recovery for a user who already hit this is necessarily
+"re-enter the affected keys" — the plaintext is gone once the device key that
+encrypted it is gone. This item is about detection and a recoverable UX, not
+about recovering already-orphaned ciphertext.
+
+## Acceptance criteria
+
+- [ ] A test reproduces the defect: encrypt a secret under one device key,
+      then attempt decryption after `loadKeyFromDB` is made to return `null`
+      (simulating a lost IndexedDB key) with `encryptedSecrets` still present,
+      and show today's code either silently regenerates a key or fails with no
+      user-visible signal
+- [ ] The chosen fix makes that scenario either refuse to silently mint a
+      replacement key, or surface a clear, actionable message to the user (per
+      whichever option above is chosen) — not just a `console.error`
+- [ ] Existing decrypt/unlock tests for the normal (matching device key) path
+      are unaffected
+- [ ] `npm run check` and `npm test` are clean
+
+## Out of scope
+
+Recovering plaintext for secrets already orphaned by a device key that is
+gone — there is nothing left to recover it from, by design (ADR-0001, no
+server-side copy of Class-A data). This item is about detecting and
+communicating the failure going forward, not undoing past instances of it.
+
+Master-password mode's `unlock()` path (`settings.svelte.ts:989-1043`) has the
+same "per-key catch, only `console.error`" shape and would benefit from the
+same user-visible-failure fix (option 2 above), but the mismatch-detection
+question (option 1) doesn't apply there the same way, since a wrong password
+is a different failure class than a lost device key. Worth revisiting once
+this item's approach is chosen, not bundled into it.
+
+## Links
+
+- `src/services/cryptoService.ts:318-352` — `getOrGenerateDeviceKey()`,
+  `loadKeyFromDB()`
+- `src/stores/settings.svelte.ts:1236-1266` — the Obfuscation Mode decrypt
+  loop that surfaced this
+- `src/stores/settings.svelte.ts:989-1043` — the analogous master-password
+  `unlock()` path
+- `src/lib/appAuth.ts` — why a decrypted-empty `appAccessToken` produces a
+  clean 401 rather than a crash, downstream of this bug
+- [`BUG-0004`](BUG-0004-legacy-aes-cbc-blobs.md) — same subsystem
+  (`cryptoService.ts`), different mechanism (legacy AES-CBC iteration
+  fallback, already fixed)
+- [`docs/adr/0001-local-first-boundary.md`](../../adr/0001-local-first-boundary.md)
+  — why there is no server-side copy to fall back to


### PR DESCRIPTION
## Summary

Files a new backlog bug, [BUG-0053](docs/backlog/bugs/BUG-0053-device-key-loss-orphans-secrets.md), for an issue surfaced live on `dev.cachy.app` while testing BUG-0052 (self-issued client tokens, PR #1638, already merged): every Class-A secret (`geminiApiKey`, `newsApiKey`, `cryptoPanicApiKey`, `cmcApiKey`, `imgbbApiKey`, `appAccessToken`, ...) failed to decrypt at once with `OperationError`.

- **Demonstrated**: real browser console output showing every `SENSITIVE_KEYS` entry failing in the same page load.
- **Derived cause**: `getOrGenerateDeviceKey()` (`src/services/cryptoService.ts:318-352`) silently mints a brand-new IndexedDB device key whenever it can't find the existing one, with no check for whether `localStorage`'s `encryptedSecrets` still holds data only the *old* key could open. IndexedDB and `localStorage` can be cleared independently by the browser, orphaning every secret at once with only a `console.error` per key — no user-visible signal.
- Downstream, this explains an otherwise-confusing `401` on `/api/sentiment`: an orphaned `appAccessToken` decrypts to `""`, so `appAuthHeaders()` correctly omits the header and the new `checkClientToken` guard (BUG-0052) rejects the request — a symptom of this bug, not a regression from the token-auth change.
- Distinct from [BUG-0004](docs/backlog/bugs/BUG-0004-legacy-aes-cbc-blobs.md) (already fixed, PR #1648): that was a legacy AES-CBC iteration-count fallback; this is the current AES-GCM/device-key path.

No code changes — this PR only adds the backlog entry (`npm run backlog:index` / `--check` both pass) so the issue is tracked rather than lost in a chat transcript.

## Test plan

- [x] `npm run backlog:check` — front matter valid, index up to date

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzQaMAAswHCpfk8xkTMr3u)_