### PR TITLE
fix: unify Positions/Orders/Account on a single live store, fix cancel/close 400s

### DIFF
--- a/src/components/shared/PositionsSidebar.svelte
+++ b/src/components/shared/PositionsSidebar.svelte
@@ -55,7 +55,30 @@
     isolationUnrealizedPNL: number | string;
   }
 
-  let openOrders: NormalizedOrder[] = $state([]);
+  // Pending orders live in accountState (hydrated from REST on mount/tab
+  // switch below, kept current afterwards by the WS order channel via
+  // accountState.updateOrderFromWs) — mapped back to the NormalizedOrder
+  // shape OpenOrdersList already renders, so a new order/fill/cancel shows
+  // up immediately instead of only after the next manual tab switch.
+  let openOrders: NormalizedOrder[] = $derived(
+    accountState.openOrders.map((o) => ({
+      id: o.orderId,
+      orderId: o.orderId,
+      symbol: o.symbol,
+      type: o.type,
+      side: o.side.toUpperCase(),
+      price: o.price.toString(),
+      amount: o.amount.toString(),
+      filled: o.filled.toString(),
+      status: o.status,
+      time: o.timestamp,
+      // Pending orders haven't been filled yet, so both are always zero —
+      // OpenOrdersList doesn't render either, this only satisfies the
+      // shared NormalizedOrder shape.
+      fee: "0",
+      realizedPNL: "0",
+    })),
+  );
   let historyOrders: NormalizedOrder[] = $state([]);
   let accountInfo: AccountInfo = $state({
     available: 0,
@@ -101,6 +124,12 @@
   }
 
   // Map AccountState Position to OMSPosition
+  // Available/margin/frozen come from the WS-live balance channel once it
+  // has pushed at least once; PnL is always derived live from open
+  // positions (also WS-fed). Both fall back to the last REST snapshot
+  // (accountInfo) before that, rather than showing 0 until the first push.
+  let liveAsset = $derived(accountState.assets.find((a) => a.currency === "USDT"));
+
   let mappedPositions = $derived(
     accountState.positions.map((p): OMSPosition => ({
         symbol: p.symbol,
@@ -137,15 +166,13 @@
       });
       const data = await response.json();
       if (data.error) errorPositions = translateError(data);
-      else {
-        // Initial Population of Store if needed, or just let WS handle it?
-        // For now, let's trust the WS to update, but initial fetch is good.
-        // We'll update the local store manually? Or rely on accountStore?
-        // Since PositionsList uses `positions` prop, let's pass data.
-        // Ideally, accountStore should manage this.
-        if (data.positions) {
-          accountState.positions = data.positions;
-        }
+      else if (data.positions) {
+        // hydratePositions parses through the same safe Decimal path as WS
+        // updates and fills in positionId — a raw `accountState.positions =
+        // data.positions` assignment used to silently violate the Position
+        // type (string fields, no positionId), which both risked a render
+        // crash and broke matching against subsequent WS position pushes.
+        accountState.hydratePositions(data.positions);
       }
     } catch {
       errorPositions = $_("apiErrors.failedToLoadPositions");
@@ -154,19 +181,13 @@
     }
   }
 
-  async function fetchOrders(type: "pending" | "history") {
+  async function fetchPendingOrders() {
     const provider = settingsState.apiProvider || "bitunix";
     const keys = settingsState.apiKeys[provider];
     if (!keys?.key || !keys?.secret) return;
 
-    if (type === "pending") {
-      loadingOrders = true;
-      errorOrders = "";
-    } else {
-      loadingHistory = true;
-      errorHistory = "";
-    }
-
+    loadingOrders = true;
+    errorOrders = "";
     try {
       const response = await appFetch("/api/orders", {
         method: "POST",
@@ -175,25 +196,78 @@
           exchange: provider,
           apiKey: keys.key,
           apiSecret: keys.secret,
-          type,
+          type: "pending",
         }),
       });
       const data = await response.json();
       if (data.error) {
-        const msg = translateError(data);
-        if (type === "pending") errorOrders = msg;
-        else errorHistory = msg;
+        errorOrders = translateError(data);
       } else {
-        if (type === "pending") openOrders = data.orders || [];
-        else historyOrders = data.orders || [];
+        // Same reasoning as fetchPositions: hydrate through accountState so
+        // this list is live afterwards (WS order-channel pushes update it),
+        // instead of a snapshot that never changes until the tab is
+        // revisited.
+        accountState.hydrateOpenOrders(data.orders || []);
       }
     } catch {
-      const msg = $_("apiErrors.failedToLoadOrders");
-      if (type === "pending") errorOrders = msg;
-      else errorHistory = msg;
+      errorOrders = $_("apiErrors.failedToLoadOrders");
     } finally {
-      if (type === "pending") loadingOrders = false;
-      else loadingHistory = false;
+      loadingOrders = false;
+    }
+  }
+
+  async function fetchHistoryOrders() {
+    const provider = settingsState.apiProvider || "bitunix";
+    const keys = settingsState.apiKeys[provider];
+    if (!keys?.key || !keys?.secret) return;
+
+    loadingHistory = true;
+    errorHistory = "";
+    try {
+      // Bitunix's get_history_orders splits FILLED/EXPIRED (queryCanceled
+      // omitted) from CANCELED (queryCanceled: true) — one call never
+      // returns both, so both are fetched and merged. Only relevant for
+      // Bitunix; Bitget's history endpoint has no such split.
+      const requests =
+        provider === "bitunix"
+          ? [{ queryCanceled: false }, { queryCanceled: true }]
+          : [{}];
+
+      const responses = await Promise.all(
+        requests.map((extra) =>
+          appFetch("/api/orders", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              exchange: provider,
+              apiKey: keys.key,
+              apiSecret: keys.secret,
+              type: "history",
+              ...extra,
+            }),
+          }).then((r) => r.json()),
+        ),
+      );
+
+      const firstError = responses.find((data) => data.error);
+      if (firstError) {
+        errorHistory = translateError(firstError);
+        return;
+      }
+
+      const merged = new Map<string, NormalizedOrder>();
+      for (const data of responses) {
+        for (const order of (data.orders || []) as NormalizedOrder[]) {
+          merged.set(order.id || order.orderId, order);
+        }
+      }
+      historyOrders = Array.from(merged.values()).sort(
+        (a, b) => (b.time || 0) - (a.time || 0),
+      );
+    } catch {
+      errorHistory = $_("apiErrors.failedToLoadOrders");
+    } finally {
+      loadingHistory = false;
     }
   }
 
@@ -215,6 +289,16 @@
       const data = await response.json();
       if (!data.error) {
         accountInfo = data;
+        // available/margin/frozen also flow into accountState so
+        // AccountSummary can prefer the WS-live balance channel over this
+        // snapshot once it starts pushing (see liveAsset below); the
+        // remaining fields here (bonus/transfer/positionMode/per-mode PnL)
+        // have no WS equivalent and stay REST-only.
+        accountState.hydrateBalance({
+          available: data.available,
+          margin: data.margin,
+          frozen: data.frozen,
+        });
       }
     } catch (e) {
       if (import.meta.env.DEV) {
@@ -230,21 +314,21 @@
     if (keys?.key && keys?.secret) {
       fetchAccount();
       fetchPositions();
-      fetchOrders("pending");
+      fetchPendingOrders();
     }
   });
 
   // Load orders only when switching to the tab and if not already loaded or stale
   $effect(() => {
     if (activeTab === "orders" && openOrders.length === 0) {
-      fetchOrders("pending");
+      fetchPendingOrders();
     }
   });
 
   $effect(() => {
     // History should only load once when requested or via manual refresh
     if (activeTab === "history" && historyOrders.length === 0) {
-      fetchOrders("history");
+      fetchHistoryOrders();
     }
   });
 
@@ -330,7 +414,7 @@
             uiState.showError($_("dashboard.alerts.cancelOrderError", { values: { error: res.error } }) || `Cancel failed: ${res.error}`);
         } else {
              uiState.showToast($_("dashboard.alerts.cancelOrderSuccess") || "Order cancelled", "success");
-             fetchOrders("pending");
+             fetchPendingOrders();
         }
     } catch (e: unknown) {
         // Prefer rawMessage on BitunixApiError — `e.message` carries the i18n
@@ -404,11 +488,11 @@
   {#if isOpen}
     <!-- Account Summary -->
     <AccountSummary
-      available={accountInfo.available}
-      margin={accountInfo.margin}
-      pnl={accountInfo.totalUnrealizedPnL}
+      available={liveAsset ? liveAsset.available : accountInfo.available}
+      margin={liveAsset ? liveAsset.margin : accountInfo.margin}
+      pnl={accountState.totalUnrealizedPnl}
       currency={accountInfo.marginCoin}
-      frozen={accountInfo.frozen}
+      frozen={liveAsset ? liveAsset.frozen : accountInfo.frozen}
       transfer={accountInfo.transfer}
       bonus={accountInfo.bonus}
       positionMode={accountInfo.positionMode}

--- a/src/routes/api/orders/+server.ts
+++ b/src/routes/api/orders/+server.ts
@@ -121,7 +121,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
         result = { orders };
       }
       else if (payload.type === "history") {
-        const orders = await fetchBitunixHistoryOrders(apiKey, apiSecret, Number(payload.limit));
+        const orders = await fetchBitunixHistoryOrders(apiKey, apiSecret, Number(payload.limit), payload.queryCanceled);
         result = { orders };
       }
       else if (payload.type === "place-order") {
@@ -449,10 +449,14 @@ function cleanPayload<T extends object>(payload: T): T {
   return cleaned as T;
 }
 
-async function fetchBitunixHistoryOrders(apiKey: string, apiSecret: string, limit = 20): Promise<NormalizedOrder[]> {
+async function fetchBitunixHistoryOrders(apiKey: string, apiSecret: string, limit = 20, queryCanceled = false): Promise<NormalizedOrder[]> {
   const baseUrl = "https://fapi.bitunix.com";
   const path = "/api/v1/futures/trade/get_history_orders";
-  const params = { limit: String(limit) };
+  // Bitunix's own split: queryCanceled=false returns everything except
+  // CANCELED (up to 90 days back); true returns ONLY CANCELED (up to 3 days
+  // back). Neither call alone is a complete history.
+  const params: Record<string, string> = { limit: String(limit) };
+  if (queryCanceled) params.queryCanceled = "true";
   const { nonce, timestamp, signature, queryString } = generateBitunixSignature(apiKey, apiSecret, params, "");
 
   const response = await fetch(`${baseUrl}${path}?${queryString}`, {

--- a/src/routes/api/orders/orders_history_queryCanceled.test.ts
+++ b/src/routes/api/orders/orders_history_queryCanceled.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./+server";
+import * as clientToken from "../../../lib/server/clientToken";
+
+// Regression: Bitunix's get_history_orders excludes CANCELED orders unless
+// queryCanceled=true is passed — and then excludes everything else (see
+// docs/bitunix-api/07_trade.md). The route used to never forward this
+// param, so cancelled orders (extremely common while testing/trading)
+// silently never appeared in History.
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const getClientAddress = () => "127.0.0.1";
+
+function makeRequest(body: unknown): Request {
+  return {
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(clientToken, "checkClientToken").mockReturnValue(null);
+  fetchMock.mockResolvedValue({
+    ok: true,
+    text: async () => JSON.stringify({ code: 0, data: { orderList: [] }, msg: "Success" }),
+  });
+});
+
+describe("POST /api/orders history forwards queryCanceled", () => {
+  it("omits queryCanceled from the query string by default", async () => {
+    await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "history",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).not.toContain("queryCanceled");
+  });
+
+  it("adds queryCanceled=true to the query string when requested", async () => {
+    await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "history",
+        queryCanceled: true,
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("queryCanceled=true");
+  });
+});

--- a/src/routes/api/positions/+server.ts
+++ b/src/routes/api/positions/+server.ts
@@ -30,6 +30,7 @@ import type { NormalizedPosition } from "../../../types/bitunix";
 // Raw Bitunix position fields — names vary across API versions/endpoints,
 // hence the fallback chains at each read site below.
 interface BitunixRawPosition {
+  positionId?: string | number;
   side?: string | number;
   positionSide?: string;
   symbol: string;
@@ -195,6 +196,7 @@ async function fetchBitunixPositions(
       }
 
       return {
+        positionId: p.positionId !== undefined ? String(p.positionId) : undefined,
         symbol: p.symbol,
         side: side,
         // size: "qty" as per docs. Fallback to older fields.

--- a/src/routes/api/positions/positions_positionId.test.ts
+++ b/src/routes/api/positions/positions_positionId.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./+server";
+import * as clientToken from "../../../lib/server/clientToken";
+
+// Regression: the Bitunix "Get Pending Positions" response includes
+// positionId (docs/bitunix-api/05_position.md), but the normalizer dropped
+// it. Without it, the client can't correlate a REST-hydrated position with
+// subsequent WS position-channel updates (which match by positionId), so
+// every WS push after a REST refresh created a duplicate instead of
+// updating the existing entry.
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const getClientAddress = () => "127.0.0.1";
+
+function makeRequest(body: unknown): Request {
+  return {
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(clientToken, "checkClientToken").mockReturnValue(null);
+});
+
+describe("POST /api/positions includes positionId in the normalized response", () => {
+  it("passes Bitunix's positionId through", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          code: 0,
+          data: [
+            {
+              positionId: "12345678",
+              symbol: "BTCUSDT",
+              side: "LONG",
+              qty: "0.5",
+              avgOpenPrice: "60000",
+              marginMode: "ISOLATION",
+            },
+          ],
+          msg: "Success",
+        }),
+    });
+
+    const response = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.positions).toHaveLength(1);
+    expect(body.data.positions[0].positionId).toBe("12345678");
+  });
+});

--- a/src/services/tradeService.ts
+++ b/src/services/tradeService.ts
@@ -111,8 +111,15 @@ class TradeService {
             ...(keys.passphrase ? { "X-Api-Passphrase": keys.passphrase } : {})
         };
 
+        // Every guarded route's Zod schema requires `exchange` in the body
+        // (there is no header fallback for it, only for the credentials
+        // above) — inject it here once rather than relying on every call
+        // site to remember it. Callers that already set it (none currently
+        // do) win, since they're spread after.
+        const payloadWithExchange = { exchange: provider, ...payload };
+
         // Deep serialize Decimals to strings before JSON.stringify
-        const serializedPayload = this.serializePayload(payload);
+        const serializedPayload = this.serializePayload(payloadWithExchange);
 
         const response = await appFetch(endpoint, {
             method,
@@ -282,6 +289,7 @@ class TradeService {
             }
 
             const result = await this.signedRequest("POST", "/api/orders", {
+                type: "place-order",
                 symbol,
                 side: apiSide,
                 orderType: "MARKET",
@@ -465,6 +473,7 @@ class TradeService {
         logger.log("market", `[ClosePosition] Closing ${symbol} ${positionSide} (${qty})`);
 
         return this.signedRequest("POST", "/api/orders", {
+            type: "place-order",
             symbol,
             side,
             orderType: "MARKET",

--- a/src/services/tradeService_requestFields.test.ts
+++ b/src/services/tradeService_requestFields.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
+import { tradeService } from "./tradeService";
+import { omsService } from "./omsService";
+import { Decimal } from "decimal.js";
+
+// Regression coverage for a request body missing `exchange` (and, for
+// place-order calls, `type`) — both required by the server-side Zod schemas
+// (BaseRequestSchema.exchange, OrderRequestSchema's "type" discriminant).
+// signedRequest sent credentials via headers only, so every one of these
+// calls 400'd with "Validation Error" before ever reaching Bitunix,
+// regardless of whether the endpoint path itself was correct.
+
+vi.mock("../stores/settings.svelte", () => ({
+  settingsState: {
+    apiProvider: "bitunix",
+    apiKeys: {
+      bitunix: { key: "test", secret: "test" },
+    },
+    appAccessToken: "test-token",
+    secretsReady: Promise.resolve(),
+  },
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+  },
+}));
+
+vi.mock("../stores/trade.svelte", () => ({
+  tradeState: {
+    symbol: "BTCUSDT",
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("./omsService", () => ({
+  omsService: {
+    getPositions: vi.fn().mockReturnValue([]),
+    addOptimisticOrder: vi.fn(),
+    updatePosition: vi.fn(),
+  },
+}));
+
+vi.mock("../stores/market.svelte", () => ({
+  marketState: { data: {} },
+}));
+
+describe("TradeService request bodies include exchange (and type for place-order)", () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ code: "0", data: [] }),
+      json: async () => ({ code: "0", data: [] }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function lastBody(): Record<string, unknown> {
+    const call = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1];
+    return JSON.parse(call[1]?.body as string);
+  }
+
+  it("cancelOrder sends exchange", async () => {
+    await tradeService.cancelOrder("BTCUSDT", "1");
+    const body = lastBody();
+    expect(body.exchange).toBe("bitunix");
+    expect(body.type).toBe("cancel-order");
+  });
+
+  it("cancelAllOrders sends exchange", async () => {
+    await tradeService.cancelAllOrders("BTCUSDT");
+    const body = lastBody();
+    expect(body.exchange).toBe("bitunix");
+    expect(body.type).toBe("cancel-all");
+  });
+
+  it("closePosition sends exchange and the place-order type discriminant", async () => {
+    vi.mocked(omsService.getPositions).mockReturnValue([
+      {
+        symbol: "BTCUSDT",
+        side: "long",
+        amount: new Decimal(1),
+        lastUpdated: Date.now(),
+      },
+    ]);
+
+    await tradeService.closePosition({
+      symbol: "BTCUSDT",
+      positionSide: "long",
+      forceFullClose: true,
+    });
+
+    const body = lastBody();
+    expect(body.exchange).toBe("bitunix");
+    expect(body.type).toBe("place-order");
+  });
+
+  it("fetchTpSlOrders sends exchange on /api/tpsl", async () => {
+    await tradeService.fetchTpSlOrders("pending");
+    const call = fetchSpy.mock.calls.find((c) => c[0] === "/api/tpsl");
+    expect(call).toBeDefined();
+    const body = JSON.parse(call![1]?.body as string);
+    expect(body.exchange).toBe("bitunix");
+  });
+});

--- a/src/stores/account.svelte.ts
+++ b/src/stores/account.svelte.ts
@@ -9,6 +9,7 @@
 
 import { Decimal } from "decimal.js";
 import { parseTimestamp, parseDecimal } from "../utils/utils";
+import type { NormalizedPosition, NormalizedOrder } from "../types/bitunix";
 
 export interface Position {
   positionId: string;
@@ -294,6 +295,77 @@ class AccountManager {
     for (const data of dataList) {
       this.updateBalanceFromWs(data);
     }
+  }
+
+  // --- REST snapshot hydration ---
+  //
+  // REST is the authoritative full snapshot (replaces the array outright);
+  // WS pushes then keep it live via the incremental updaters above. Routing
+  // REST responses through the same Decimal-safe parsing as WS — rather than
+  // assigning the raw (string-typed) API JSON straight into these
+  // Decimal-typed arrays — is what actually makes this the single source of
+  // truth: before this, `PositionsSidebar.svelte` wrote raw REST JSON here
+  // directly, silently violating the `Position`/`OpenOrder` types (nothing
+  // caught it because `response.json()` returns `any`) and leaving
+  // `positionId` unset, which broke matching against subsequent WS updates.
+
+  hydratePositions(raw: NormalizedPosition[]) {
+    this.positions = raw.map((p, i) => ({
+      // Bitunix always returns positionId; Bitget's normalized shape
+      // currently doesn't carry one — synthesize a stable key so hydration
+      // still works, at the cost of not correlating with WS updates for
+      // that exchange (tracked as a known gap, not silently broken).
+      positionId: p.positionId ?? `${p.symbol}-${p.side}-${i}`,
+      symbol: p.symbol,
+      side: (p.side || "long").toLowerCase() as "long" | "short",
+      size: parseDecimal(p.size),
+      entryPrice: parseDecimal(p.entryPrice),
+      leverage: parseDecimal(p.leverage),
+      unrealizedPnl: parseDecimal(p.unrealizedPnL),
+      margin: parseDecimal(p.margin),
+      marginMode: (p.marginMode || "cross").toLowerCase(),
+      liquidationPrice: parseDecimal(p.liquidationPrice),
+      markPrice: parseDecimal(p.markPrice),
+      breakEvenPrice: new Decimal(0),
+    }));
+    this.notifyListeners();
+  }
+
+  hydrateOpenOrders(raw: NormalizedOrder[]) {
+    this.openOrders = raw.map((o) => ({
+      orderId: String(o.orderId ?? o.id ?? ""),
+      symbol: o.symbol,
+      side: (o.side || "buy").toLowerCase() as "buy" | "sell",
+      type: (o.type || "limit").toLowerCase() as "limit" | "market",
+      price: parseDecimal(o.price),
+      amount: parseDecimal(o.amount),
+      filled: parseDecimal(o.filled),
+      status: o.status || "",
+      timestamp: Number(o.time) || Date.now(),
+    }));
+    this.notifyListeners();
+  }
+
+  hydrateBalance(raw: { available?: string; margin?: string; frozen?: string }) {
+    const available = parseDecimal(raw.available);
+    const margin = parseDecimal(raw.margin);
+    const frozen = parseDecimal(raw.frozen);
+    const newAsset: Asset = {
+      currency: "USDT",
+      available,
+      margin,
+      frozen,
+      total: available.plus(margin).plus(frozen),
+    };
+    const idx = this.assets.findIndex((a) => a.currency === "USDT");
+    if (idx !== -1) this.assets[idx] = newAsset;
+    else this.assets.push(newAsset);
+    this.notifyListeners();
+  }
+
+  /** Live sum of every open position's unrealized PnL — updates as the position channel pushes. */
+  get totalUnrealizedPnl(): Decimal {
+    return this.positions.reduce((sum, p) => sum.plus(p.unrealizedPnl), new Decimal(0));
   }
 
   // Compatibility

--- a/src/stores/account.test.ts
+++ b/src/stores/account.test.ts
@@ -135,4 +135,92 @@ describe('AccountManager', () => {
         expect(accountState.assets).toHaveLength(1);
         expect(accountState.assets[0].total.toString()).toBe('0');
     });
+
+    // Regression: PositionsSidebar.svelte used to assign the raw REST JSON
+    // straight into accountState.positions (string fields, no positionId),
+    // silently violating the Position type (`response.json()` is `any`, so
+    // nothing caught it) and breaking correlation with subsequent WS
+    // updates. hydratePositions/hydrateOpenOrders/hydrateBalance replace
+    // that with the same Decimal-safe parsing WS updates already use.
+    describe('hydratePositions', () => {
+        it('converts REST NormalizedPosition[] into typed Decimal positions', () => {
+            accountState.hydratePositions([
+                {
+                    positionId: '456',
+                    symbol: 'BTCUSDT',
+                    side: 'LONG',
+                    size: '1.5',
+                    entryPrice: '50000',
+                    unrealizedPnL: '100',
+                    margin: '500',
+                    leverage: '10',
+                    marginMode: 'CROSS',
+                },
+            ]);
+
+            expect(accountState.positions).toHaveLength(1);
+            const pos = accountState.positions[0];
+            expect(pos.positionId).toBe('456');
+            expect(pos.side).toBe('long');
+            expect(pos.size.toString()).toBe('1.5');
+            expect(pos.entryPrice.toString()).toBe('50000');
+            expect(pos.marginMode).toBe('cross');
+        });
+
+        it('does not throw on a malformed field and replaces the whole array', () => {
+            accountState.hydratePositions([
+                { positionId: '1', symbol: 'BTCUSDT', side: 'LONG', size: 'MARKET', marginMode: 'CROSS' },
+            ]);
+            expect(accountState.positions).toHaveLength(1);
+            expect(accountState.positions[0].size.toString()).toBe('0');
+
+            // A second hydration fully replaces the first (REST is a full snapshot).
+            accountState.hydratePositions([]);
+            expect(accountState.positions).toHaveLength(0);
+        });
+    });
+
+    describe('hydrateOpenOrders', () => {
+        it('converts REST NormalizedOrder[] into typed Decimal orders', () => {
+            accountState.hydrateOpenOrders([
+                {
+                    id: '1', orderId: '1', symbol: 'ETHUSDT', type: 'LIMIT', side: 'BUY',
+                    price: '3000', amount: '2', filled: '0', status: 'NEW', time: 1700000000000,
+                    fee: '0', realizedPNL: '0',
+                },
+            ]);
+
+            expect(accountState.openOrders).toHaveLength(1);
+            const order = accountState.openOrders[0];
+            expect(order.orderId).toBe('1');
+            expect(order.side).toBe('buy');
+            expect(order.type).toBe('limit');
+            expect(order.price.toString()).toBe('3000');
+        });
+    });
+
+    describe('hydrateBalance', () => {
+        it('sets available/margin/frozen and derives total', () => {
+            accountState.hydrateBalance({ available: '1000', margin: '50', frozen: '10' });
+            expect(accountState.assets).toHaveLength(1);
+            const asset = accountState.assets[0];
+            expect(asset.available.toString()).toBe('1000');
+            expect(asset.total.toString()).toBe('1060');
+        });
+    });
+
+    describe('totalUnrealizedPnl', () => {
+        it('sums unrealizedPnl across all open positions', () => {
+            accountState.hydratePositions([
+                { symbol: 'BTCUSDT', side: 'LONG', unrealizedPnL: '100', marginMode: 'CROSS' },
+                { symbol: 'ETHUSDT', side: 'SHORT', unrealizedPnL: '-30', marginMode: 'CROSS' },
+            ]);
+            expect(accountState.totalUnrealizedPnl.toString()).toBe('70');
+        });
+
+        it('is zero with no open positions', () => {
+            accountState.hydratePositions([]);
+            expect(accountState.totalUnrealizedPnl.toString()).toBe('0');
+        });
+    });
 });

--- a/src/types/bitunix.ts
+++ b/src/types/bitunix.ts
@@ -91,6 +91,7 @@ export interface NormalizedOrder {
 // Normalized Internal Position Interface — shared shape both exchanges'
 // /api/positions routes map their raw responses into.
 export interface NormalizedPosition {
+  positionId?: string;
   symbol: string;
   side: string;
   size?: string;

--- a/src/types/orderSchemas.ts
+++ b/src/types/orderSchemas.ts
@@ -109,6 +109,10 @@ export const HistorySchema = BaseRequestSchema.extend({
        return isNaN(n) ? 50 : Math.min(Math.max(n, 1), 100);
     }).optional().default(50),
   symbol: z.string().optional(), // Optional filter
+  // Bitunix's get_history_orders excludes CANCELED orders unless this is
+  // true — and then it excludes everything else. There is no single call
+  // that returns both, so the client fetches once per value and merges.
+  queryCanceled: z.boolean().optional().default(false),
 });
 
 // --- Pending ---


### PR DESCRIPTION
## Summary

Full audit of Market Activity against the Bitunix API docs, prompted by: cancelling an order 400'd, Account Summary stayed at 0 USDT after a real fill, and Orders/History never updated on their own.

### Konzept: eine Datenquelle pro Domäne, REST = Snapshot, WS = Live-Delta

Vorher hatte jede Kategorie ihr eigenes, inkonsistentes Muster:

| Bereich | Vorher | Nachher |
|---|---|---|
| Positions | ✅ bereits `accountState` (WS-live) | unverändert, jetzt aber mit korrektem `positionId` |
| Orders | ❌ einmaliger REST-Snapshot in Komponenten-State, nie wieder aktualisiert | ✅ `accountState.openOrders`, wie Positions |
| Account Summary | ❌ einmaliger REST-Snapshot, nie wieder aktualisiert | ✅ Available/Margin/Frozen aus `accountState.assets` (WS-live), PnL live aus Positions summiert |
| History | REST, unvollständig (Bitunix schließt CANCELED-Orders standardmäßig aus) | REST mit beiden `queryCanceled`-Werten gemerged |

### Vier unabhängige Root Causes

1. **Cancel/Close → 400**: `tradeService.ts`s `signedRequest()` schickt Credentials nur per Header, der Body wird aber vom jeweiligen Aufrufer gebaut — und keiner davon hat `exchange` gesetzt (von `BaseRequestSchema` zwingend gefordert), `closePosition`/`flashClosePosition` hat zusätzlich das `type: "place-order"`-Diskriminator-Feld vergessen. Jede dieser vier Aktionen (Order canceln, alle canceln, Position schließen, Flash-Close) scheiterte an der Zod-Validierung, bevor sie Bitunix überhaupt erreichte. Jetzt zentral in `signedRequest()` injiziert statt an jeder Aufrufstelle einzeln.
2. **`positionId` fehlte** in `/api/positions`' Normalisierung, obwohl Bitunix es liefert (`docs/bitunix-api/05_position.md`). `PositionsSidebar.svelte` hat das rohe REST-JSON zudem direkt und typunsicher in den Decimal-typisierten `accountState.positions` geschrieben (`response.json()` ist `any`, daher hat TypeScript das nie erkannt). Ohne `positionId` konnten spätere WS-Updates die Position nie wiederfinden → Duplikate statt Updates.
3. **Keine Live-Reaktivität** bei Orders/Account: anders als Positions liefen diese nur einmalig auf REST, nie erneut befüllt durch WS-Pushes.
4. **History unvollständig**: Bitunix schließt bei `get_history_orders` standardmäßig CANCELED-Orders aus (`queryCanceled=true` zeigt NUR stornierte); es gibt keinen einzelnen Call für beides.

## Changes

- `account.svelte.ts`: neue `hydratePositions`/`hydrateOpenOrders`/`hydrateBalance` (REST → gleicher Decimal-sicherer Pfad wie WS-Updates) + `totalUnrealizedPnl` (live Summe offener Positionen).
- `PositionsSidebar.svelte`: Orders/Account lesen jetzt aus `accountState` statt lokalem Einmal-State; History merged beide `queryCanceled`-Varianten.
- `tradeService.ts`: `exchange` zentral in `signedRequest()`, `type: "place-order"` bei Close/FlashClose ergänzt.
- `/api/positions`, `types/bitunix.ts`: `positionId` durchgereicht.
- `/api/orders`, `orderSchemas.ts`: `queryCanceled` Parameter unterstützt.

**Bekannte, bewusst nicht behobene Lücke:** History hat bei Bitunix keinen WS-Push-Kanal — eine frisch geschlossene/stornierte Order erscheint dort erst beim nächsten Tab-Wechsel, nicht sofort live. Dokumentiert als Folgearbeit, nicht in diesem Umfang mitgelöst.

## Test plan

- [x] `npm run check` — 0 Fehler
- [x] `npm test` — 1048 Tests grün (6 skipped)
- [x] Neue Regressionstests: `exchange`/`type` in allen betroffenen Request-Bodies, `hydratePositions`/`hydrateOpenOrders`/`hydrateBalance`/`totalUnrealizedPnl`, `positionId`-Durchreichung, `queryCanceled`-Weiterleitung


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_