### PR TITLE
fix: WS position update without qty was silently closing open positions (BUG-0058)

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-57 items. How to read and add them: [README.md](README.md).
+58 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 19
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 20
 
 ---
 
@@ -49,6 +49,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 19
 
 | ID | Title | Prio | Status | Area |
 | --- | --- | --- | --- | --- |
+| [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | trade-panel |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | trade-panel |
 | [FEAT-0020](features/FEAT-0020-account-settings-panel.md) | Show and change exchange account settings from Cachy | P1 | 📋 specced | trade-panel |
 | [FEAT-0021](features/FEAT-0021-order-types.md) | Support market, limit, trigger and fixed-risk orders with TP/SL attached | P1 | 📋 specced | trade-panel |
@@ -131,6 +132,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 19
 | [BUG-0001](bugs/BUG-0001-bitget-ws-field-mismatch.md) | Bitget WebSocket account sync sends field names the account store never reads | P0 | ✅ done | M0 | community, pro, private | none | none | — |
 | [BUG-0002](bugs/BUG-0002-numeric-zero-target-price.md) | Trade state stores numbers where its type declares strings | P0 | ✅ done | M0 | community, pro, private | A | none | — |
 | [BUG-0053](bugs/BUG-0053-device-key-loss-orphans-secrets.md) | A lost or regenerated IndexedDB device key silently orphans every encrypted secret | P0 | 📋 specced | M0 | community, pro, private | A | none | — |
+| [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
@@ -188,4 +190,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 19
 
 ---
 
-Next free number: **0058**
+Next free number: **0059**

--- a/docs/backlog/bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md
+++ b/docs/backlog/bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md
@@ -1,0 +1,85 @@
+---
+id: BUG-0058
+title: A WS position push that omits qty silently closes a still-open position
+type: bug
+status: done
+priority: P0
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: []
+---
+
+# BUG-0058 — A WS position push that omits `qty` silently closes a still-open position
+
+## Symptom
+
+Reported by the user directly after FEAT-0057/BUG-0055 shipped: with a real,
+currently open Bitunix position (entry filled, TP and SL set), the Positions
+tab is empty and Account Summary shows 0 for margin/PnL — while the entry
+fill correctly shows up in the History tab. The position exists on the
+exchange and momentarily rendered correctly (via the initial REST fetch),
+then disappeared.
+
+## Evidence
+
+**Derived, not demonstrated against a live account** (no live keys
+available in this environment) — but the mechanism is unambiguous from
+reading the code, and a unit test reproduces it exactly.
+
+`src/stores/account.svelte.ts`, `updatePositionFromWs()`, pre-fix:
+
+```ts
+const isClose =
+  data.event === "CLOSE" ||
+  safeDecimal(data.qty, new Decimal(0)).isZero();
+```
+
+`safeDecimal(val, fallback)` returns `fallback` whenever `val` is
+`undefined`/`null` — the same fallback (`Decimal(0)`) it also uses to mean
+"treat a genuinely absent field as zero" everywhere else in this file. Used
+here, a WS position push that simply doesn't repeat `qty` (e.g. an `UPDATE`
+event carrying only a changed margin or `unrealizedPNL`, not the unchanged
+size) is indistinguishable from an explicit `qty: "0"` — both produce
+`Decimal(0).isZero() === true`, so the position gets `splice()`d out of
+`accountState.positions` on the very next such push, regardless of whether
+the position is actually still open.
+
+This is a **derived-and-then-confirmed-by-test** bug:
+`account.test.ts`'s new `'does not close an existing position when a WS
+push omits qty'` case fails against the pre-fix code (position count goes
+to 0 after a margin-only update) and passes after the fix.
+
+## Cause
+
+`isClose` used one fallback value to mean two different things: "the field
+was not sent" and "the field was sent and is genuinely zero." Only the
+second should ever close a position.
+
+## Fix
+
+`src/stores/account.svelte.ts`, `updatePositionFromWs()`: only treat a push
+as a close when `data.qty` is *explicitly* present and parses to zero, or
+`data.event === "CLOSE"`. A push that omits `qty` now falls through to the
+normal OPEN/UPDATE path, where `size: safeDecimal(data.qty, existing.size)`
+already correctly preserves the last known size.
+
+## Acceptance criteria
+
+- [x] A test reproduces the defect (position removed by a qty-omitting
+      update) and fails without the fix
+- [x] The test passes with the fix
+- [x] A push with an explicit `qty: "0"` still closes the position
+- [x] An explicit `event: "CLOSE"` with no `qty` at all still closes the
+      position
+- [x] Existing `account.svelte.ts` tests continue to pass unchanged
+
+## Links
+
+- `src/stores/account.svelte.ts` — `updatePositionFromWs()`
+- `src/stores/account.test.ts`
+- [`FEAT-0057`](../features/FEAT-0057-market-activity-panel-redesign.md),
+  [`BUG-0055`](BUG-0055-position-mark-price-always-zero.md) — the report
+  that surfaced this while re-testing those changes

--- a/src/stores/account.svelte.ts
+++ b/src/stores/account.svelte.ts
@@ -140,10 +140,18 @@ class AccountManager {
       (p) => String(p.positionId) === String(data.positionId),
     );
 
-    // Robust check for close event or zero quantity
+    // Close only on an explicit CLOSE event or a push that *explicitly*
+    // carries qty: "0". A push that omits `qty` entirely (e.g. a
+    // margin/PnL-only UPDATE) must NOT be treated as a close — it
+    // previously was, because `safeDecimal(data.qty, new Decimal(0))`
+    // defaults a *missing* field to Decimal(0) the same way it defaults an
+    // explicit zero, so `.isZero()` was `true` either way. That silently
+    // deleted a still-open position from `this.positions` on the very next
+    // WS push that didn't happen to repeat `qty` (see BUG-0058).
+    const hasExplicitQty = data.qty !== undefined && data.qty !== null;
     const isClose =
       data.event === "CLOSE" ||
-      safeDecimal(data.qty, new Decimal(0)).isZero();
+      (hasExplicitQty && safeDecimal(data.qty, new Decimal(0)).isZero());
 
     if (isClose) {
       if (index !== -1) {

--- a/src/stores/account.test.ts
+++ b/src/stores/account.test.ts
@@ -54,6 +54,53 @@ describe('AccountManager', () => {
         expect(accountState.positions[0].side).toBe('long'); // Should persist
     });
 
+    // Regression (BUG-0058): a WS push that omits `qty` entirely (e.g. an
+    // UPDATE carrying only a margin/PnL change) used to be treated as a
+    // close, because the same `Decimal(0)` fallback used for "field absent"
+    // was also what `.isZero()` checked against — silently deleting a still
+    // -open position from the store on the very next such push.
+    it('does not close an existing position when a WS push omits qty', () => {
+        accountState.updatePositionFromWs({
+            positionId: '123', symbol: 'BTCUSDT', side: 'long',
+            qty: '1.0', averagePrice: '50000', leverage: '10',
+            unrealizedPNL: '100', margin: '500', marginMode: 'cross',
+        });
+        expect(accountState.positions).toHaveLength(1);
+
+        // Margin/PnL-only update, no qty field at all.
+        accountState.updatePositionFromWs({
+            positionId: '123', unrealizedPNL: '150', margin: '520',
+        });
+
+        expect(accountState.positions).toHaveLength(1);
+        expect(accountState.positions[0].size.toString()).toBe('1'); // preserved
+        expect(accountState.positions[0].unrealizedPnl.toString()).toBe('150');
+    });
+
+    it('still closes a position when the push explicitly carries qty "0"', () => {
+        accountState.updatePositionFromWs({
+            positionId: '123', symbol: 'BTCUSDT', side: 'long',
+            qty: '1.0', averagePrice: '50000', marginMode: 'cross',
+        });
+        expect(accountState.positions).toHaveLength(1);
+
+        accountState.updatePositionFromWs({ positionId: '123', qty: '0' });
+
+        expect(accountState.positions).toHaveLength(0);
+    });
+
+    it('still closes a position on an explicit CLOSE event with no qty', () => {
+        accountState.updatePositionFromWs({
+            positionId: '123', symbol: 'BTCUSDT', side: 'long',
+            qty: '1.0', averagePrice: '50000', marginMode: 'cross',
+        });
+        expect(accountState.positions).toHaveLength(1);
+
+        accountState.updatePositionFromWs({ positionId: '123', event: 'CLOSE' });
+
+        expect(accountState.positions).toHaveLength(0);
+    });
+
     it('should trigger sync callback on partial update for unknown position (Race Condition Fix)', () => {
         const consoleSpy = vi.spyOn(console, 'warn');
         const syncCallback = vi.fn();


### PR DESCRIPTION
## Summary

Found while re-testing the just-merged FEAT-0057/BUG-0055 changes against a
real account: a currently open position with TP and SL set showed nothing
in the Positions tab (only its entry fill was visible in History), and
Account Summary read 0 for margin/PnL.

Root cause is unrelated to those changes — a pre-existing bug in
`updatePositionFromWs()` (`src/stores/account.svelte.ts`):

```ts
const isClose =
  data.event === "CLOSE" ||
  safeDecimal(data.qty, new Decimal(0)).isZero();
```

`safeDecimal(val, fallback)` returns `Decimal(0)` both when `qty` is
explicitly `"0"` **and** when `qty` is simply absent from the push (e.g. a
WS `UPDATE` carrying only a changed margin or `unrealizedPNL`, not the
unchanged size). Either way `.isZero()` is `true`, so the position gets
spliced out of `accountState.positions` on the very next push that doesn't
happen to repeat `qty` — even though it's still open on the exchange.

Fix: only treat a push as a close when `qty` is *explicitly* present and
parses to zero, or `event === "CLOSE"`. A push that omits `qty` now falls
through to the normal OPEN/UPDATE path, which already correctly preserves
the last known size (`size: safeDecimal(data.qty, existing.size)`).

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — 1063 passed, 6 skipped (full suite, no regressions)
- [x] New regression tests in `account.test.ts`: a qty-omitting update no
      longer closes the position (fails without the fix); an explicit
      `qty: "0"` still closes it; an explicit `event: "CLOSE"` with no qty
      still closes it
- [x] `npm run backlog:check` — index up to date, front matter valid
- [ ] Manual verification against a live/test Bitunix account (position
      stays visible across several WS updates) — not done in this sandbox,
      no live keys available

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_