### PR TITLE
fix(ui): enable Bitunix market activities sidebar visibility & update Pro cheatcode

### DIFF
--- a/src/components/settings/tabs/TradingTab.svelte
+++ b/src/components/settings/tabs/TradingTab.svelte
@@ -401,6 +401,21 @@
                     <label class="toggle-card mb-4">
                         <div class="flex flex-col">
                             <span class="text-sm font-medium"
+                                >{$_("dashboard.marketActivity")}</span
+                            >
+                            <span
+                                class="text-[10px] text-[var(--text-secondary)]"
+                                >{$_("settings.showSidebarActivity")}</span
+                            >
+                        </div>
+                        <Toggle
+                            bind:checked={settingsState.showSidebarActivity}
+                        />
+                    </label>
+
+                    <label class="toggle-card mb-4">
+                        <div class="flex flex-col">
+                            <span class="text-sm font-medium"
                                 >{$_("settings.showTechnicals")}</span
                             >
                             <span

--- a/src/components/shared/LeftControlPanel.svelte
+++ b/src/components/shared/LeftControlPanel.svelte
@@ -40,6 +40,7 @@
     academy: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path d="M12 14l9-5-9-5-9 5 9 5z" /><path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222" /></svg>`,
     chartPatterns: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 3v18h18" /></svg>`,
     assistant: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" /></svg>`,
+    activity: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>`,
   };
 </script>
 
@@ -168,6 +169,17 @@
     title="Toggle Market Tiles"
   >
     {@html ICONS.overview}
+  </button>
+
+  <!-- Market Activities Toggle -->
+  <button
+    class="control-btn"
+    class:active={settingsState.showSidebarActivity}
+    onclick={() =>
+      (settingsState.showSidebarActivity = !settingsState.showSidebarActivity)}
+    title={$_("dashboard.marketActivity") || "Toggle Market Activity"}
+  >
+    {@html ICONS.activity}
   </button>
 
   <!-- Sentiment Toggle -->

--- a/src/components/shared/PowerToggle.svelte
+++ b/src/components/shared/PowerToggle.svelte
@@ -23,8 +23,8 @@
 
     // SHA-256 Hash of the cheat code (not stored in plaintext)
     const CHEAT_CODE_HASH =
-        "6c7de706af22343c9919ce5addec8b8341cfbcf82e5854f30fa98a3990bbc556";
-    const CHEAT_CODE_LENGTH = 9;
+        "ee49857c95936c560e923fb24e0af4b65814fa8937cd0437a7b3a0b3893e6daf";
+    const CHEAT_CODE_LENGTH = 5;
 
     let typedBuffer = $state("");
 

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -127,7 +127,7 @@ export const app = {
 
       // Settings for visibility
       settingsState.showMarketActivity = true; // Show details in tiles
-      settingsState.showSidebarActivity = false; // Hide sidebar
+      settingsState.showSidebarActivity = true; // Show sidebar activity (Positions & Orders)
       settingsState.showMarketSentiment = true;
       settingsState.showMarketSentiment = true;
       settingsState.enableNewsAnalysis = true;

--- a/src/stores/settings.svelte.ts
+++ b/src/stores/settings.svelte.ts
@@ -402,7 +402,7 @@ const defaultSettings: Settings = {
   showMarketOverview: true,
   showMarketActivity: true,
   showMarketSentiment: true,
-  showSidebarActivity: false,
+  showSidebarActivity: true,
   showTechnicalsSummary: true,
   showTechnicalsConfluence: true,
   showTechnicalsVolatility: true,
@@ -655,7 +655,18 @@ export class SettingsManager {
   analysisTimeframes = $state<string[]>(defaultSettings.analysisTimeframes);
   showSidebarActivity = $state<boolean>(defaultSettings.showSidebarActivity);
   get effectiveShowSidebarActivity() {
-    return this.isPro && this.showSidebarActivity;
+    const hasBitgetKeys = Boolean(
+      this.apiKeys?.bitget?.key &&
+      this.apiKeys?.bitget?.secret &&
+      this.apiKeys?.bitget?.passphrase,
+    );
+    const hasBitunixKeys = Boolean(
+      this.apiKeys?.bitunix?.key && this.apiKeys?.bitunix?.secret,
+    );
+    const hasApiKeys =
+      this.apiProvider === "bitget" ? hasBitgetKeys : hasBitunixKeys;
+
+    return (this.isPro || hasApiKeys) && this.showSidebarActivity;
   }
 
   get capabilities() {


### PR DESCRIPTION
## Summary
Fixes an issue where entering Bitunix API keys allowed fetching the balance in calculator inputs, but left the **Market Activities** window (`PositionsSidebar.svelte`, showing positions, orders, TP/SL, and history) hidden. Also updates the Pro unlock cheatcode to `TEICH`.

## Changes Made
- **`src/stores/settings.svelte.ts`**: Update `effectiveShowSidebarActivity` getter to check `(this.isPro || hasApiKeys) && this.showSidebarActivity`, allowing Bitunix/Bitget API key holders to view live market activity sidebar without needing manual `isPro` toggle. Set default `showSidebarActivity` to `true`.
- **`src/services/app.ts`**: Set `showSidebarActivity = true` in `setupFirstStart`.
- **`src/components/shared/LeftControlPanel.svelte`**: Added a quick toggle button for Market Activities (`PositionsSidebar`) in the left side control bar.
- **`src/components/settings/tabs/TradingTab.svelte`**: Added a setting toggle card for Market Activities under Chart & Data.
- **`src/components/shared/PowerToggle.svelte`**: Renewed cheatcode hash and length for `TEICH`.

## Verification
- Verified `svelte-check` (0 errors, 0 warnings).
- Verified `vitest` unit tests (1004 passed).