### PR TITLE
fix: funding-rate debug log never fires from the Settings toggle

### DIFF
--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -162,7 +162,11 @@ class BitunixWebSocketService {
   private lastFundingRateDebugLog = new Map<string, number>();
   private readonly FUNDING_RATE_DEBUG_INTERVAL = 15000;
   private debugLogRawFundingRate(symbol: string, rawFr: string): void {
-    if (!import.meta.env.DEV) return;
+    // Gated on `enableNetworkLogs` (the "Netzwerk-Logs" toggle in Settings),
+    // matching every other network debug log in this file. `logger.debug()`
+    // checks a different, UI-disconnected flag (`logSettings.network`) and
+    // would silently never fire from the Settings toggle a user would reach for.
+    if (!settingsState.enableNetworkLogs) return;
     const now = Date.now();
     const last = this.lastFundingRateDebugLog.get(symbol) ?? 0;
     if (now - last < this.FUNDING_RATE_DEBUG_INTERVAL) return;
@@ -175,9 +179,11 @@ class BitunixWebSocketService {
       // ignore parse errors, still log raw value below
     }
 
-    logger.debug(
+    logger.log(
       "network",
       `[FUNDING RATE RAW] ${symbol}: fr="${rawFr}" (as currently displayed: ${asPercentIfFraction})`,
+      undefined,
+      true,
     );
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1654. The user reported that the raw funding-rate debug log added there never shows up in the console, even after enabling the "Netzwerk-Logs" toggle in Settings.

Root cause: `logger.debug()` gates on `settingsState.logSettings.network` (or `debugMode`), but the "Netzwerk-Logs" toggle in `SystemTab.svelte` writes to a **different**, unrelated flag: `settingsState.enableNetworkLogs`. Every other network debug log in `bitunixWs.ts` gates directly on `enableNetworkLogs` — the funding-rate raw-value log from #1654 missed that convention, so it was unreachable from the Settings UI a user would actually use.

## Fix

`debugLogRawFundingRate()` now gates on `settingsState.enableNetworkLogs` and logs via `logger.log("network", ..., undefined, true)` (force), matching the existing pattern used elsewhere in this file.

## Test plan

- [x] `npm run check` (0 errors)
- [x] `npx vitest run src/services/bitunixWs.test.ts src/services/bitunixWs_leak.test.ts src/services/bitunixWs_force_reconnect.test.ts src/services/bitunixWs_fastpath.test.ts src/services/bitunixWs_hardening.test.ts src/services/bitunixWs.leak.test.ts` (28/28 passed)
- [ ] Manual: enable "Netzwerk-Logs" in Settings → System, confirm `[FUNDING RATE RAW] ...` now appears in the browser console, and compare the raw value against Bitunix's own UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUG2Amk5KECu216LqafeJ4)_