### PR TITLE
fix: token issuance rate limit locks out every visitor behind a reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,26 @@ APP_ACCESS_TOKEN=
 # Not read by application code — adapter-node reads it. See DEPLOYMENT.md.
 # ORIGIN=
 
+# Header adapter-node reads the real client IP from when this app sits behind
+# a reverse proxy (this app's own documented deployment shape — aaPanel's
+# nginx, see DEPLOYMENT.md). Without this, `event.getClientAddress()` returns
+# the proxy's own address for every request, so the per-IP rate limits in
+# src/lib/server/clientToken.ts and /api/auth/token (BUG-0052) bucket every
+# visitor together instead of separating them.
+#
+# ONLY set this if the app is not directly reachable from the internet on its
+# own PORT — otherwise a caller can forge this header and spoof any IP,
+# bypassing every per-IP rate limit outright.
+# Not read by application code — adapter-node reads it.
+# ADDRESS_HEADER=X-Forwarded-For
+
+# How many proxy hops to trust when reading ADDRESS_HEADER, counting from the
+# right of a comma-separated list. 1 for a single reverse proxy (aaPanel's
+# nginx sitting directly in front of this app) — set higher only if another
+# trusted proxy sits in front of that one.
+# Not read by application code — adapter-node reads it.
+# XFF_DEPTH=1
+
 # adapter-node honours further variables (HOST, BODY_SIZE_LIMIT,
 # SHUTDOWN_TIMEOUT, ...) that this app never reads itself. They are documented
 # upstream: https://svelte.dev/docs/kit/adapter-node#Environment-variables

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -341,11 +341,24 @@ APP_ACCESS_TOKEN=<openssl rand -hex 32>
 PORT=3001
 ORIGIN=https://cachy.app
 NODE_ENV=production
+ADDRESS_HEADER=X-Forwarded-For
+XFF_DEPTH=1
 ```
 
 > ⚠️ **`APP_ACCESS_TOKEN` is required, not optional.** Authentication fails closed: without it, all 17 guarded API routes answer 401 and the deployed app cannot reach its own backend. Set it on the server **before** deploying, and enter the same value in the running app under **Settings → Connections → App Access Token**. See [ADR-0002](docs/adr/0002-api-authentication-fails-closed.md).
 
 _Note: `ORIGIN` is important behind a reverse proxy — SvelteKit uses it to resolve `event.url` and to pass its cross-origin check on form submissions._
+
+> ⚠️ **`ADDRESS_HEADER`/`XFF_DEPTH` matter as soon as any per-IP rate limit is
+> in play** (`/api/auth/token`, `checkClientToken` — see
+> [ADR-0002's BUG-0052 amendment](docs/adr/0002-api-authentication-fails-closed.md)).
+> This deployment shape (aaPanel's nginx in front of the Node process) is a
+> reverse proxy, so without these set, `event.getClientAddress()` returns
+> nginx's own address for every request — every visitor shares one rate-limit
+> bucket instead of getting their own. Only set these because the Node process
+> here is *not* directly reachable from the internet on its own `PORT` —
+> otherwise a caller could forge the header and spoof any IP, bypassing every
+> per-IP limit.
 
 ---
 

--- a/docs/adr/0002-api-authentication-fails-closed.md
+++ b/docs/adr/0002-api-authentication-fails-closed.md
@@ -131,9 +131,12 @@ uniform gate blocked all of them for a reason that only applied to one route.
 per-client bearer tokens.
 
 - `POST /api/auth/token` is deliberately unguarded — it is how a client gets
-  its first token — and is itself rate-limited per IP (one issuance per IP
-  per hour for v1) so a script cannot mint unlimited tokens to route around
-  the per-token limits below.
+  its first token — and is itself rate-limited per IP (20 issuances per IP
+  per hour) so a script cannot mint unlimited tokens to route around the
+  per-token limits below. (Shipped at 1/hour initially; raised after
+  deployment showed every visitor behind a reverse proxy without
+  `ADDRESS_HEADER`/`XFF_DEPTH` configured shares one IP bucket — see
+  DEPLOYMENT.md and `.env.example`.)
 - The server stores only `{ tokenHash, createdAt, requestCount, lastSeenAt }`
   per issued token, hashed with SHA-256 — never the raw token, mirroring how
   `APP_ACCESS_TOKEN` was hashed before comparison.

--- a/src/routes/api/auth/token/+server.ts
+++ b/src/routes/api/auth/token/+server.ts
@@ -23,13 +23,20 @@ import { createRateLimiter } from "../../../../lib/server/rateLimit";
 /**
  * Deliberately unguarded (BUG-0052): this is where a client gets its first
  * token, so it cannot itself require one. The only protection is a per-IP
- * ceiling — the floor for v1 per the backlog item. A bot challenge (e.g.
- * Turnstile) here is a reasonable follow-up if IP limiting alone proves
- * insufficient, not required to ship.
+ * ceiling. A bot challenge (e.g. Turnstile) here is a reasonable follow-up if
+ * IP limiting alone proves insufficient, not required to ship.
+ *
+ * `getClientAddress()` behind a reverse proxy (this app's own documented
+ * deployment shape, see DEPLOYMENT.md) returns the proxy's own address unless
+ * `ADDRESS_HEADER`/`XFF_DEPTH` are set for adapter-node — see .env.example.
+ * Until that's configured, every visitor shares one bucket here, so this
+ * stays generous rather than the originally-shipped 1/hour, which locked out
+ * every visitor after the first token request on exactly that kind of
+ * deployment.
  */
 export const _issuanceLimiter = createRateLimiter({
   windowMs: 60 * 60 * 1000,
-  max: 1,
+  max: 20,
 });
 
 export const POST: RequestHandler = async ({ getClientAddress }) => {

--- a/src/routes/api/auth/token/token.test.ts
+++ b/src/routes/api/auth/token/token.test.ts
@@ -36,12 +36,14 @@ describe("POST /api/auth/token", () => {
     expect(body.token.length).toBeGreaterThan(20);
   });
 
-  it("rejects a second request from the same IP within the window", async () => {
-    const first = await POST(eventFromIp("2.2.2.2"));
-    expect(first.status).toBe(200);
+  it("rejects a request once its IP is over the issuance window's limit", async () => {
+    for (let i = 0; i < 20; i++) {
+      const response = await POST(eventFromIp("2.2.2.2"));
+      expect(response.status).toBe(200);
+    }
 
-    const second = await POST(eventFromIp("2.2.2.2"));
-    expect(second.status).toBe(429);
+    const overLimit = await POST(eventFromIp("2.2.2.2"));
+    expect(overLimit.status).toBe(429);
   });
 
   it("does not rate-limit a different IP", async () => {


### PR DESCRIPTION
## Summary

Fixes a live regression from BUG-0052 (#1638), reported as `Could not create a token` / `POST /api/auth/token 429` on `dev.cachy.app`.

- `/api/auth/token` shipped at 1 issuance per IP per hour. This app's own documented deployment shape (aaPanel's nginx in front of the Node process, `DEPLOYMENT.md`) is a reverse proxy — without `ADDRESS_HEADER`/`XFF_DEPTH` set for adapter-node, `getClientAddress()` returns nginx's own address for **every** request. Every visitor shares one bucket: the first token request after a restart consumes it, and everyone else gets 429 for the rest of the hour.
- Raises the limit to 20/hour per IP as a pragmatic floor (still bounds abuse; tolerates a shared-bucket deployment reasonably well).
- Documents `ADDRESS_HEADER=X-Forwarded-For` / `XFF_DEPTH=1` in `.env.example` and `DEPLOYMENT.md` as the actual fix for a correctly-proxied deployment, with the spoofing caveat: only set these when the Node process isn't directly internet-reachable on its own `PORT`, since a caller could otherwise forge the header and bypass every per-IP limit (this affects `/api/auth/token`'s limiter and `checkClientToken`'s per-IP tracking alike).
- Updates the ADR-0002/BUG-0052 amendment to record the corrected limit and why.

## Test plan

- [x] `npm run check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 178 files / 1003 tests passing
- [x] `token.test.ts` updated: asserts the new 20/hour ceiling instead of the old 1/hour

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzQaMAAswHCpfk8xkTMr3u)_