### PR TITLE
fix: correct 100x-too-high funding rate from Bitunix price channel

### DIFF
--- a/src/services/bitunixWs.test.ts
+++ b/src/services/bitunixWs.test.ts
@@ -91,8 +91,10 @@ describe('BitunixWS Fast Path Fallback', () => {
         wsService.handleMessage(msg, 'public');
 
         // Price channel now updates Index Price and Funding Rate, NOT Last Price (to avoid flickering)
+        // Bitunix's price channel sends `fr` already as a percentage (0.01 = 0.01%),
+        // so it's normalized to a fraction (÷100) to match the app-wide fraction convention.
         expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', {
-            fundingRate: new Decimal('0.01'),
+            fundingRate: new Decimal('0.0001'),
             indexPrice: new Decimal('50001'),
             nextFundingTime: undefined
         });

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -152,13 +152,11 @@ class BitunixWebSocketService {
   private readonly VALIDATION_ERROR_WINDOW = 60000; // [HYBRID FIX] Increased window to 1m
   private lastNumericWarning = 0; // Throttle for numeric precision warnings
 
-  // BUG-INVESTIGATION (funding rate shows ~100x the value Bitunix's own UI shows):
-  // logs the raw, unmodified "fr" field exactly as received from the "price"
-  // channel, per symbol, throttled to avoid console spam. Compare the raw value
-  // against Bitunix's own UI at the same instant to confirm whether the wire
-  // value itself is already wrong, or only the display-side `.times(100)`
-  // conversion (MarketOverview.svelte, ai.svelte.ts) is misinterpreting it.
-  // Remove once the root cause is confirmed and fixed.
+  // Logs the raw, unmodified "fr" field exactly as received from the "price"
+  // channel, per symbol, throttled to avoid console spam. Confirmed the root
+  // cause of the ~100x-too-high funding rate display: Bitunix's price channel
+  // sends `fr` already as a percentage (e.g. "-0.01" = -0.01%), not as a
+  // fraction - see normalizeFundingRatePercent() below for the fix.
   private lastFundingRateDebugLog = new Map<string, number>();
   private readonly FUNDING_RATE_DEBUG_INTERVAL = 15000;
   private debugLogRawFundingRate(symbol: string, rawFr: string): void {
@@ -185,6 +183,22 @@ class BitunixWebSocketService {
       undefined,
       true,
     );
+  }
+
+  /**
+   * Bitunix's "price" channel sends `fr` already as a percentage (e.g. "-0.01"
+   * means -0.01%), unlike the fraction convention (0.0001 = 0.01%) used by
+   * Bitunix's own REST funding-rate endpoint and by every display site in this
+   * app (MarketOverview.svelte, ai.svelte.ts both do `.times(100)`). Convert to
+   * a fraction here, once, at ingestion, so the store stays in the fraction
+   * convention the rest of the app assumes.
+   */
+  private normalizeFundingRatePercent(rawFr: string): Decimal | undefined {
+    try {
+      return new Decimal(rawFr).dividedBy(100);
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -950,7 +964,7 @@ class BitunixWebSocketService {
                         // them and then reading `data.*` anyway.
                         marketState.updateSymbol(symbol, {
                           indexPrice: ip ? new Decimal(ip) : undefined,
-                          fundingRate: fr ? new Decimal(fr) : undefined,
+                          fundingRate: fr ? this.normalizeFundingRatePercent(fr) : undefined,
                           nextFundingTime: nft
                         });
                     }
@@ -1267,7 +1281,7 @@ class BitunixWebSocketService {
           marketState.updateSymbol(symbol, {
             // lastPrice: normalized.lastPrice, // [HYBRID FIX] Disabled
             indexPrice: d.ip ? String(d.ip) : undefined,
-            fundingRate: d.fr ? String(d.fr) : undefined,
+            fundingRate: d.fr !== undefined ? this.normalizeFundingRatePercent(String(d.fr)) : undefined,
             nextFundingTime: d.nft ? String(d.nft) : undefined
           });
         }


### PR DESCRIPTION
## Summary

Fixes the bug reported against the Market-Tiles (`MarketOverview.svelte`): favorited-symbol funding rates were consistently ~76–100x larger than Bitunix's own UI (e.g. SOL: `-1%` in Cachy vs. `0.0100%` on Bitunix).

Debug logging added in #1654/#1657 captured the raw wire values directly from Bitunix's WS `price` channel:

| Symbol | raw `fr` | Bitunix reference |
|---|---|---|
| SOLUSDT | `-0.01` | `0.0100%` |
| LINKUSDT | `0.01` | — |
| ETHUSDT | `0.002614` | `0.0030%` |
| BTCUSDT | `-0.005192` | `0.0068%` |

Reading `fr` **as an already-percent value** (`-0.01` → `-0.01%`) matches Bitunix's own reference almost exactly (remaining deltas are normal live drift of the predicted funding rate). So the root cause: Bitunix's `price`-channel `fr` field is a **percentage**, not a fraction — unlike Bitunix's own REST `get_funding_rate` endpoint (documented example `"0.0005"` = a fraction) and unlike every display site in this app, which all assume a fraction and do `.times(100)` (`MarketOverview.svelte:718`, `ai.svelte.ts:964-966`).

## Fix

Normalize `fr` to a fraction once, at ingestion in `bitunixWs.ts` (both the fast path and the slower fallback validation path), via a new `normalizeFundingRatePercent()` helper (`÷100`). The store now consistently holds funding rate as a fraction, so the existing `.times(100)` display logic (shared with the Bitget provider) stays correct and untouched.

## Test plan

- [x] `npm run check` (0 errors)
- [x] `npx vitest run src/services/bitunixWs.test.ts src/services/bitunixWs_leak.test.ts src/services/bitunixWs_force_reconnect.test.ts src/services/bitunixWs_fastpath.test.ts src/services/bitunixWs_hardening.test.ts src/services/bitunixWs.leak.test.ts` (28/28 passed)
- [x] Updated `bitunixWs.test.ts` fast-path assertion to the new normalized value
- [ ] Manual: confirm the Market Tiles now show funding rates matching Bitunix's own UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUG2Amk5KECu216LqafeJ4)_