### PR TITLE
fix: surface account-fetch errors instead of silently leaving the summary at zero (BUG-0059)

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-58 items. How to read and add them: [README.md](README.md).
+59 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 20
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 21
 
 ---
 
@@ -51,6 +51,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 20
 | --- | --- | --- | --- | --- |
 | [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | trade-panel |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | trade-panel |
+| [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | trade-panel |
 | [FEAT-0020](features/FEAT-0020-account-settings-panel.md) | Show and change exchange account settings from Cachy | P1 | 📋 specced | trade-panel |
 | [FEAT-0021](features/FEAT-0021-order-types.md) | Support market, limit, trigger and fixed-risk orders with TP/SL attached | P1 | 📋 specced | trade-panel |
 | [FEAT-0023](features/FEAT-0023-position-management.md) | Manage open positions without leaving Cachy | P1 | 📋 specced | trade-panel |
@@ -142,6 +143,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 20
 | [BUG-0047](bugs/BUG-0047-academy-unusable-on-mobile.md) | The Trading Academy content is unreachable on a phone because the pattern list fills the screen | P1 | ✅ done | M0 | community, pro, private | none | none | — |
 | [BUG-0052](bugs/BUG-0052-app-access-token-blocks-public-byok-users.md) | APP_ACCESS_TOKEN blocks BYOK users who have no way to know it | P1 | ✅ done | none | community, pro, private | none | ADR-0002 | — |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | M3 | community, pro, private | none | none | — |
+| [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | M3 | community, pro, private | none | none | — |
 | [FEAT-0014](features/FEAT-0014-edition-build-targets.md) | Produce Community, Pro and Private builds from one tree | P1 | 📋 specced | M5 | community, pro, private | none | ADR-0003 | — |
 | [FEAT-0015](features/FEAT-0015-order-audit-trail.md) | Record every order submission attempt locally | P1 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0016](features/FEAT-0016-exchange-adapter-interface.md) | Put every exchange behind one adapter interface | P1 | 📋 specced | M2 | community, pro, private | none | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
@@ -190,4 +192,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 20
 
 ---
 
-Next free number: **0059**
+Next free number: **0060**

--- a/docs/backlog/bugs/BUG-0059-account-fetch-error-silently-swallowed.md
+++ b/docs/backlog/bugs/BUG-0059-account-fetch-error-silently-swallowed.md
@@ -1,0 +1,107 @@
+---
+id: BUG-0059
+title: A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account
+type: bug
+status: done
+priority: P1
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: []
+---
+
+# BUG-0059 — A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account
+
+## Symptom
+
+Reported while chasing BUG-0058: with a real open position on the exchange,
+the Account Summary tooltip shows every field at zero — Available, Total
+Equity, Margin Level, Wallet Balance, Transferable, Bonus, Frozen, Cross
+PnL, Mode "-" — with no error message anywhere. These are exactly the
+hard-coded initial defaults of `accountInfo` in `PositionsSidebar.svelte`,
+meaning it was never actually updated with real data.
+
+## Evidence
+
+**Demonstrated by code inspection, not a live reproduction** (no live keys
+available in this environment).
+
+`fetchAccount()` (`src/components/shared/PositionsSidebar.svelte`,
+pre-fix):
+
+```ts
+const data = await response.json();
+if (!data.error) {
+  accountInfo = data;
+  accountState.hydrateBalance({ ... });
+}
+```
+```ts
+} catch (e) {
+  if (import.meta.env.DEV) {
+    console.error(e);
+  }
+}
+```
+
+If the server responds with `{ error: ... }` (any exchange-side failure —
+auth, signature, rate limit, permissions), the `if` branch is skipped
+entirely: `accountInfo` is never reassigned, stays at its all-zero initial
+`$state`, and nothing renders an error. The `catch` block is just as
+silent outside dev builds (`console.error` gated on `import.meta.env.DEV`
+does nothing in a production build the user is actually running). A
+genuinely empty account and a completely failed fetch look identical to
+the user — this is why the report could not be told apart from "the
+account really has no data" without opening the browser's network
+inspector.
+
+Contrast with `fetchPositions()`, which already sets `errorPositions` and
+renders it in `PositionsList.svelte` — `fetchAccount()` had no equivalent.
+
+## Cause
+
+`fetchAccount()` predates the pattern the other three fetchers
+(`fetchPositions`, `fetchPendingOrders`, `fetchHistoryOrders`) already use
+(a dedicated `error*` state surfaced in the corresponding list component)
+and was never brought in line with it.
+
+## Fix
+
+Added `errorAccount` state, set from `translateError(data)` on an API
+error response and from `apiErrors.generic` on a thrown exception (matching
+the other three fetchers), cleared on success. Passed through to
+`AccountSummary.svelte` as a new `error` prop, rendered as a visible
+message at the top of the summary.
+
+This does not by itself explain *why* the account fetch is failing for the
+reporting user — it makes the failure visible so the actual server
+response (status code, error body) can be captured on the next report
+instead of guessed at.
+
+## Acceptance criteria
+
+- [x] An account-fetch API error is shown to the user instead of silently
+      leaving every field at zero
+- [x] A thrown exception (network failure) is shown too, not just
+      dev-console-logged
+- [x] Successful fetches clear any previously shown error
+- [x] `npm run check` and the full Vitest suite pass
+
+## Open question
+
+What is actually failing for the reporting user's account — auth,
+signature, exchange-side rate limiting, or a genuinely empty response being
+misread as populated data elsewhere (e.g. `fetchPositions`' Bitunix
+position-size filter dropping a position whose `qty` field doesn't match
+any of the three field names it checks)? Needs the actual error text (now
+visible) or a Network-tab response body from the reporting user to pin
+down — deliberately not guessed at further here.
+
+## Links
+
+- `src/components/shared/PositionsSidebar.svelte` — `fetchAccount()`
+- `src/components/shared/AccountSummary.svelte`
+- [`BUG-0058`](BUG-0058-ws-position-update-missing-qty-closes-position.md) —
+  the report that surfaced this while re-testing

--- a/src/components/shared/AccountSummary.svelte
+++ b/src/components/shared/AccountSummary.svelte
@@ -39,6 +39,10 @@
     // has no API field for this either, its own Assets panel derives it
     // the same way.
     totalPositionSize?: FinancialValue;
+    // Set when the REST account fetch failed. Previously a failure here
+    // left every field at its all-zero default with nothing in the UI
+    // distinguishing that from a genuinely empty account.
+    error?: string;
   }
 
   let {
@@ -52,13 +56,19 @@
     positionMode = "",
     crossUnrealizedPNL = 0,
     isolationUnrealizedPNL = 0,
-    totalPositionSize = 0
+    totalPositionSize = 0,
+    error = ""
   }: Props = $props();
 </script>
 
 <div
   class="p-3 bg-[var(--bg-tertiary)] border-b border-[var(--border-primary)] flex flex-col gap-2 relative"
 >
+  {#if error}
+    <div class="text-xs text-[var(--danger-color)] flex justify-between items-center gap-2">
+      <span>{error}</span>
+    </div>
+  {/if}
   <div
     class="flex justify-between items-center group cursor-help relative"
     role="tooltip"

--- a/src/components/shared/PositionsSidebar.svelte
+++ b/src/components/shared/PositionsSidebar.svelte
@@ -106,6 +106,7 @@
   let errorPositions = $state("");
   let errorOrders = $state("");
   let errorHistory = $state("");
+  let errorAccount = $state("");
 
   // Tab State
   type Tab = "positions" | "orders" | "tpsl" | "history";
@@ -340,7 +341,13 @@
         }),
       });
       const data = await response.json();
-      if (!data.error) {
+      if (data.error) {
+        // Previously silent: accountInfo stayed at its all-zero initial
+        // state forever with nothing in the UI indicating a fetch ever
+        // failed — indistinguishable from a genuinely empty account.
+        errorAccount = translateError(data);
+      } else {
+        errorAccount = "";
         accountInfo = data;
         // available/margin/frozen also flow into accountState so
         // AccountSummary can prefer the WS-live balance channel over this
@@ -353,10 +360,8 @@
           frozen: data.frozen,
         });
       }
-    } catch (e) {
-      if (import.meta.env.DEV) {
-        console.error(e);
-      }
+    } catch {
+      errorAccount = $_("apiErrors.generic");
     }
   }
 
@@ -586,6 +591,7 @@
       crossUnrealizedPNL={accountInfo.crossUnrealizedPNL}
       isolationUnrealizedPNL={accountInfo.isolationUnrealizedPNL}
       totalPositionSize={totalPositionSize}
+      error={errorAccount}
     />
 
     <!-- Tabs -->


### PR DESCRIPTION
## Summary

Follow-up to BUG-0058: after that fix, the user still saw an all-zero
Account Summary (Available, Total Equity, Margin Level, Wallet Balance,
Transferable, Bonus, Frozen, Cross PnL — every field) despite having a real
open position, with the position missing from the Positions tab too.

Confirmed via a live test: manually editing the position on Bitunix made it
reappear in Cachy's Positions tab immediately, but only with the fields a
WS push carries (size, entry, side, PnL) — `liquidationPrice`/`markPrice`/
`marginRate`, which are REST-only, stayed at 0. This isolates the problem
to the **initial REST fetch** (`/api/positions`, `/api/account`, both fired
from `onMount`) failing or never completing — the WS layer and BUG-0058's
fix are confirmed working.

This PR doesn't fix that REST failure itself (root cause still unconfirmed
— see BUG-0059's "Open question"). What it fixes: `fetchAccount()` silently
swallowed any error response or thrown exception, leaving `accountInfo`
stuck at its all-zero initial state with nothing in the UI indicating a
fetch had ever failed — indistinguishable from a genuinely empty account.
`fetchPositions()` already had this (`errorPositions` → shown in
`PositionsList`); `fetchAccount()` didn't.

Once this deploys, the actual error message will be visible above the
Available balance, which is what's needed to pin down the real root cause
(auth, signature, exchange-side rate limit, or something else) instead of
guessing further.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — 1063 passed, 6 skipped (full suite, no regressions)
- [x] `npm run backlog:check` — index up to date, front matter valid
- [ ] Manual verification against a live/test Bitunix account — not done in
      this sandbox, no live keys available. Next step once this merges: ask
      the reporting user what error text (if any) now shows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_