### PR TITLE
fix: source funding rate from Bitunix REST, not the undocumented WS field

### DIFF
--- a/docs/bitunix-api/QUICK_REFERENCE.md
+++ b/docs/bitunix-api/QUICK_REFERENCE.md
@@ -42,6 +42,12 @@ const sign = SHA256(digest + secretKey);
 | Get Pending  | GET    | `/api/v1/futures/trade/get_pending_orders` |
 | Order Detail | GET    | `/api/v1/futures/trade/get_order_detail`   |
 | Batch Order  | POST   | `/api/v1/futures/trade/batch_order`        |
+| Funding Rate (batch) | GET | `/api/v1/futures/market/funding_rate/batch` |
+| Funding Rate History | GET | `/api/v1/futures/market/get_funding_rate_history` |
+
+`fundingRate` in both REST responses is a **fraction** (`"0.0005"` = 0.05%) —
+do not confuse with the WS `price` channel's `fr` field, which is a
+**percentage** already (see `src/services/bitunixWs.ts`).
 
 ---
 

--- a/docs/bitunix-api/README.md
+++ b/docs/bitunix-api/README.md
@@ -2,7 +2,7 @@
 
 **Base URL:** `https://fapi.bitunix.com`  
 **Version:** Futures Trading API  
-**Last Updated:** 2026-01-21
+**Last Updated:** 2026-08-08
 
 ---
 
@@ -458,6 +458,112 @@ All responses follow this structure:
 
 ---
 
+## Market Data - Funding Rate
+
+Confirmed against the official docs (<https://www.bitunix.com/api-docs/futures/market/>) on 2026-08-08.
+These are REST endpoints — distinct from the WS `price` channel's `fr` field (see
+`src/services/bitunixWs.ts`), which is **not documented** on these pages and, per
+live-traffic investigation, is scaled differently (already a percentage, not a
+fraction — see `normalizeFundingRatePercent()` in that file).
+
+### Get Funding Rate Batch
+
+**GET** `/api/v1/futures/market/funding_rate/batch`
+
+**Description:** Get the current funding rate of the contract(s).
+
+**Rate Limit:** 10 req/sec/ip
+
+Note: despite the doc page being named `get_funding_rate_batch.html`, the actual
+HTTP path has no `get_` prefix and uses `funding_rate/batch`, not
+`funding_rate_batch` — verified from the page's own request example.
+
+#### Response
+
+```typescript
+{
+  code: 0,
+  data: [
+    {
+      symbol: string;          // "BTCUSDT"
+      markPrice: string;       // decimal as string
+      lastPrice: string;
+      indexPrice: string;
+      fundingRate: string;     // decimal AS A FRACTION, e.g. "0.0005" = 0.05%
+      fundingInterval: number; // settlement interval in HOURS (varies per symbol, not fixed at 8h)
+      nextFundingTime: string; // ms epoch
+      maxFundingRate: string;  // fraction, e.g. "0.3"
+      minFundingRate: string;  // fraction, e.g. "-0.3"
+    }
+  ],
+  msg: "Success"
+}
+```
+
+#### Response Example
+
+```json
+{
+  "code": 0,
+  "data": [
+    {
+      "symbol": "BTCUSDT",
+      "markPrice": "60000",
+      "lastPrice": "60001",
+      "indexPrice": "60001",
+      "fundingRate": "0.0005",
+      "fundingInterval": 8,
+      "nextFundingTime": "1770710400000",
+      "maxFundingRate": "0.3",
+      "minFundingRate": "-0.3"
+    }
+  ],
+  "msg": "Success"
+}
+```
+
+### Get Funding Rate History
+
+**GET** `/api/v1/futures/market/get_funding_rate_history`
+
+**Description:** Get the history funding rate of the contract.
+
+**Rate Limit:** 10 req/sec/ip
+
+#### Request Parameters
+
+| Parameter | Type   | Required | Description                                                  |
+| --------- | ------ | -------- | -------------------------------------------------------------- |
+| symbol    | string | true     | Trading pair, e.g. `BTCUSDT`                                    |
+| starTime  | int64  | false    | Start timestamp (funding settle time), ms epoch (sic, no `t`)  |
+| endTime   | int64  | false    | End timestamp (funding settle time), ms epoch                  |
+| limit     | int32  | false    | Default: 100, Maximum: 200                                      |
+
+#### Response
+
+```typescript
+{
+  code: 0,
+  data: [
+    {
+      markPrice: string;
+      fundingRate: string; // decimal AS A FRACTION, e.g. "-0.00001191"
+      fundingTime: string; // ms epoch
+    }
+  ],
+  msg: "Success"
+}
+```
+
+### Get Funding Rate (single symbol)
+
+**GET** `/api/v1/futures/market/get_funding_rate` (path unconfirmed — inferred from
+sidebar link, not yet verified against the actual doc page content; likely mirrors
+the batch endpoint's schema for a single symbol). **TODO:** confirm exact path and
+schema before relying on it.
+
+---
+
 ## WebSocket Support
 
 For real-time data, Bitunix provides WebSocket endpoints:
@@ -467,7 +573,8 @@ For real-time data, Bitunix provides WebSocket endpoints:
 ### Topics
 
 - **Private:** Orders, Positions, Balance (requires authentication)
-- **Public:** Tickers, Depth, Trades, Klines
+- **Public:** Tickers, Depth, Trades, Klines, MarketPrice (includes an
+  undocumented `fr` funding-rate field — see note above)
 
 ---
 

--- a/src/routes/api/funding-rate/+server.ts
+++ b/src/routes/api/funding-rate/+server.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { RequestHandler } from "@sveltejs/kit";
+import { json } from "@sveltejs/kit";
+import { cache } from "$lib/server/cache";
+import { safeJsonParse } from "../../../utils/safeJson";
+
+interface StatusError {
+  status: number;
+  message: string;
+}
+
+function isStatusError(error: unknown): error is StatusError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    "message" in error &&
+    typeof (error as { status: unknown }).status === "number" &&
+    typeof (error as { message: unknown }).message === "string"
+  );
+}
+
+// Bitunix's funding_rate/batch endpoint returns ALL trading pairs in one
+// response and takes no filter parameters (confirmed against the official
+// docs) - so this proxies it as-is, cached briefly server-side. A 30s TTL
+// is generous: funding rate only changes at settlement, hours apart.
+export const GET: RequestHandler = async ({ url, fetch }) => {
+  const provider = url.searchParams.get("provider") || "bitunix";
+
+  if (provider !== "bitunix") {
+    return json({ message: "Unsupported provider" }, { status: 400 });
+  }
+
+  const cacheKey = `funding-rate:${provider}`;
+
+  try {
+    const data = await cache.getOrFetch(
+      cacheKey,
+      async () => {
+        const apiUrl = "https://fapi.bitunix.com/api/v1/futures/market/funding_rate/batch";
+        const response = await fetch(apiUrl);
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw { status: response.status, message: errorText };
+        }
+
+        const text = await response.text();
+        return safeJsonParse(text);
+      },
+      30000,
+    );
+
+    return json(data);
+  } catch (error: unknown) {
+    if (isStatusError(error)) {
+      return new Response(error.message, {
+        status: error.status,
+      });
+    }
+
+    const message =
+      error instanceof Error ? error.message : "An unknown error occurred.";
+    return json(
+      { message: `Internal server error: ${message}` },
+      { status: 500 },
+    );
+  }
+};

--- a/src/routes/api/funding-rate/funding-rate.test.ts
+++ b/src/routes/api/funding-rate/funding-rate.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './+server';
+import { cache } from '$lib/server/cache';
+
+describe('GET /api/funding-rate', () => {
+  beforeEach(() => {
+    cache.clear();
+  });
+
+  it('proxies the Bitunix funding_rate/batch endpoint as-is', async () => {
+    const mockResponse = {
+      code: 0,
+      data: [
+        {
+          symbol: 'BTCUSDT',
+          markPrice: '60000',
+          lastPrice: '60001',
+          indexPrice: '60001',
+          fundingRate: '0.0005',
+          fundingInterval: 8,
+          nextFundingTime: '1770710400000',
+          maxFundingRate: '0.3',
+          minFundingRate: '-0.3',
+        },
+      ],
+      msg: 'Success',
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(mockResponse),
+    } as unknown as Response);
+
+    const url = new URL('http://localhost/api/funding-rate?provider=bitunix');
+    const response = await GET({
+      url,
+      fetch: mockFetch,
+    } as unknown as Parameters<typeof GET>[0]);
+    const json = await response.json();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://fapi.bitunix.com/api/v1/futures/market/funding_rate/batch',
+    );
+    expect(json).toEqual(mockResponse);
+  });
+
+  it('rejects unsupported providers without calling upstream', async () => {
+    const mockFetch = vi.fn();
+    const url = new URL('http://localhost/api/funding-rate?provider=bitget');
+    const response = await GET({
+      url,
+      fetch: mockFetch,
+    } as unknown as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns a 500 with the upstream error when the upstream request fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => 'Bad Gateway',
+    } as unknown as Response);
+
+    const url = new URL('http://localhost/api/funding-rate?provider=bitunix');
+    const response = await GET({
+      url,
+      fetch: mockFetch,
+    } as unknown as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -35,6 +35,7 @@ export class ApiStatusError extends Error {
 
 import {
   BitunixTickerResponseSchema,
+  BitunixFundingRateBatchResponseSchema,
   BitunixKlineSchema,
   BitgetKlineSchema,
   validateResponseSize,
@@ -52,6 +53,12 @@ export interface Ticker24h {
   lowPrice: Decimal;
   volume: Decimal; // Base volume usually
   quoteVolume?: Decimal;
+}
+
+export interface FundingRateEntry {
+  fundingRate: Decimal; // fraction, e.g. 0.0005 = 0.05%
+  nextFundingTime: number | string; // ms epoch
+  fundingInterval?: number | string; // settlement interval in hours, varies per symbol
 }
 
 // Raw Bitget kline shape when the endpoint returns objects instead of
@@ -956,6 +963,67 @@ export const apiService = {
         } catch (e: unknown) {
           logger.error("network", "fetchTicker24h error", e);
           if (e instanceof Error && e.name === "AbortError") throw e; // Pass through for RequestManager
+          if (
+            e instanceof Error &&
+            (e.message.startsWith("apiErrors.") ||
+              e.message.startsWith("bitunixErrors."))
+          ) {
+            throw e;
+          }
+          throw new Error("apiErrors.generic", { cause: e });
+        }
+      },
+      priority,
+      1,
+      timeout,
+    );
+  },
+
+  // Source of truth for funding rate: Bitunix's REST funding_rate/batch
+  // endpoint, documented and confirmed to return `fundingRate` as a fraction,
+  // labeled "Current funding rates" (the settlement-locked value). The WS
+  // `price` channel's `fr` field is undocumented, scaled differently, and
+  // not used for this anymore - see bitunixWs.ts.
+  async fetchBitunixFundingRates(
+    priority: "high" | "normal" = "normal",
+    timeout = 10000,
+  ): Promise<Map<string, FundingRateEntry>> {
+    const key = "FUNDING_RATE:bitunix:ALL";
+    return requestManager.schedule(
+      key,
+      async (signal) => {
+        try {
+          const response = await fetch(`/api/funding-rate?provider=bitunix`, {
+            signal,
+          });
+          if (!response.ok) throw new Error("apiErrors.generic");
+          const data = await apiService.safeJson(response);
+
+          const validation = BitunixFundingRateBatchResponseSchema.safeParse(data);
+          if (!validation.success) {
+            logger.error("network", "[API] Invalid funding rate response", validation.error.issues);
+            throw new Error("apiErrors.invalidResponse");
+          }
+          const validatedRes = validation.data;
+          if (validatedRes.code !== undefined && validatedRes.code !== 0) {
+            throw new Error(getBitunixErrorKey(validatedRes.code));
+          }
+          if (!validatedRes.data) {
+            throw new Error("apiErrors.invalidResponse");
+          }
+
+          const result = new Map<string, FundingRateEntry>();
+          for (const entry of validatedRes.data) {
+            const symbol = apiService.normalizeSymbol(entry.symbol, "bitunix");
+            result.set(symbol, {
+              fundingRate: entry.fundingRate,
+              nextFundingTime: entry.nextFundingTime,
+              fundingInterval: entry.fundingInterval,
+            });
+          }
+          return result;
+        } catch (e: unknown) {
+          if (e instanceof Error && e.name === "AbortError") throw e;
           if (
             e instanceof Error &&
             (e.message.startsWith("apiErrors.") ||

--- a/src/services/apiService_fundingRate.test.ts
+++ b/src/services/apiService_fundingRate.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Decimal } from "decimal.js";
+import { apiService, requestManager } from "./apiService";
+
+describe("apiService.fetchBitunixFundingRates", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    // fetchBitunixFundingRates uses a fixed request key ("FUNDING_RATE:bitunix:ALL")
+    // since the batch endpoint isn't per-symbol - clear requestManager's 10s
+    // success cache so each test hits the mocked fetch instead of a prior result.
+    requestManager.clearCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns fundingRate as a fraction (not scaled), keyed by normalized symbol", async () => {
+    const mockResponse = {
+      code: 0,
+      data: [
+        {
+          symbol: "BTCUSDT",
+          markPrice: "60000",
+          lastPrice: "60001",
+          indexPrice: "60001",
+          fundingRate: "0.0005",
+          fundingInterval: 8,
+          nextFundingTime: "1770710400000",
+          maxFundingRate: "0.3",
+          minFundingRate: "-0.3",
+        },
+      ],
+      msg: "Success",
+    };
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(mockResponse),
+      headers: new Headers({ "content-type": "application/json" }),
+    } as unknown as Response);
+
+    const result = await apiService.fetchBitunixFundingRates();
+
+    expect(result.get("BTCUSDT")).toEqual({
+      fundingRate: new Decimal("0.0005"),
+      nextFundingTime: "1770710400000",
+      fundingInterval: 8,
+    });
+  });
+
+  it("throws on a response missing the required fundingRate field", async () => {
+    const mockResponse = {
+      code: 0,
+      data: [{ symbol: "BTCUSDT", nextFundingTime: "1770710400000" }],
+      msg: "Success",
+    };
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(mockResponse),
+      headers: new Headers({ "content-type": "application/json" }),
+    } as unknown as Response);
+
+    await expect(apiService.fetchBitunixFundingRates()).rejects.toThrow();
+  });
+
+  it("throws when the HTTP request fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as unknown as Response);
+
+    await expect(apiService.fetchBitunixFundingRates()).rejects.toThrow();
+  });
+});

--- a/src/services/appEffects.svelte.ts
+++ b/src/services/appEffects.svelte.ts
@@ -4,6 +4,7 @@ import { settingsState, type Settings } from "../stores/settings.svelte";
 import { marketState } from "../stores/market.svelte";
 import { marketWatcher } from "./marketWatcher";
 import { connectionManager } from "./connectionManager";
+import { fundingRateService } from "./fundingRateService";
 import { normalizeSymbol } from "../utils/symbolUtils";
 import { Decimal } from "decimal.js";
 
@@ -102,6 +103,14 @@ export function setupRealtimeUpdatesEffect(app: any) {
           }
         }
       });
+    });
+
+    // 5. Funding Rate Polling (REST, Bitunix only - see fundingRateService)
+    $effect(() => {
+      const provider = settingsState.apiProvider;
+      if (provider !== "bitunix") return;
+      fundingRateService.start();
+      return () => fundingRateService.stop();
     });
   });
 }

--- a/src/services/bitunixWs.test.ts
+++ b/src/services/bitunixWs.test.ts
@@ -81,7 +81,7 @@ describe('BitunixWS Fast Path Fallback', () => {
         }
     });
 
-    it('should use Fast Path for valid price message (Price Channel updates Funding/Index)', () => {
+    it('should use Fast Path for valid price message (Price Channel updates Index Price)', () => {
         const msg = {
             ch: 'price',
             symbol: 'BTCUSDT',
@@ -90,13 +90,12 @@ describe('BitunixWS Fast Path Fallback', () => {
 
         wsService.handleMessage(msg, 'public');
 
-        // Price channel now updates Index Price and Funding Rate, NOT Last Price (to avoid flickering)
-        // Bitunix's price channel sends `fr` already as a percentage (0.01 = 0.01%),
-        // so it's normalized to a fraction (÷100) to match the app-wide fraction convention.
+        // Price channel updates Index Price, NOT Last Price (to avoid flickering).
+        // fundingRate is intentionally NOT set from `fr` here: it's undocumented
+        // and scaled differently from Bitunix's REST funding-rate endpoints, which
+        // are the sole source of truth for fundingRate (see fundingRateService.ts).
         expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', {
-            fundingRate: new Decimal('0.0001'),
             indexPrice: new Decimal('50001'),
-            nextFundingTime: undefined
         });
     });
 

--- a/src/services/bitunixWs.ts
+++ b/src/services/bitunixWs.ts
@@ -153,10 +153,11 @@ class BitunixWebSocketService {
   private lastNumericWarning = 0; // Throttle for numeric precision warnings
 
   // Logs the raw, unmodified "fr" field exactly as received from the "price"
-  // channel, per symbol, throttled to avoid console spam. Confirmed the root
-  // cause of the ~100x-too-high funding rate display: Bitunix's price channel
-  // sends `fr` already as a percentage (e.g. "-0.01" = -0.01%), not as a
-  // fraction - see normalizeFundingRatePercent() below for the fix.
+  // channel, per symbol, throttled to avoid console spam. This field is
+  // undocumented and scaled as a percentage, not the fraction convention
+  // Bitunix's REST funding-rate endpoints use - fundingRate is no longer
+  // sourced from it (see fundingRateService.ts). Kept for future diagnosis
+  // in case Bitunix's WS behavior needs re-investigating.
   private lastFundingRateDebugLog = new Map<string, number>();
   private readonly FUNDING_RATE_DEBUG_INTERVAL = 15000;
   private debugLogRawFundingRate(symbol: string, rawFr: string): void {
@@ -183,22 +184,6 @@ class BitunixWebSocketService {
       undefined,
       true,
     );
-  }
-
-  /**
-   * Bitunix's "price" channel sends `fr` already as a percentage (e.g. "-0.01"
-   * means -0.01%), unlike the fraction convention (0.0001 = 0.01%) used by
-   * Bitunix's own REST funding-rate endpoint and by every display site in this
-   * app (MarketOverview.svelte, ai.svelte.ts both do `.times(100)`). Convert to
-   * a fraction here, once, at ingestion, so the store stays in the fraction
-   * convention the rest of the app assumes.
-   */
-  private normalizeFundingRatePercent(rawFr: string): Decimal | undefined {
-    try {
-      return new Decimal(rawFr).dividedBy(100);
-    } catch {
-      return undefined;
-    }
   }
 
   /**
@@ -949,9 +934,13 @@ class BitunixWebSocketService {
                   try {
                     // HARDENING: Direct property access + Warning on Numeric Types
                     const ip = data.ip !== undefined ? this.safeString(data.ip, symbol, 'indexPrice') : undefined;
+                    // fundingRate/nextFundingTime are NOT read from this WS field anymore:
+                    // `fr` is undocumented and scaled differently from Bitunix's REST
+                    // funding_rate/batch endpoint, which is now the sole source of truth
+                    // for funding rate (see fundingRateService.ts). Kept as a debug log
+                    // only, in case Bitunix's WS behavior needs re-investigating later.
                     const fr = data.fr !== undefined ? this.safeString(data.fr, symbol, 'fundingRate') : undefined;
                     if (fr !== undefined) this.debugLogRawFundingRate(symbol, fr);
-                    const nft = data.nft ? String(data.nft) : undefined;
 
                     // Check precision loss on lastPrice if present (though we don't use it currently)
                     if (typeof data.lastPrice === 'number' || typeof data.lp === 'number') {
@@ -964,8 +953,6 @@ class BitunixWebSocketService {
                         // them and then reading `data.*` anyway.
                         marketState.updateSymbol(symbol, {
                           indexPrice: ip ? new Decimal(ip) : undefined,
-                          fundingRate: fr ? this.normalizeFundingRatePercent(fr) : undefined,
-                          nextFundingTime: nft
                         });
                     }
                     return;
@@ -1281,8 +1268,8 @@ class BitunixWebSocketService {
           marketState.updateSymbol(symbol, {
             // lastPrice: normalized.lastPrice, // [HYBRID FIX] Disabled
             indexPrice: d.ip ? String(d.ip) : undefined,
-            fundingRate: d.fr !== undefined ? this.normalizeFundingRatePercent(String(d.fr)) : undefined,
-            nextFundingTime: d.nft ? String(d.nft) : undefined
+            // fundingRate/nextFundingTime: see fast path above - sourced from
+            // REST (fundingRateService.ts), not this undocumented WS field.
           });
         }
       } else if (validatedChannel === "ticker") {

--- a/src/services/fundingRateService.test.ts
+++ b/src/services/fundingRateService.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+
+vi.mock('./apiService', () => ({
+  apiService: {
+    fetchBitunixFundingRates: vi.fn(),
+  },
+}));
+
+vi.mock('../stores/market.svelte', () => ({
+  marketState: {
+    data: {} as Record<string, unknown>,
+    updateSymbol: vi.fn(),
+  },
+}));
+
+import { apiService } from './apiService';
+import { marketState } from '../stores/market.svelte';
+import { fundingRateService } from './fundingRateService';
+
+describe('fundingRateService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (marketState.data as Record<string, unknown>) = {};
+    fundingRateService.stop();
+  });
+
+  afterEach(() => {
+    fundingRateService.stop();
+  });
+
+  it('only updates symbols already tracked in marketState (avoids LRU eviction from untracked symbols)', async () => {
+    (marketState.data as Record<string, unknown>) = { BTCUSDT: {} };
+    const rates = new Map([
+      ['BTCUSDT', { fundingRate: new Decimal('0.0005'), nextFundingTime: '1770710400000', fundingInterval: 8 }],
+      ['ETHUSDT', { fundingRate: new Decimal('0.0003'), nextFundingTime: '1770710400000', fundingInterval: 8 }],
+    ]);
+    vi.mocked(apiService.fetchBitunixFundingRates).mockResolvedValue(rates);
+
+    fundingRateService.start();
+    await vi.waitFor(() => {
+      expect(marketState.updateSymbol).toHaveBeenCalled();
+    });
+
+    expect(marketState.updateSymbol).toHaveBeenCalledTimes(1);
+    expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', {
+      fundingRate: new Decimal('0.0005'),
+      nextFundingTime: '1770710400000',
+      fundingInterval: 8,
+    });
+  });
+
+  it('does not throw when the fetch fails', async () => {
+    vi.mocked(apiService.fetchBitunixFundingRates).mockRejectedValue(new Error('network error'));
+
+    expect(() => fundingRateService.start()).not.toThrow();
+    await vi.waitFor(() => {
+      expect(apiService.fetchBitunixFundingRates).toHaveBeenCalled();
+    });
+    expect(marketState.updateSymbol).not.toHaveBeenCalled();
+  });
+
+  it('start() is idempotent (does not schedule a second interval)', () => {
+    vi.mocked(apiService.fetchBitunixFundingRates).mockResolvedValue(new Map());
+    fundingRateService.start();
+    const callsAfterFirstStart = vi.mocked(apiService.fetchBitunixFundingRates).mock.calls.length;
+    fundingRateService.start();
+    expect(vi.mocked(apiService.fetchBitunixFundingRates).mock.calls.length).toBe(callsAfterFirstStart);
+  });
+});

--- a/src/services/fundingRateService.ts
+++ b/src/services/fundingRateService.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { apiService } from "./apiService";
+import { marketState } from "../stores/market.svelte";
+import { logger } from "./logger";
+
+// Funding rate only changes at settlement (hours apart per fundingInterval),
+// so a slow poll is plenty fresh and stays far under Bitunix's 10 req/sec limit.
+const POLL_INTERVAL_MS = 60_000;
+
+class FundingRateService {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  start(): void {
+    if (this.intervalId) return;
+    void this.poll();
+    this.intervalId = setInterval(() => void this.poll(), POLL_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  private async poll(): Promise<void> {
+    try {
+      const rates = await apiService.fetchBitunixFundingRates();
+      for (const [symbol, entry] of rates) {
+        // Only refresh symbols already tracked (watched/favorited/traded).
+        // The batch endpoint returns every pair on the exchange - blindly
+        // calling updateSymbol for all of them would create hundreds of new
+        // cache entries and evict the actively-watched symbols from
+        // marketState's LRU cache.
+        if (!marketState.data[symbol]) continue;
+        marketState.updateSymbol(symbol, {
+          fundingRate: entry.fundingRate,
+          nextFundingTime: entry.nextFundingTime,
+          fundingInterval: entry.fundingInterval,
+        });
+      }
+    } catch (e) {
+      logger.warn("market", "[FundingRate] Poll failed", e);
+    }
+  }
+}
+
+export const fundingRateService = new FundingRateService();

--- a/src/stores/market.svelte.ts
+++ b/src/stores/market.svelte.ts
@@ -28,6 +28,7 @@ export interface MarketData {
   indexPrice: Decimal | null;
   fundingRate: Decimal | null;
   nextFundingTime: number | null; // Unix timestamp in ms
+  fundingInterval?: number | null; // Settlement interval in hours (varies per symbol)
   depth?: {
     bids: [string, string][]; // [price, qty]
     asks: [string, string][];
@@ -406,6 +407,11 @@ export class MarketManager {
       if (partial.fundingRate !== undefined) {
           const newVal = toDecimal(partial.fundingRate, current.fundingRate);
           if (newVal !== undefined) current.fundingRate = newVal;
+      }
+      if (partial.fundingInterval !== undefined) {
+          const raw = partial.fundingInterval;
+          const n = raw === null ? null : Number(raw);
+          if (n === null || !isNaN(n)) current.fundingInterval = n;
       }
 
       if (partial.nextFundingTime !== undefined && partial.nextFundingTime !== null) {

--- a/src/stores/marketStore.test.ts
+++ b/src/stores/marketStore.test.ts
@@ -68,6 +68,28 @@ describe("marketStore", () => {
     expect(data.priceChangePercent?.toNumber()).toBe(4);
   });
 
+  describe("updateSymbol - funding rate", () => {
+    it("stores fundingRate, nextFundingTime, and fundingInterval as given (REST is the source of truth)", async () => {
+      marketState.updateSymbol("BTCUSDT", {
+        fundingRate: "0.0005",
+        nextFundingTime: "1770710400000",
+        fundingInterval: 8,
+      });
+      await vi.advanceTimersByTimeAsync(300);
+
+      const data = marketState.data["BTCUSDT"];
+      expect(data.fundingRate?.toString()).toBe("0.0005");
+      expect(data.nextFundingTime).toBe(1770710400000);
+      expect(data.fundingInterval).toBe(8);
+    });
+
+    it("accepts a variable fundingInterval per symbol (not fixed at 8h)", async () => {
+      marketState.updateSymbol("XRPUSDT", { fundingInterval: 6 });
+      await vi.advanceTimersByTimeAsync(300);
+      expect(marketState.data["XRPUSDT"].fundingInterval).toBe(6);
+    });
+  });
+
   describe("Kline Protection (Single Source of Truth)", () => {
     it("should prioritize WS updates over REST for the live candle", async () => {
       const symbol = "BTCUSDT";

--- a/src/types/apiSchemas.ts
+++ b/src/types/apiSchemas.ts
@@ -38,6 +38,28 @@ export const BitunixTickerResponseSchema = z.object({
   data: z.array(BitunixTickerSchema).optional(),
 });
 
+// Bitunix Funding Rate Schema (REST market/funding_rate/batch,
+// market/get_funding_rate_history). fundingRate here is a FRACTION
+// (e.g. "0.0005" = 0.05%) - unlike the WS `price` channel's `fr` field,
+// which is already a percentage. See bitunixWs.ts for that distinction.
+export const BitunixFundingRateSchema = z.object({
+  symbol: z.string(),
+  markPrice: StrictDecimal.nullable().optional(),
+  lastPrice: StrictDecimal.nullable().optional(),
+  indexPrice: StrictDecimal.nullable().optional(),
+  fundingRate: StrictDecimal,
+  nextFundingTime: z.union([z.number(), z.string()]),
+  fundingInterval: z.union([z.number(), z.string()]).optional(),
+  maxFundingRate: StrictDecimal.nullable().optional(),
+  minFundingRate: StrictDecimal.nullable().optional(),
+});
+
+export const BitunixFundingRateBatchResponseSchema = z.object({
+  code: z.union([z.number(), z.string()]),
+  msg: z.string().optional(),
+  data: z.array(BitunixFundingRateSchema).optional(),
+});
+
 // Bitunix Kline Schema
 export const BitunixKlineSchema = z.object({
   open: StrictDecimal,


### PR DESCRIPTION
## Summary

Follow-up to #1658. After the percent-vs-fraction fix there, funding rate values in Cachy still diverged from Bitunix's own UI by uneven, non-uniform amounts per symbol (e.g. BTC `-0.0052%` vs `-0.0066%`, ETH `0.0026%` vs `0.0033%`) — not a clean scaling factor, so a different bug.

**Root cause:** Cachy sourced funding rate exclusively from the WebSocket `price` channel's `fr` field, which is **not documented anywhere** in Bitunix's official API docs. Verified against the docs the user provided (`www.bitunix.com/api-docs/futures/market/get_funding_rate*.html`, added to `docs/bitunix-api/README.md` in #1660's earlier commit): the REST `funding_rate/batch` endpoint returns `fundingRate` as a **fraction**, explicitly labeled **"Current funding rates"** — the settlement-locked value matching the fixed countdown users see (settlement interval varies per symbol, not fixed at 8h — also confirmed, via the endpoint's own `fundingInterval` field).

## Fix

Switch funding rate to the documented REST source, dropping the WS field entirely for this purpose:

- New `GET /api/funding-rate` proxy route (mirrors the existing `/api/tickers` pattern), server-cached 30s.
- `apiService.fetchBitunixFundingRates()` — new Zod-validated REST call, returns `fundingRate`/`nextFundingTime`/`fundingInterval` per symbol.
- New `fundingRateService` polls it every 60s (well under the 10 req/sec limit), wired up in `appEffects.svelte.ts`. **Only updates symbols already tracked in `marketState`** — the batch endpoint returns every pair on the exchange, and blindly updating all of them would create hundreds of cache entries and evict the actively-watched symbols from `marketState`'s small LRU cache.
- `market.svelte.ts` gains a `fundingInterval` field (hours, per-symbol).
- `bitunixWs.ts` no longer writes `fundingRate`/`nextFundingTime` from the WS `fr`/`nft` fields. The raw-value debug log stays (gated behind the "Netzwerk-Logs" setting) for future diagnosis.

## Test plan

- [x] `npm run check` (0 errors)
- [x] `npm test` — full suite, 1016 passed / 6 skipped (unrelated), no regressions
- [x] New tests: `fundingRateService.test.ts` (incl. the LRU-eviction-avoidance guard), `apiService_fundingRate.test.ts`, `routes/api/funding-rate/funding-rate.test.ts`, plus updated `bitunixWs.test.ts` and `marketStore.test.ts`
- [ ] Manual: confirm Market Tiles now match Bitunix's own displayed funding rate