### PR TITLE
fix: funding rate row disappearing on load; add REST raw-value debug log

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -999,6 +999,22 @@ export const apiService = {
           if (!response.ok) throw new Error("apiErrors.generic");
           const data = await apiService.safeJson(response);
 
+          // BUG-INVESTIGATION: user-reported ~100x-too-high funding rate
+          // persisting after the REST migration (#1660) for at least one
+          // symbol, despite Bitunix's REST docs confirming a fraction
+          // convention. Logs the RAW, pre-validation fundingRate string per
+          // symbol so a mismatch between what Bitunix's REST API actually
+          // returns and what its own UI shows can be confirmed directly,
+          // the same way the WS `fr` scaling bug was confirmed in #1658.
+          if (settingsState.enableNetworkLogs && data && typeof data === "object" && Array.isArray((data as { data?: unknown }).data)) {
+            for (const raw of (data as { data: unknown[] }).data) {
+              if (raw && typeof raw === "object") {
+                const r = raw as Record<string, unknown>;
+                logger.log("network", `[FUNDING RATE RAW REST] ${r.symbol}: fundingRate="${r.fundingRate}" fundingInterval=${r.fundingInterval}`, undefined, true);
+              }
+            }
+          }
+
           const validation = BitunixFundingRateBatchResponseSchema.safeParse(data);
           if (!validation.success) {
             logger.error("network", "[API] Invalid funding rate response", validation.error.issues);

--- a/src/services/appEffects.svelte.ts
+++ b/src/services/appEffects.svelte.ts
@@ -19,6 +19,7 @@ export function setupRealtimeUpdatesEffect(app: any) {
   let lastKeys = settingsState.apiKeys ? computeKeys(settingsState) : "";
   let currentWatchedSymbol: string | null = null;
   let symbolDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const knownFundingRateSymbols = new Set<string>();
 
   return $effect.root(() => {
     // 1. Settings / Connection Manager
@@ -111,6 +112,22 @@ export function setupRealtimeUpdatesEffect(app: any) {
       if (provider !== "bitunix") return;
       fundingRateService.start();
       return () => fundingRateService.stop();
+    });
+
+    // 6. Backfill funding rate immediately for symbols newly added to
+    // marketState (from fundingRateService's cache of the last REST poll).
+    // Without this, a symbol that starts being tracked between polls - e.g.
+    // right after page load, before the first poll's tracked-symbol set
+    // includes it - would show no funding rate for up to POLL_INTERVAL_MS.
+    $effect(() => {
+      const symbols = Object.keys(marketState.data);
+      untrack(() => {
+        for (const symbol of symbols) {
+          if (knownFundingRateSymbols.has(symbol)) continue;
+          knownFundingRateSymbols.add(symbol);
+          fundingRateService.applyCachedRateFor(symbol);
+        }
+      });
     });
   });
 }

--- a/src/services/fundingRateService.test.ts
+++ b/src/services/fundingRateService.test.ts
@@ -84,4 +84,52 @@ describe('fundingRateService', () => {
     fundingRateService.start();
     expect(vi.mocked(apiService.fetchBitunixFundingRates).mock.calls.length).toBe(callsAfterFirstStart);
   });
+
+  describe('applyCachedRateFor', () => {
+    it('backfills a symbol from the last poll immediately, without waiting for the next poll', async () => {
+      // Symbol not tracked yet when the poll happens (e.g. page just loaded,
+      // WS hasn't populated marketState for it yet) - reproduces the "row
+      // missing for up to 60s" bug.
+      const rates = new Map([
+        ['BTCUSDT', { fundingRate: new Decimal('0.0005'), nextFundingTime: '1770710400000', fundingInterval: 8 }],
+      ]);
+      vi.mocked(apiService.fetchBitunixFundingRates).mockResolvedValue(rates);
+
+      fundingRateService.start();
+      await vi.waitFor(() => {
+        expect(apiService.fetchBitunixFundingRates).toHaveBeenCalled();
+      });
+      expect(marketState.updateSymbol).not.toHaveBeenCalled(); // not tracked yet, poll skipped it
+
+      // Symbol now starts being tracked (e.g. WS delivers a price tick).
+      fundingRateService.applyCachedRateFor('BTCUSDT');
+
+      expect(marketState.updateSymbol).toHaveBeenCalledWith('BTCUSDT', {
+        fundingRate: new Decimal('0.0005'),
+        nextFundingTime: '1770710400000',
+        fundingInterval: 8,
+      });
+    });
+
+    it('does nothing for a symbol with no cached rate', () => {
+      fundingRateService.applyCachedRateFor('UNKNOWNUSDT');
+      expect(marketState.updateSymbol).not.toHaveBeenCalled();
+    });
+
+    it('clears the cache on stop(), so a stale rate is not applied after restart', async () => {
+      const rates = new Map([
+        ['BTCUSDT', { fundingRate: new Decimal('0.0005'), nextFundingTime: '1770710400000', fundingInterval: 8 }],
+      ]);
+      vi.mocked(apiService.fetchBitunixFundingRates).mockResolvedValue(rates);
+
+      fundingRateService.start();
+      await vi.waitFor(() => {
+        expect(apiService.fetchBitunixFundingRates).toHaveBeenCalled();
+      });
+      fundingRateService.stop();
+
+      fundingRateService.applyCachedRateFor('BTCUSDT');
+      expect(marketState.updateSymbol).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/fundingRateService.ts
+++ b/src/services/fundingRateService.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { apiService } from "./apiService";
+import { apiService, type FundingRateEntry } from "./apiService";
 import { marketState } from "../stores/market.svelte";
 import { logger } from "./logger";
 
@@ -25,6 +25,12 @@ const POLL_INTERVAL_MS = 60_000;
 
 class FundingRateService {
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  // Cache of the last successful batch fetch, keyed by symbol. Lets a symbol
+  // that starts being tracked *between* polls (e.g. right after page load,
+  // before the periodic poll has a tracked symbol to update) be backfilled
+  // immediately from already-fetched data instead of waiting up to
+  // POLL_INTERVAL_MS for the next scheduled poll - see applyCachedRateFor().
+  private lastRates: Map<string, FundingRateEntry> | null = null;
 
   start(): void {
     if (this.intervalId) return;
@@ -37,17 +43,36 @@ class FundingRateService {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }
+    this.lastRates = null;
+  }
+
+  /**
+   * Apply the last fetched funding rate for `symbol` right away, if known.
+   * Call this whenever a symbol starts being tracked in marketState (new
+   * favorite, trade symbol change, WS subscription) so it doesn't sit
+   * without a funding rate until the next scheduled poll.
+   */
+  applyCachedRateFor(symbol: string): void {
+    const entry = this.lastRates?.get(symbol);
+    if (!entry) return;
+    marketState.updateSymbol(symbol, {
+      fundingRate: entry.fundingRate,
+      nextFundingTime: entry.nextFundingTime,
+      fundingInterval: entry.fundingInterval,
+    });
   }
 
   private async poll(): Promise<void> {
     try {
       const rates = await apiService.fetchBitunixFundingRates();
+      this.lastRates = rates;
       for (const [symbol, entry] of rates) {
         // Only refresh symbols already tracked (watched/favorited/traded).
         // The batch endpoint returns every pair on the exchange - blindly
         // calling updateSymbol for all of them would create hundreds of new
         // cache entries and evict the actively-watched symbols from
-        // marketState's LRU cache.
+        // marketState's LRU cache. Symbols not yet tracked at this point
+        // are covered by applyCachedRateFor() once they start being tracked.
         if (!marketState.data[symbol]) continue;
         marketState.updateSymbol(symbol, {
           fundingRate: entry.fundingRate,


### PR DESCRIPTION
## Summary

Follow-up to #1660 (merged) after manual testing surfaced two issues:

### 1. Funding-rate row disappears for up to 60s after page load (fixed)

`fundingRateService` only updated symbols already present in `marketState.data` at poll time (to avoid polluting the LRU cache with the ~300 symbols the batch endpoint always returns). But a symbol that starts being tracked *between* polls — e.g. right after page load, before WS has populated `marketState.data` for it — was skipped by that poll and had no funding rate until the *next* scheduled poll, up to `POLL_INTERVAL_MS` (60s) later.

Fix: `fundingRateService` now caches the last successful batch fetch and exposes `applyCachedRateFor(symbol)`. A new effect in `appEffects.svelte.ts` calls it immediately whenever a new symbol key appears in `marketState.data`. This closes the gap to "as soon as either the symbol is tracked or the next REST response arrives, whichever is later" — typically sub-second instead of up to 60s.

### 2. A symbol still showing ~100x too high (investigating)

One symbol reportedly showed `0.6145%` in Cachy vs `0.0061%` on Bitunix's own UI after the REST migration — a ~100x mismatch again, despite the REST endpoint's documented fraction convention (verified in #1660) and no scaling step existing anywhere in the REST → Zod → store → `.times(100)` display pipeline.

Since guessing another scale fix already went wrong once in this chain (#1658 → #1660), this needs the same raw-wire verification that resolved the original bug: added a debug log of the **raw, pre-validation** `fundingRate` string per symbol from the REST batch response (gated behind the existing "Netzwerk-Logs" setting, prefix `[FUNDING RATE RAW REST]`). No numeric fix applied yet — pending confirmation of what Bitunix's REST API actually returns for the affected symbol.

## Test plan

- [x] `npm run check` (0 errors)
- [x] `npm test` — full suite, 1019 passed / 6 skipped (unrelated), no regressions
- [x] New tests for `applyCachedRateFor` (backfill-from-cache, no-cache no-op, cache cleared on `stop()`)
- [ ] Manual: confirm the row no longer disappears on reload
- [ ] Manual: capture `[FUNDING RATE RAW REST]` log output for the affected symbol to determine the root cause of issue 2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUG2Amk5KECu216LqafeJ4)_