### PR TITLE
fix(windows): initial 854x480 resolution and 16:9 ratio for channel windows

### DIFF
--- a/src/lib/windows/WindowBase.svelte.ts
+++ b/src/lib/windows/WindowBase.svelte.ts
@@ -443,6 +443,9 @@ export abstract class WindowBase {
         this.minWidth = l.minWidth ?? 200;
         this.minHeight = l.minHeight ?? 150;
         this.aspectRatio = l.aspectRatio ?? null;
+        if (this.aspectRatio) {
+            this.updateSize(this.width, this.height);
+        }
 
         if (config.opacity !== undefined) this.opacity = config.opacity;
         if (config.defaultTitle && !this.title) this.title = config.defaultTitle;

--- a/src/lib/windows/WindowRegistry.svelte.ts
+++ b/src/lib/windows/WindowRegistry.svelte.ts
@@ -365,6 +365,8 @@ class WindowRegistry {
             },
             layout: {
                 ...baseLayout,
+                width: 854,
+                height: 480,
                 aspectRatio: 16 / 9
             }
         });

--- a/src/tests/unit/channel_window.test.ts
+++ b/src/tests/unit/channel_window.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ChannelWindow } from '../../lib/windows/implementations/ChannelWindow.svelte';
+import { windowRegistry } from '../../lib/windows/WindowRegistry.svelte';
+
+describe('ChannelWindow Initial Dimensions and Aspect Ratio', () => {
+  it('should register channel window type with 854x480 layout and 16:9 ratio', () => {
+    const config = windowRegistry.getConfig('channel');
+    expect(config.layout.width).toBe(854);
+    expect(config.layout.height).toBe(480);
+    expect(config.layout.aspectRatio).toBeCloseTo(16 / 9);
+  });
+
+  it('should instantiate ChannelWindow with 854 width and 16:9 content aspect ratio', () => {
+    const win = new ChannelWindow(
+      'https://space.cachy.app/index.php?plot_id=genesis',
+      'Cachy Space',
+      'genesis'
+    );
+
+    expect(win.width).toBe(854);
+    expect(win.aspectRatio).toBeCloseTo(16 / 9);
+    // Total window height includes 41px header -> 480 + 41 = 521px
+    // Content height (win.height - 41) is exactly 480px.
+    const contentHeight = win.height - 41;
+    expect(contentHeight).toBe(480);
+    expect(win.width / contentHeight).toBeCloseTo(16 / 9);
+  });
+});


### PR DESCRIPTION
## Summary
- Sets default dimensions for  window type to 854x480 (with 16:9 content aspect ratio) in .
- Enforces aspect ratio calculation on initial window creation in .
- Fixes issue where Market Overview tiles ('Open Channel') and Floating Iframe Button ('Toggle Genesis') opened with incorrect 1000x800 size prior to user resize.
- Added unit tests in .