### PR TITLE
fix: TP/SL missing exchange field, harden Decimal parsing against malformed exchange data

### DIFF
--- a/src/services/mappers.test.ts
+++ b/src/services/mappers.test.ts
@@ -115,5 +115,26 @@ describe("Mappers", () => {
             expect(result.price.toString()).toBe("0");
             expect(result.amount.toString()).toBe("0");
         });
+
+        it("should not throw when a numeric field holds a non-numeric string", () => {
+            // Regression: `new Decimal("MARKET")` throws (decimal.js does not
+            // return NaN like Number() does), which used to crash the whole
+            // reactive tree consuming OMS state when a raw WS/API field ended
+            // up here malformed.
+            const raw = {
+                orderId: "1",
+                symbol: "ETHUSDT",
+                side: "BUY",
+                type: "MARKET",
+                price: "MARKET",
+                qty: "MARKET",
+                dealAmount: "MARKET",
+            };
+
+            const result = mapToOMSOrder(raw);
+            expect(result.price.toString()).toBe("0");
+            expect(result.amount.toString()).toBe("0");
+            expect(result.filledAmount.toString()).toBe("0");
+        });
     });
 });

--- a/src/services/mappers.ts
+++ b/src/services/mappers.ts
@@ -22,7 +22,20 @@
 
 import { Decimal } from "decimal.js";
 import { logger } from "./logger";
+import { parseDecimal } from "../utils/utils";
 import type { OMSOrder, OMSPosition, OMSOrderSide, OMSOrderStatus } from "./omsTypes";
+
+/**
+ * `parseDecimal`, for the "field absent means omit it entirely" call sites
+ * below (e.g. `markPrice` on a position where the exchange sent none) —
+ * `parseDecimal` itself always falls back to `Decimal(0)`, which is right
+ * for a price/amount but wrong for an optional field consumers expect to be
+ * `undefined` when absent.
+ */
+function parseDecimalOrUndefined(value: unknown): Decimal | undefined {
+    if (value === undefined || value === null || value === "") return undefined;
+    return parseDecimal(value as string | number | Decimal);
+}
 
 /**
  * Maps raw API/WS data to a standardized OMSPosition.
@@ -36,7 +49,7 @@ import type { OMSOrder, OMSPosition, OMSOrderSide, OMSOrderStatus } from "./omsT
 export function mapToOMSPosition(data: any): OMSPosition {
     const isClose = data.event === "CLOSE";
     // If event is CLOSE, the position is effectively closed (qty 0).
-    const amount = isClose ? new Decimal(0) : new Decimal(data.qty || data.size || data.amount || 0);
+    const amount = isClose ? new Decimal(0) : parseDecimal(data.qty || data.size || data.amount);
 
     // Side normalization
     let side: "long" | "short" = "long";
@@ -46,12 +59,11 @@ export function mapToOMSPosition(data: any): OMSPosition {
     }
 
     // Price priority: avgOpenPrice (API/WS) > entryPrice (API fallback)
-    const entryPrice = new Decimal(data.avgOpenPrice || data.averagePrice || data.entryPrice || 0);
-    const upnl = new Decimal(data.unrealizedPNL || data.unrealizedPnl || 0);
-    const lev = new Decimal(data.leverage || 0);
-    const liq = (data.liquidationPrice || data.liqPrice)
-        ? new Decimal(data.liquidationPrice || data.liqPrice)
-        : undefined;
+    const entryPrice = parseDecimal(data.avgOpenPrice || data.averagePrice || data.entryPrice);
+    const upnl = parseDecimal(data.unrealizedPNL || data.unrealizedPnl);
+    const lev = parseDecimal(data.leverage);
+    const rawLiq = data.liquidationPrice || data.liqPrice;
+    const liq = rawLiq ? parseDecimalOrUndefined(rawLiq) : undefined;
 
     return {
         symbol: data.symbol || "",
@@ -64,12 +76,8 @@ export function mapToOMSPosition(data: any): OMSPosition {
         liquidationPrice: liq,
         // Hardening: Extract real values from API instead of using Decimal(0) placeholder.
         // Use undefined when the field is absent — consumers already handle optional fields.
-        margin: (data.margin || data.isolatedMargin || data.crossMargin)
-            ? new Decimal(data.margin || data.isolatedMargin || data.crossMargin)
-            : undefined,
-        markPrice: data.markPrice
-            ? new Decimal(data.markPrice)
-            : undefined,
+        margin: parseDecimalOrUndefined(data.margin || data.isolatedMargin || data.crossMargin),
+        markPrice: parseDecimalOrUndefined(data.markPrice),
         size: amount,
         lastUpdated: Date.now()
     };
@@ -116,9 +124,9 @@ export function mapToOMSOrder(data: any): OMSOrder {
         side,
         type: (data.type || "").toLowerCase() as "limit" | "market",
         status: status,
-        price: new Decimal(data.price || 0),
-        amount: new Decimal(data.qty || data.amount || 0),
-        filledAmount: new Decimal(data.dealAmount || data.filledQty || 0),
+        price: parseDecimal(data.price),
+        amount: parseDecimal(data.qty || data.amount),
+        filledAmount: parseDecimal(data.dealAmount || data.filledQty),
         timestamp: Number(data.ctime || data.timestamp || Date.now()),
     };
 }

--- a/src/services/tradeService.ts
+++ b/src/services/tradeService.ts
@@ -526,6 +526,7 @@ class TradeService {
                               if (sym) params.symbol = sym;
 
                               const data = await this.signedRequest<Record<string, unknown>>("POST", "/api/tpsl", {
+                                  exchange: "bitunix",
                                   action: view,
                                   params
                               }).catch((e): Record<string, unknown> => {
@@ -572,6 +573,7 @@ class TradeService {
 
     public async cancelTpSlOrder(order: TpSlOrder) {
         return this.signedRequest("POST", "/api/tpsl", {
+            exchange: "bitunix",
             action: "cancel",
             params: {
                 orderId: order.orderId || order.id,
@@ -589,6 +591,7 @@ class TradeService {
         qty?: string
     }) {
         return this.signedRequest("POST", "/api/tpsl", {
+            exchange: "bitunix",
             action: "modify",
             params: {
                 orderId: params.orderId,

--- a/src/stores/account.svelte.ts
+++ b/src/stores/account.svelte.ts
@@ -8,7 +8,7 @@
  */
 
 import { Decimal } from "decimal.js";
-import { parseTimestamp } from "../utils/utils";
+import { parseTimestamp, parseDecimal } from "../utils/utils";
 
 export interface Position {
   positionId: string;
@@ -88,8 +88,15 @@ interface AccountSnapshot {
   assets: Asset[];
 }
 
+/**
+ * `parseDecimal` already falls back to `Decimal(0)` on a missing or
+ * unparseable value (`new Decimal()` throws on a non-numeric string instead
+ * of returning NaN — a malformed field on a raw WS push would otherwise
+ * crash this store outright). This wraps it with a caller-supplied fallback
+ * for the "keep the existing value" update paths below.
+ */
 const safeDecimal = (val: Decimal.Value | null | undefined, fallback: Decimal) =>
-  val !== undefined && val !== null ? new Decimal(val) : fallback;
+  val === undefined || val === null ? fallback : parseDecimal(val as string | number | Decimal);
 
 class AccountManager {
   positions = $state<Position[]>([]);
@@ -119,7 +126,7 @@ class AccountManager {
     // Robust check for close event or zero quantity
     const isClose =
       data.event === "CLOSE" ||
-      new Decimal(data.qty || 0).isZero();
+      safeDecimal(data.qty, new Decimal(0)).isZero();
 
     if (isClose) {
       if (index !== -1) {
@@ -180,11 +187,11 @@ class AccountManager {
           positionId: String(data.positionId),
           symbol: data.symbol ?? "",
           side: side as "long" | "short",
-          size: new Decimal(data.qty || 0),
-          entryPrice: new Decimal(data.averagePrice || data.avgOpenPrice || 0),
-          leverage: new Decimal(data.leverage || 0),
-          unrealizedPnl: new Decimal(data.unrealizedPNL || 0),
-          margin: new Decimal(data.margin || 0),
+          size: safeDecimal(data.qty, new Decimal(0)),
+          entryPrice: safeDecimal(data.averagePrice || data.avgOpenPrice, new Decimal(0)),
+          leverage: safeDecimal(data.leverage, new Decimal(0)),
+          unrealizedPnl: safeDecimal(data.unrealizedPNL, new Decimal(0)),
+          margin: safeDecimal(data.margin, new Decimal(0)),
           marginMode: data.marginMode ? data.marginMode.toLowerCase() : "cross",
           liquidationPrice: new Decimal(0),
           markPrice: new Decimal(0),
@@ -232,9 +239,9 @@ class AccountManager {
           symbol: data.symbol ?? "",
           side: (data.side ? data.side.toLowerCase() : "buy") as "buy" | "sell",
           type: (data.type ? data.type.toLowerCase() : "limit") as "limit" | "market",
-          price: new Decimal(data.price || 0),
-          amount: new Decimal(data.qty || 0),
-          filled: new Decimal(data.dealAmount || 0),
+          price: safeDecimal(data.price, new Decimal(0)),
+          amount: safeDecimal(data.qty, new Decimal(0)),
+          filled: safeDecimal(data.dealAmount, new Decimal(0)),
           status: data.orderStatus || "",
           timestamp: parseTimestamp(data.ctime) || Date.now(),
         };
@@ -247,14 +254,15 @@ class AccountManager {
     if (data.coin === "USDT") {
       const idx = this.assets.findIndex((a) => a.currency === "USDT");
 
+      const available = safeDecimal(data.available, new Decimal(0));
+      const margin = safeDecimal(data.margin, new Decimal(0));
+      const frozen = safeDecimal(data.frozen, new Decimal(0));
       const newAsset = {
         currency: "USDT",
-        available: new Decimal(data.available || 0),
-        margin: new Decimal(data.margin || 0),
-        frozen: new Decimal(data.frozen || 0),
-        total: new Decimal(data.available || 0)
-          .plus(new Decimal(data.margin || 0))
-          .plus(new Decimal(data.frozen || 0)),
+        available,
+        margin,
+        frozen,
+        total: available.plus(margin).plus(frozen),
       };
 
       if (idx !== -1) {

--- a/src/stores/account.test.ts
+++ b/src/stores/account.test.ts
@@ -81,4 +81,58 @@ describe('AccountManager', () => {
             expect.anything()
         );
     });
+
+    // Regression: `new Decimal("MARKET")` throws (decimal.js does not return
+    // NaN like Number() does), so a malformed field on a raw WS push used to
+    // crash the store outright instead of falling back safely.
+    it('should not throw when a new position has a non-numeric field', () => {
+        expect(() =>
+            accountState.updatePositionFromWs({
+                positionId: '456',
+                symbol: 'ETHUSDT',
+                side: 'long',
+                qty: '1.5', // non-zero, so this isn't treated as a CLOSE
+                averagePrice: 'MARKET',
+                leverage: 'MARKET',
+                unrealizedPNL: 'MARKET',
+                margin: 'MARKET',
+            }),
+        ).not.toThrow();
+
+        expect(accountState.positions).toHaveLength(1);
+        expect(accountState.positions[0].size.toString()).toBe('1.5');
+        expect(accountState.positions[0].entryPrice.toString()).toBe('0');
+    });
+
+    it('should not throw when a new order has a non-numeric price', () => {
+        expect(() =>
+            accountState.updateOrderFromWs({
+                orderId: '789',
+                symbol: 'ETHUSDT',
+                side: 'BUY',
+                type: 'MARKET',
+                price: 'MARKET',
+                qty: 'MARKET',
+                dealAmount: 'MARKET',
+                orderStatus: 'NEW',
+            }),
+        ).not.toThrow();
+
+        expect(accountState.openOrders).toHaveLength(1);
+        expect(accountState.openOrders[0].price.toString()).toBe('0');
+    });
+
+    it('should not throw when a balance push has a non-numeric field', () => {
+        expect(() =>
+            accountState.updateBalanceFromWs({
+                coin: 'USDT',
+                available: 'MARKET',
+                margin: 'MARKET',
+                frozen: 'MARKET',
+            }),
+        ).not.toThrow();
+
+        expect(accountState.assets).toHaveLength(1);
+        expect(accountState.assets[0].total.toString()).toBe('0');
+    });
 });

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { parseDateString, parseTimestamp, escapeHtml, parseAiValue, parseDecimal } from "./utils";
+import { parseDateString, parseTimestamp, escapeHtml, parseAiValue, parseDecimal, formatDynamicDecimal } from "./utils";
 
 describe("parseTimestamp", () => {
   it("should return number as is (milliseconds)", () => {
@@ -210,5 +210,25 @@ describe("parseDecimal", () => {
     expect(parseDecimal("MARKET").toNumber()).toBe(0);
     expect(parseDecimal("LIMIT").toNumber()).toBe(0);
     expect(parseDecimal("abc").toNumber()).toBe(0);
+  });
+});
+
+describe("formatDynamicDecimal", () => {
+  it("should format valid numeric input", () => {
+    expect(formatDynamicDecimal("123.4500")).toBe("123.45");
+    expect(formatDynamicDecimal(100)).toBe("100");
+  });
+
+  it("should return '-' for null/undefined", () => {
+    expect(formatDynamicDecimal(null)).toBe("-");
+    expect(formatDynamicDecimal(undefined)).toBe("-");
+  });
+
+  it("should return '-' instead of throwing on a non-numeric string", () => {
+    // Regression: `new Decimal("MARKET")` throws rather than yielding NaN,
+    // and this is called from dozens of list/tooltip components with
+    // whatever field an order/position object happens to hold.
+    expect(formatDynamicDecimal("MARKET")).toBe("-");
+    expect(formatDynamicDecimal("LIMIT")).toBe("-");
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -161,7 +161,17 @@ export function formatDynamicDecimal(
 ): string {
   if (value === null || value === undefined) return "-";
 
-  const dec = new Decimal(value);
+  // decimal.js throws on a non-numeric string (e.g. an order's `type` field
+  // ending up here by mistake) rather than returning NaN like Number() does.
+  // This is a render-layer choke point called from dozens of list/tooltip
+  // components on live exchange data, so one bad field must degrade to "-"
+  // rather than crash the whole reactive tree.
+  let dec: Decimal;
+  try {
+    dec = new Decimal(value);
+  } catch {
+    return "-";
+  }
   if (dec.isNaN()) return "-";
 
   // Format to a fixed number of decimal places, then remove trailing zeros


### PR DESCRIPTION
## Summary

Follow-up to #1665 (merged). After that fix landed, the console still showed `POST /api/tpsl 400 (Bad Request)` with `"Validation Error"` for every symbol, and separately an uncaught `[DecimalError] Invalid argument: MARKET` that crashes the reactive tree rendering Positions/Orders — both blocking the Market Activity window from showing data.

### 1. TP/SL requests never included `exchange`

`TpSlRequestSchema` (`src/types/apiSchemas.ts`) requires `exchange: z.literal("bitunix")` on every `/api/tpsl` request body. `tradeService.ts`'s `fetchTpSlOrders`/`cancelTpSlOrder`/`modifyTpSlOrder` never sent it — only `action`/`params`, with credentials going out via headers instead. Every real request from the app therefore failed Zod validation before the (now-correct, per #1665) Bitunix endpoint was ever reached. This is why TP/SL kept failing even after the endpoint-path fix: the path was right, but the request never got that far. Added `exchange: "bitunix"` to all three call sites.

### 2. Decimal construction crashes on malformed exchange data

`decimal.js` throws on a non-numeric string (e.g. `new Decimal("MARKET")`) instead of returning `NaN` like `Number()` would. Several places fed raw, untrusted Bitunix WS/REST fields straight into `new Decimal()` with no guard, so one malformed field crashes the whole render:

- `mapToOMSPosition`/`mapToOMSOrder` (`src/services/mappers.ts`) now use the existing, already-tested `parseDecimal()` helper (`src/utils/utils.ts`, which already has a regression test for exactly `"MARKET"`) instead of raw `new Decimal()`.
- `account.svelte.ts`'s WS handlers (position/order/balance) route through the same safe parsing consistently — previously only the "update existing position" path had a fallback, not "new position", "new order", or balance updates.
- `formatDynamicDecimal` (`src/utils/utils.ts`) — the single most-reused render-layer function, called from dozens of order/position/tooltip components — now catches the throw and returns `"-"`, same as it already does for `null`/`undefined`.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — full suite green (1032 passed, 6 skipped)
- [x] New regression tests: `mapToOMSOrder` and `updatePositionFromWs`/`updateOrderFromWs`/`updateBalanceFromWs` no longer throw on a `"MARKET"`-valued numeric field; `formatDynamicDecimal("MARKET")` returns `"-"` instead of throwing


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_