### PR TITLE
fix: Market Activity - Bitunix TP/SL & Order-Cancel endpoints, client-token auto-recovery

### DIFF
--- a/src/lib/appAuth.test.ts
+++ b/src/lib/appAuth.test.ts
@@ -115,4 +115,78 @@ describe("appFetch", () => {
 
     readySpy.mockRestore();
   });
+
+  it("issues a token before the first request when none is configured yet", async () => {
+    settingsState.appAccessToken = "";
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === "/api/auth/token") {
+        return Promise.resolve(new Response(JSON.stringify({ token: "fresh-token" })));
+      }
+      return Promise.resolve(new Response("{}"));
+    }) as typeof fetch;
+
+    await appFetch("/api/balance", { method: "POST" });
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(1, "/api/auth/token", { method: "POST" });
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/balance",
+      expect.objectContaining({
+        headers: { "x-app-access-token": "fresh-token" },
+      }),
+    );
+    expect(settingsState.appAccessToken).toBe("fresh-token");
+  });
+
+  it("re-issues the token and retries once when the server no longer recognises it", async () => {
+    // Mirrors checkClientToken's in-memory store resetting on a server
+    // restart: the client still has a token, the server has forgotten it.
+    settingsState.appAccessToken = "stale-token";
+    let balanceCalls = 0;
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === "/api/auth/token") {
+        return Promise.resolve(new Response(JSON.stringify({ token: "fresh-token" })));
+      }
+      balanceCalls += 1;
+      if (balanceCalls === 1) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ error: "Unauthorized: Invalid or missing client access token" }),
+            { status: 401 },
+          ),
+        );
+      }
+      return Promise.resolve(new Response("{}"));
+    }) as typeof fetch;
+
+    const response = await appFetch("/api/balance", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    expect(balanceCalls).toBe(2);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/balance",
+      expect.objectContaining({ headers: { "x-app-access-token": "fresh-token" } }),
+    );
+    expect(settingsState.appAccessToken).toBe("fresh-token");
+  });
+
+  it("does not retry a 401 that is unrelated to the client token", async () => {
+    settingsState.appAccessToken = "secret-token";
+    let balanceCalls = 0;
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === "/api/auth/token") {
+        throw new Error("should not re-issue a token for this error");
+      }
+      balanceCalls += 1;
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: "Missing API Credentials" }), { status: 401 }),
+      );
+    }) as typeof fetch;
+
+    const response = await appFetch("/api/balance", { method: "POST" });
+
+    expect(response.status).toBe(401);
+    expect(balanceCalls).toBe(1);
+    expect(settingsState.appAccessToken).toBe("secret-token");
+  });
 });

--- a/src/lib/appAuth.ts
+++ b/src/lib/appAuth.ts
@@ -60,6 +60,54 @@ export function appAuthHeaders(
   return headers;
 }
 
+// In-flight issuance request, shared across concurrent callers so a burst of
+// guarded requests with no token yet (e.g. every onMount fetch firing at
+// once) triggers one POST /api/auth/token, not one per caller.
+let issuingToken: Promise<void> | null = null;
+
+/**
+ * Requests a fresh client token from the deliberately unguarded
+ * `POST /api/auth/token` and stores it, so a caller never needs to know this
+ * happened.
+ *
+ * `checkClientToken`'s token store is in-memory and resets on server restart
+ * (see the ADR-0002 amendment for BUG-0052) — "acceptable friction for v1 (a
+ * background fetch, not a user-facing flow)". This is that background fetch:
+ * without it, a client whose token the server no longer recognises is stuck
+ * showing "Unauthorized: Invalid or missing client access token" on every
+ * guarded route until someone finds the manual "Create access token" button
+ * in Settings → Connections.
+ */
+function issueAccessToken(): Promise<void> {
+  if (!issuingToken) {
+    issuingToken = (async () => {
+      try {
+        const res = await fetch("/api/auth/token", { method: "POST" });
+        if (res.ok) {
+          const data = await res.json();
+          if (data?.token) settingsState.appAccessToken = data.token;
+        }
+      } catch {
+        // Network error: leave appAccessToken as-is, the caller's request
+        // will fail on its own and can be retried later.
+      } finally {
+        issuingToken = null;
+      }
+    })();
+  }
+  return issuingToken;
+}
+
+function isClientTokenError(body: unknown): boolean {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "error" in body &&
+    typeof (body as { error: unknown }).error === "string" &&
+    (body as { error: string }).error.includes("client access token")
+  );
+}
+
 /**
  * `fetch` with the app access token attached.
  *
@@ -72,11 +120,34 @@ export function appAuthHeaders(
  * `onMount` — would otherwise read an empty token and take a 401 that a later,
  * hand-clicked retry of the same request does not. The headers are built after
  * the await, never before.
+ *
+ * Two self-healing steps around that: if there is no token yet, one is issued
+ * before the first attempt; if the request still comes back 401 for "invalid
+ * or missing client access token" (the server no longer recognises this
+ * token, e.g. it restarted), a fresh one is issued and the request is retried
+ * once. Neither step touches other 401s (a route-specific auth failure) or
+ * 429s (rate limiting, where retrying immediately would only make it worse).
  */
 export async function appFetch(
   input: string,
   init: RequestInit = {},
 ): Promise<Response> {
   await settingsState.secretsReady;
+  if (!settingsState.appAccessToken) {
+    await issueAccessToken();
+  }
+
+  const response = await fetch(input, { ...init, headers: appAuthHeaders(init.headers) });
+  if (response.status !== 401) return response;
+
+  let body: unknown;
+  try {
+    body = await response.clone().json();
+  } catch {
+    return response;
+  }
+  if (!isClientTokenError(body)) return response;
+
+  await issueAccessToken();
   return fetch(input, { ...init, headers: appAuthHeaders(init.headers) });
 }

--- a/src/lib/appAuth.ts
+++ b/src/lib/appAuth.ts
@@ -99,13 +99,12 @@ function issueAccessToken(): Promise<void> {
 }
 
 function isClientTokenError(body: unknown): boolean {
-  return (
-    typeof body === "object" &&
-    body !== null &&
-    "error" in body &&
-    typeof (body as { error: unknown }).error === "string" &&
-    (body as { error: string }).error.includes("client access token")
-  );
+  if (typeof body !== "object" || body === null || !("error" in body)) return false;
+  const error = (body as { error: unknown }).error;
+  if (typeof error !== "string") return false;
+  // i18n-ignore: matched against the server's own literal error string
+  // (clientToken.ts's `unauthorized()`), not rendered UI text.
+  return error.includes("client access token");
 }
 
 /**

--- a/src/routes/api/orders/+server.ts
+++ b/src/routes/api/orders/+server.ts
@@ -261,13 +261,13 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 
 async function cancelBitunixOrder(apiKey: string, apiSecret: string, symbol: string, orderId: string) {
     const baseUrl = "https://fapi.bitunix.com";
-    const path = "/api/v1/futures/trade/cancel_order";
+    const path = "/api/v1/futures/trade/cancel_orders";
 
-    const payload = { symbol, orderId };
+    const payload = { symbol, orderList: [{ orderId }] };
     const { nonce, timestamp, signature, bodyStr } = generateBitunixSignature(apiKey, apiSecret, {}, payload);
 
     const response = await fetch(`${baseUrl}${path}`, {
-        method: "DELETE", // Bitunix typically uses DELETE or POST for cancel. Assuming DELETE based on common REST standards.
+        method: "POST",
         headers: {
             "api-key": apiKey,
             "timestamp": timestamp,
@@ -288,6 +288,13 @@ async function cancelBitunixOrder(apiKey: string, apiSecret: string, symbol: str
     const text = await response.text();
     const res = safeJsonParse(text);
     if (String(res.code) !== "0") throw new Error(res.msg);
+
+    // cancel_orders reports per-order outcomes rather than failing the whole
+    // call — surface a rejected order (e.g. already filled) as an error
+    // instead of a silent success.
+    const failure = res.data?.failureList?.[0];
+    if (failure) throw new Error(failure.errorMsg || `Cancel failed: ${failure.errorCode}`);
+
     return res.data;
 }
 

--- a/src/routes/api/orders/orders_cancel_path.test.ts
+++ b/src/routes/api/orders/orders_cancel_path.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./+server";
+import * as clientToken from "../../../lib/server/clientToken";
+
+// Regression test: order cancellation used to call the singular, DELETE-only
+// /trade/cancel_order, which Bitunix does not expose (see
+// docs/bitunix-api/07_trade.md "Cancel Orders" — POST, plural, orderList).
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const getClientAddress = () => "127.0.0.1";
+
+function makeRequest(body: unknown): Request {
+  return {
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(clientToken, "checkClientToken").mockReturnValue(null);
+});
+
+describe("POST /api/orders cancel-order uses the real Bitunix endpoint", () => {
+  it("calls POST /api/v1/futures/trade/cancel_orders with an orderList", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({ code: 0, data: { successList: [{ orderId: "42" }], failureList: [] }, msg: "Success" }),
+    });
+
+    const response = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "cancel-order",
+        symbol: "BTCUSDT",
+        orderId: "42",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://fapi.bitunix.com/api/v1/futures/trade/cancel_orders");
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({
+      symbol: "BTCUSDT",
+      orderList: [{ orderId: "42" }],
+    });
+  });
+
+  it("surfaces a rejected order from failureList as an error", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          code: 0,
+          data: { successList: [], failureList: [{ orderId: "42", errorMsg: "Order status error", errorCode: 10013 }] },
+          msg: "Success",
+        }),
+    });
+
+    const response = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "cancel-order",
+        symbol: "BTCUSDT",
+        orderId: "42",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe("Order status error");
+  });
+});

--- a/src/routes/api/tpsl/+server.ts
+++ b/src/routes/api/tpsl/+server.ts
@@ -74,7 +74,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         result = await fetchBitunixTpSl(
           apiKey,
           apiSecret,
-          "/api/v1/futures/tp_sl/get_pending_tp_sl_order",
+          "/api/v1/futures/tpsl/get_pending_orders",
           params,
         );
         break;
@@ -82,7 +82,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         result = await fetchBitunixTpSl(
           apiKey,
           apiSecret,
-          "/api/v1/futures/tp_sl/get_history_tp_sl_order",
+          "/api/v1/futures/tpsl/get_history_orders",
           params,
         );
         break;
@@ -90,7 +90,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         result = await executeBitunixAction(
           apiKey,
           apiSecret,
-          "/api/v1/futures/tp_sl/cancel_tp_sl_order",
+          "/api/v1/futures/tpsl/cancel_order",
           params,
         );
         break;
@@ -98,7 +98,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         result = await executeBitunixAction(
           apiKey,
           apiSecret,
-          "/api/v1/futures/tp_sl/modify_tp_sl_order",
+          "/api/v1/futures/tpsl/modify_order",
           params,
         );
         break;

--- a/src/routes/api/tpsl/tpsl_paths.test.ts
+++ b/src/routes/api/tpsl/tpsl_paths.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./+server";
+import * as clientToken from "../../../lib/server/clientToken";
+
+// Regression test for the wrong Bitunix TP/SL paths (tp_sl/*_tp_sl_order
+// instead of tpsl/*_order(s)) that made every TP/SL request 404/error at
+// Bitunix regardless of the client-token or signature being correct. See
+// docs/bitunix-api/06_tp_sl.md for the endpoints these must match.
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const getClientAddress = () => "127.0.0.1";
+
+function makeRequest(body: unknown): Request {
+  return {
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+const creds = { apiKey: "validApiKey123", apiSecret: "validSecret123456" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(clientToken, "checkClientToken").mockReturnValue(null);
+  fetchMock.mockResolvedValue({
+    ok: true,
+    text: async () => JSON.stringify({ code: 0, data: [], msg: "Success" }),
+  });
+});
+
+describe("POST /api/tpsl uses the real Bitunix endpoints", () => {
+  it("pending -> GET /api/v1/futures/tpsl/get_pending_orders", async () => {
+    const response = await POST({
+      request: makeRequest({ exchange: "bitunix", action: "pending", params: {}, ...creds }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("https://fapi.bitunix.com/api/v1/futures/tpsl/get_pending_orders");
+  });
+
+  it("history -> GET /api/v1/futures/tpsl/get_history_orders", async () => {
+    const response = await POST({
+      request: makeRequest({ exchange: "bitunix", action: "history", params: {}, ...creds }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("https://fapi.bitunix.com/api/v1/futures/tpsl/get_history_orders");
+  });
+
+  it("cancel -> POST /api/v1/futures/tpsl/cancel_order", async () => {
+    const response = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        action: "cancel",
+        params: { orderId: "1", symbol: "BTCUSDT" },
+        ...creds,
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://fapi.bitunix.com/api/v1/futures/tpsl/cancel_order");
+    expect(options.method).toBe("POST");
+  });
+
+  it("modify -> POST /api/v1/futures/tpsl/modify_order", async () => {
+    const response = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        action: "modify",
+        params: { orderId: "1", symbol: "BTCUSDT", planType: "PROFIT", triggerPrice: "50000" },
+        ...creds,
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://fapi.bitunix.com/api/v1/futures/tpsl/modify_order");
+    expect(options.method).toBe("POST");
+  });
+});

--- a/src/services/aiModelsService.test.ts
+++ b/src/services/aiModelsService.test.ts
@@ -11,6 +11,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getModels } from "./aiModelsService";
 
+// appFetch auto-issues a client token when settingsState.appAccessToken is
+// empty (the real default). Pre-set one here so that background request
+// doesn't consume the fetch mocks these tests set up for the Ollama calls.
+vi.mock("../stores/settings.svelte", () => ({
+  settingsState: {
+    appAccessToken: "test-token",
+    secretsReady: Promise.resolve(),
+  },
+}));
+
 describe("aiModelsService", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/services/tradeService_flashClose.test.ts
+++ b/src/services/tradeService_flashClose.test.ts
@@ -38,7 +38,9 @@ vi.mock('../stores/settings.svelte', () => ({
     apiProvider: 'bitunix',
     apiKeys: {
       bitunix: { key: 'test', secret: 'test' }
-    }
+    },
+    appAccessToken: 'test-token',
+    secretsReady: Promise.resolve(),
   }
 }));
 

--- a/src/services/tradeService_hardening.test.ts
+++ b/src/services/tradeService_hardening.test.ts
@@ -38,7 +38,9 @@ vi.mock('../stores/settings.svelte', () => ({
     apiProvider: 'bitunix',
     apiKeys: {
       bitunix: { key: 'test', secret: 'test' }
-    }
+    },
+    appAccessToken: 'test-token',
+    secretsReady: Promise.resolve(),
   }
 }));
 

--- a/src/services/tradeService_serialization.test.ts
+++ b/src/services/tradeService_serialization.test.ts
@@ -26,7 +26,9 @@ vi.mock("../stores/settings.svelte", () => ({
         apiProvider: "bitunix",
         apiKeys: {
             bitunix: { key: "test", secret: "test" }
-        }
+        },
+        appAccessToken: "test-token",
+        secretsReady: Promise.resolve(),
     }
 }));
 


### PR DESCRIPTION
## Summary

Investigated the reported "Market Activity" window issues (Positions `Unauthorized`, Orders tab loader spinning, TP/SL always empty, `POST /api/tpsl 400`) against the now fully-imported Bitunix API docs (`docs/bitunix-api/`) and found two independent, verifiable bugs:

- **TP/SL requests used nonexistent Bitunix endpoints.** `src/routes/api/tpsl/+server.ts` called `/api/v1/futures/tp_sl/*_tp_sl_order`, but Bitunix's documented paths (`docs/bitunix-api/06_tp_sl.md`) are `/api/v1/futures/tpsl/*_order(s)`. This is why the TP/SL tab always reported "No pending TP/SL orders found" and why `/api/tpsl` answered 400.
- **Order cancellation used a nonexistent endpoint too.** `/api/v1/futures/trade/cancel_order` (singular, `DELETE`) doesn't exist; Bitunix documents `cancel_orders` (plural, `POST`, with an `orderList` array) in `docs/bitunix-api/07_trade.md`. Fixed and now surfaces a rejected order (e.g. already filled) from the response's `failureList` as an error instead of a silent success.
- **Client access token had no recovery path.** `checkClientToken`'s token store is in-memory and resets on server restart (documented in the ADR-0002 amendment for BUG-0052 as "acceptable friction ... a background fetch, not a user-facing flow") — but that background fetch was never implemented. Once the server forgets a client's token, every guarded route (Positions, Orders, TP/SL, ...) permanently answers `Unauthorized: Invalid or missing client access token` until the user manually re-creates one in Settings → Connections. This matches the reported Positions/Orders/TP-SL failures while History kept showing stale data fetched before the token went stale. `appFetch` now issues a token automatically if none is configured, and re-issues + retries once on a 401 specifically caused by an unrecognised client token (other 401s/429s are untouched).

## Changes

- `src/routes/api/tpsl/+server.ts`: corrected the four Bitunix TP/SL endpoint paths.
- `src/routes/api/orders/+server.ts`: corrected the cancel-order endpoint, method and payload shape; surfaces per-order cancel failures.
- `src/lib/appAuth.ts`: `appFetch` self-heals the client access token (issue-if-missing, re-issue-and-retry-once on token-invalid 401).
- Test coverage: new `tpsl_paths.test.ts`, `orders_cancel_path.test.ts`, extended `appAuth.test.ts`; four unrelated service test mocks updated to set `appAccessToken` so they don't exercise the new issuance path.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — full suite green (1025 passed, 6 skipped)
- [x] New regression tests assert the corrected Bitunix endpoint paths/methods/payloads
- [x] New `appFetch` tests cover: auto-issue when no token, re-issue+retry on stale-token 401, no retry on unrelated 401s


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_