### PR TITLE
debug: log raw funding rate wire value for Bitunix price channel

### DIFF
--- a/src/services/bitunixWs.test.ts
+++ b/src/services/bitunixWs.test.ts
@@ -54,7 +54,8 @@ vi.mock('../../src/services/logger', () => ({
     logger: {
         warn: vi.fn(),
         error: vi.fn(),
-        log: vi.fn()
+        log: vi.fn(),
+        debug: vi.fn()
     }
 }));
 

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -152,6 +152,35 @@ class BitunixWebSocketService {
   private readonly VALIDATION_ERROR_WINDOW = 60000; // [HYBRID FIX] Increased window to 1m
   private lastNumericWarning = 0; // Throttle for numeric precision warnings
 
+  // BUG-INVESTIGATION (funding rate shows ~100x the value Bitunix's own UI shows):
+  // logs the raw, unmodified "fr" field exactly as received from the "price"
+  // channel, per symbol, throttled to avoid console spam. Compare the raw value
+  // against Bitunix's own UI at the same instant to confirm whether the wire
+  // value itself is already wrong, or only the display-side `.times(100)`
+  // conversion (MarketOverview.svelte, ai.svelte.ts) is misinterpreting it.
+  // Remove once the root cause is confirmed and fixed.
+  private lastFundingRateDebugLog = new Map<string, number>();
+  private readonly FUNDING_RATE_DEBUG_INTERVAL = 15000;
+  private debugLogRawFundingRate(symbol: string, rawFr: string): void {
+    if (!import.meta.env.DEV) return;
+    const now = Date.now();
+    const last = this.lastFundingRateDebugLog.get(symbol) ?? 0;
+    if (now - last < this.FUNDING_RATE_DEBUG_INTERVAL) return;
+    this.lastFundingRateDebugLog.set(symbol, now);
+
+    let asPercentIfFraction = "n/a";
+    try {
+      asPercentIfFraction = new Decimal(rawFr).times(100).toFixed(4) + "%";
+    } catch {
+      // ignore parse errors, still log raw value below
+    }
+
+    logger.debug(
+      "network",
+      `[FUNDING RATE RAW] ${symbol}: fr="${rawFr}" (as currently displayed: ${asPercentIfFraction})`,
+    );
+  }
+
   /**
    * Warns (throttled) when a field the exchange should send as a string
    * arrives as a number, then normalises it. Two call sites (price and ticker
@@ -901,6 +930,7 @@ class BitunixWebSocketService {
                     // HARDENING: Direct property access + Warning on Numeric Types
                     const ip = data.ip !== undefined ? this.safeString(data.ip, symbol, 'indexPrice') : undefined;
                     const fr = data.fr !== undefined ? this.safeString(data.fr, symbol, 'fundingRate') : undefined;
+                    if (fr !== undefined) this.debugLogRawFundingRate(symbol, fr);
                     const nft = data.nft ? String(data.nft) : undefined;
 
                     // Check precision loss on lastPrice if present (though we don't use it currently)

--- a/src/services/bitunixWs_leak.test.ts
+++ b/src/services/bitunixWs_leak.test.ts
@@ -24,7 +24,8 @@ vi.mock('./logger', () => ({
     logger: {
         log: vi.fn(),
         warn: vi.fn(),
-        error: vi.fn()
+        error: vi.fn(),
+        debug: vi.fn()
     }
 }));
 


### PR DESCRIPTION
## Summary

Investigation step for the funding-rate display bug: the Kacheln (favorited-symbol tiles, `MarketOverview.svelte`) show funding rates that are consistently ~76–100x larger than what Bitunix's own UI shows for the same symbol (e.g. SOL: Cachy `-1%` vs. Bitunix `0.0100%`).

Root-cause investigation so far:
- Ingestion (`bitunixWs.ts`) is a straight passthrough of the wire `fr` field into a `Decimal` — no scaling happens there.
- Display (`MarketOverview.svelte:718`, duplicated in `ai.svelte.ts:964-966`) does `.times(100)` to convert the stored value to a percentage, which matches Bitunix's own documented REST convention (`fundingRate: "0.0005"` = 0.05%).
- The ~100x mismatch could not be confirmed against Bitunix's live wire payload from this sandbox — outbound access to `fapi.bitunix.com` is blocked by the environment's egress policy.

This PR adds a throttled, DEV-only debug log (`logger.debug("network", ...)`) that prints the **raw, unmodified** `fr` value exactly as received from the `price` channel, per symbol, so the raw value can be compared directly against Bitunix's own UI at the same instant to pin down whether the wire value itself is already wrong, or only the `.times(100)` interpretation is off.

No behavior change for end users. Also completes two test `logger` mocks with `debug` (missing previously, which made the fast-path try/catch in `bitunixWs.ts` silently fall through to the slower fallback path whenever `logger.debug` was called during tests).

## How to use

1. Enable Netzwerk-Logs (Settings → System → `debugMode`, or `logSettings.network`).
2. Open the browser console, watch for `[FUNDING RATE RAW] <SYMBOL>: fr="..." (as currently displayed: ...%)`.
3. Compare the raw `fr` value against Bitunix's own displayed funding rate for the same symbol at the same moment.

## Test plan

- [x] `npm run check` (0 errors)
- [x] `npx vitest run src/services/bitunixWs.test.ts src/services/bitunixWs_leak.test.ts src/services/bitunixWs_force_reconnect.test.ts src/services/bitunixWs_fastpath.test.ts src/services/bitunixWs_hardening.test.ts src/services/bitunixWs.leak.test.ts` (28/28 passed)
- [ ] Manual: capture raw `fr` values in DEV console and compare against Bitunix UI to confirm the actual scaling bug, as follow-up

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUG2Amk5KECu216LqafeJ4)_