### PR TITLE
fix(windows): open channel windows in top-left position with margin

### DIFF
--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -427,7 +427,7 @@
     XRP: true,
   };
 
-  function openChannel(e?: MouseEvent) {
+  function openChannel() {
     if (!symbol) return;
     const config = CHANNEL_CONFIG[baseAsset];
     if (!config) return;
@@ -787,7 +787,7 @@
                   : $_("marketOverview.tooltips.openChannel")}
                 onclick={(e) => {
                   e.stopPropagation();
-                  openChannel(e);
+                  openChannel();
                 }}>{@html icons.monitor}</button
               >
             {/if}

--- a/src/components/shared/MarketOverview.svelte
+++ b/src/components/shared/MarketOverview.svelte
@@ -446,7 +446,6 @@
           url,
           `${baseAsset} Channel`,
           windowId,
-          e ? { x: e.clientX, y: e.clientY } : {},
         ),
       );
     }

--- a/src/lib/windows/WindowBase.svelte.ts
+++ b/src/lib/windows/WindowBase.svelte.ts
@@ -254,17 +254,25 @@ export abstract class WindowBase {
         // Position Logic: Only apply staggering/cursor-vicinity if NO valid saved state exists.
         if (typeof window !== 'undefined' && !this.hasRestoredPosition) {
             if (options.x !== undefined && options.y !== undefined) {
-                // If opened via mouse click (e.g. from MarketOverview), position near cursor.
+                // If opened via mouse click, position near cursor.
                 // Clamping avoids windows spawning partially outside viewport.
                 this.x = Math.max(10, Math.min(window.innerWidth - this.width - 10, options.x - 20));
                 this.y = Math.max(10, Math.min(window.innerHeight - this.height - 10, options.y - 20));
             } else if (options.x === undefined && options.y === undefined) {
-                // Standard staggering for new windows
-                const stagger = this.centerByDefault ? 0 : (WindowBase.staggerCount % 10) * 40;
-                this.x = (window.innerWidth - this.width) / 2 + stagger;
-                this.y = (window.innerHeight - this.height) / 2 + stagger;
-
-                if (!this.centerByDefault) {
+                const configLayout = windowRegistry.getConfig(this.windowType).layout;
+                if (configLayout.x !== undefined && configLayout.y !== undefined) {
+                    const stagger = (WindowBase.staggerCount % 10) * 30;
+                    this.x = configLayout.x + stagger;
+                    this.y = configLayout.y + stagger;
+                    WindowBase.staggerCount++;
+                } else if (this.centerByDefault) {
+                    this.x = (window.innerWidth - this.width) / 2;
+                    this.y = (window.innerHeight - this.height) / 2;
+                } else {
+                    // Standard staggering for new windows
+                    const stagger = (WindowBase.staggerCount % 10) * 40;
+                    this.x = (window.innerWidth - this.width) / 2 + stagger;
+                    this.y = (window.innerHeight - this.height) / 2 + stagger;
                     WindowBase.staggerCount++;
                 }
             }
@@ -438,6 +446,8 @@ export abstract class WindowBase {
         this.doubleClickBehavior = f.doubleClickBehavior ?? 'maximize';
 
         const l = config.layout;
+        if (l.x !== undefined) this.x = l.x;
+        if (l.y !== undefined) this.y = l.y;
         this.width = l.width ?? 640;
         this.height = l.height ?? 480;
         this.minWidth = l.minWidth ?? 200;

--- a/src/lib/windows/WindowRegistry.svelte.ts
+++ b/src/lib/windows/WindowRegistry.svelte.ts
@@ -365,6 +365,8 @@ class WindowRegistry {
             },
             layout: {
                 ...baseLayout,
+                x: 20,
+                y: 60,
                 width: 854,
                 height: 480,
                 aspectRatio: 16 / 9

--- a/src/tests/unit/channel_window.test.ts
+++ b/src/tests/unit/channel_window.test.ts
@@ -20,20 +20,24 @@ import { ChannelWindow } from '../../lib/windows/implementations/ChannelWindow.s
 import { windowRegistry } from '../../lib/windows/WindowRegistry.svelte';
 
 describe('ChannelWindow Initial Dimensions and Aspect Ratio', () => {
-  it('should register channel window type with 854x480 layout and 16:9 ratio', () => {
+  it('should register channel window type with 854x480 layout, top-left position (20, 60), and 16:9 ratio', () => {
     const config = windowRegistry.getConfig('channel');
+    expect(config.layout.x).toBe(20);
+    expect(config.layout.y).toBe(60);
     expect(config.layout.width).toBe(854);
     expect(config.layout.height).toBe(480);
     expect(config.layout.aspectRatio).toBeCloseTo(16 / 9);
   });
 
-  it('should instantiate ChannelWindow with 854 width and 16:9 content aspect ratio', () => {
+  it('should instantiate ChannelWindow with 854 width, top-left position (20, 60), and 16:9 content aspect ratio', () => {
     const win = new ChannelWindow(
       'https://space.cachy.app/index.php?plot_id=genesis',
       'Cachy Space',
       'genesis'
     );
 
+    expect(win.x).toBe(20);
+    expect(win.y).toBe(60);
     expect(win.width).toBe(854);
     expect(win.aspectRatio).toBeCloseTo(16 / 9);
     // Total window height includes 41px header -> 480 + 41 = 521px


### PR DESCRIPTION
## Summary
- Sets initial default coordinates `x: 20` and `y: 60` for `channel` windows in `WindowRegistry.svelte.ts`.
- Updates `WindowBase.svelte.ts` to use `config.layout.x` and `config.layout.y` when explicit coordinates are omitted, with staggering for multiple windows.
- Removes mouse click coordinates from `MarketOverview.svelte` when opening channel windows so they default to top-left placement.
- Updates unit tests in `src/tests/unit/channel_window.test.ts`.