### PR TITLE
fix: populate leverage/margin mode/qty in the order tooltip (BUG-0061)

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-60 items. How to read and add them: [README.md](README.md).
+61 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 22
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 23
 
 ---
 
@@ -61,6 +61,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 22
 | [FEAT-0057](features/FEAT-0057-market-activity-panel-redesign.md) | Show the full Bitunix position/order dataset in the Market Activity panel | P1 | 📋 specced | trade-panel |
 | [BUG-0054](bugs/BUG-0054-orders-tab-loading-indicator-broken.md) | Orders-tab loading indicator is broken in both directions | P2 | ✅ done | trade-panel |
 | [BUG-0056](bugs/BUG-0056-order-history-tab-stale.md) | Order history tab shows stale trades | P2 | ✅ done | trade-panel |
+| [BUG-0061](bugs/BUG-0061-order-tooltip-metadata-dropped.md) | Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns | P2 | ✅ done | trade-panel |
 | [FEAT-0025](features/FEAT-0025-trading-notifications.md) | Notify on fills, margin thresholds and connection loss | P2 | 📋 specced | trade-panel |
 
 ### M4
@@ -170,6 +171,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 22
 | [BUG-0051](bugs/BUG-0051-sidepanel-never-rendered.md) | SidePanel.svelte is never rendered, so the "Enable Side Panel" setting does nothing | P2 | ✅ done | none | community, pro, private | none | ADR-0006 | — |
 | [BUG-0054](bugs/BUG-0054-orders-tab-loading-indicator-broken.md) | Orders-tab loading indicator is broken in both directions | P2 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0056](bugs/BUG-0056-order-history-tab-stale.md) | Order history tab shows stale trades | P2 | ✅ done | M3 | community, pro, private | none | none | — |
+| [BUG-0061](bugs/BUG-0061-order-tooltip-metadata-dropped.md) | Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns | P2 | ✅ done | M3 | community, pro, private | none | none | — |
 | [FEAT-0019](features/FEAT-0019-agentic-web-search.md) | Let the assistant research the web when it needs to | P2 | 💡 idea | M8 | pro, private | C | none | [FEAT-0016](features/FEAT-0016-exchange-adapter-interface.md) |
 | [FEAT-0025](features/FEAT-0025-trading-notifications.md) | Notify on fills, margin thresholds and connection loss | P2 | 📋 specced | M3 | community, pro, private | A | none | — |
 | [FEAT-0028](features/FEAT-0028-indicator-alerts.md) | Alerts on indicator conditions | P2 | 📋 specced | M4 | community, pro, private | A | none | [FEAT-0027](features/FEAT-0027-alert-engine.md) |
@@ -194,4 +196,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 22
 
 ---
 
-Next free number: **0061**
+Next free number: **0062**

--- a/docs/backlog/bugs/BUG-0061-order-tooltip-metadata-dropped.md
+++ b/docs/backlog/bugs/BUG-0061-order-tooltip-metadata-dropped.md
@@ -1,0 +1,97 @@
+---
+id: BUG-0061
+title: Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns
+type: bug
+status: done
+priority: P2
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: []
+---
+
+# BUG-0061 — Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns
+
+## Symptom
+
+Reported while verifying BUG-0060's fix: the order tooltip (hover on an
+entry in the Orders or History tab) shows "Leverage: x" (no number), an
+empty "Margin" row, and "Qty: -" even for a filled order whose "Filled"
+row correctly shows a real quantity.
+
+## Evidence
+
+**Demonstrated by code inspection**, cross-checked against
+`docs/bitunix-api/07_trade.md` and `08_websocket.md`.
+
+Three independent gaps, all in the order data path (distinct from
+BUG-0060's position/account envelope bug):
+
+1. **Server never mapped leverage/marginMode/positionMode/TP-SL.**
+   `fetchBitunixPendingOrders()`/`fetchBitunixHistoryOrders()`
+   (`src/routes/api/orders/+server.ts`) built their `NormalizedOrder`
+   objects without `leverage`, `marginMode`, `positionMode`, `tpPrice`,
+   `tpStopType`, `tpOrderType`, `slPrice`, `slStopType`, `slOrderType`, or
+   `mtime` — even though Bitunix documents all of them on both endpoints
+   ("Analog zu Get History Orders" for pending) and the raw response
+   examples show them present. `NormalizedOrder`
+   (`src/types/bitunix.ts`) already declared these fields; they were just
+   never read off the raw response.
+
+2. **`OpenOrder` (the Orders-tab store type,
+   `src/stores/account.svelte.ts`) dropped them again** even after fix #1:
+   the interface had no fields for them, so `hydrateOpenOrders()` silently
+   discarded whatever the server now sent, and `updateOrderFromWs()` had
+   nowhere to put the WS order channel's equivalent fields (which use a
+   different name, `positionType`, for margin mode —
+   `docs/bitunix-api/08_websocket.md:235` — not a typo to unify with REST's
+   `marginMode`). This only affected the Orders (pending) tab; History
+   reads straight off the server response and was fixed by #1 alone.
+
+3. **`OrderDetailsTooltip.svelte` read the wrong field names entirely**:
+   `order.qty` (doesn't exist on `NormalizedOrder`, only `order.amount`
+   does) and `order.ctime`/`order.mtime` for the "Created" row (the field
+   is `order.time`, `ctime` doesn't exist on `NormalizedOrder`) — both
+   always undefined regardless of #1/#2.
+
+## Fix
+
+1. `src/routes/api/orders/+server.ts`: both mapping functions now include
+   `leverage`, `marginMode`, `positionMode`, `mtime`, and the six TP/SL
+   fields.
+2. `src/stores/account.svelte.ts`: extended `OpenOrder` and `RawWsOrder`
+   with the same fields (plain strings, no Decimal parsing needed — these
+   are descriptive metadata, not prices/amounts). `updateOrderFromWs()`
+   preserves them across a push that omits them, the same way
+   `updatePositionFromWs()` preserves `liquidationPrice`/`markPrice`.
+3. `src/components/shared/PositionsSidebar.svelte`: the `openOrders`
+   `$derived` now passes these fields through to the tooltip.
+4. `src/components/shared/OrderDetailsTooltip.svelte`: reads
+   `order.amount` (not `order.qty`) and `order.time` (not `order.ctime`),
+   each with a defensive fallback to the wrong name for the tooltip's other
+   loosely-typed callers.
+
+## Acceptance criteria
+
+- [x] A server-level test (`orders_leverage_marginmode.test.ts`) confirms
+      both `fetchBitunixPendingOrders`/`fetchBitunixHistoryOrders` map
+      leverage/marginMode/positionMode/TP-SL/mtime
+- [x] A store-level test confirms `hydrateOpenOrders()` and
+      `updateOrderFromWs()` (both the "positionType" WS field name and
+      preservation across an update that omits the fields) carry them
+      through to `accountState.openOrders`
+- [x] `npm run check` and the full Vitest suite pass
+
+## Links
+
+- [`BUG-0060`](BUG-0060-positions-account-envelope-mismatch.md) — the
+  report that led here
+- `src/routes/api/orders/+server.ts`
+- `src/stores/account.svelte.ts` — `OpenOrder`, `RawWsOrder`,
+  `updateOrderFromWs()`, `hydrateOpenOrders()`
+- `src/components/shared/OrderDetailsTooltip.svelte`,
+  `PositionsSidebar.svelte`
+- `docs/bitunix-api/07_trade.md:294-325`,
+  `docs/bitunix-api/08_websocket.md:216-256`

--- a/src/components/shared/OrderDetailsTooltip.svelte
+++ b/src/components/shared/OrderDetailsTooltip.svelte
@@ -105,7 +105,7 @@
     </div>
     <div class="flex justify-between">
       <span class="text-[var(--text-secondary)]">{$_("dashboard.orderHistory.details.qty")}:</span>
-      <span>{formatDynamicDecimal(order.qty)}</span>
+      <span>{formatDynamicDecimal(order.amount ?? order.qty)}</span>
     </div>
     <div class="flex justify-between">
       <span class="text-[var(--text-secondary)]">{$_("dashboard.orderHistory.details.filled")}:</span>
@@ -176,9 +176,9 @@
       >
         <div class="flex justify-between">
           <span>{$_("dashboard.orderHistory.details.created")}:</span>
-          <span>{formatDate(order.ctime)}</span>
+          <span>{formatDate(order.time ?? order.ctime)}</span>
         </div>
-        {#if order.mtime && order.mtime !== order.ctime}
+        {#if order.mtime && order.mtime !== (order.time ?? order.ctime)}
           <div class="flex justify-between">
             <span>{$_("dashboard.orderHistory.details.updated")}:</span>
             <span>{formatDate(order.mtime)}</span>

--- a/src/components/shared/PositionsSidebar.svelte
+++ b/src/components/shared/PositionsSidebar.svelte
@@ -82,6 +82,16 @@
       // shared NormalizedOrder shape.
       fee: "0",
       realizedPNL: "0",
+      mtime: o.mtime,
+      leverage: o.leverage,
+      marginMode: o.marginMode,
+      positionMode: o.positionMode,
+      tpPrice: o.tpPrice,
+      tpStopType: o.tpStopType,
+      tpOrderType: o.tpOrderType,
+      slPrice: o.slPrice,
+      slStopType: o.slStopType,
+      slOrderType: o.slOrderType,
     })),
   );
   let historyOrders: NormalizedOrder[] = $state([]);

--- a/src/routes/api/orders/+server.ts
+++ b/src/routes/api/orders/+server.ts
@@ -419,8 +419,22 @@ async function fetchBitunixPendingOrders(apiKey: string, apiSecret: string): Pro
     filled: formatApiNum(o.tradeQty) || "0",
     status: o.status || "UNKNOWN",
     time: o.ctime || 0,
+    mtime: o.mtime,
     fee: formatApiNum(o.fee) || "0",
     realizedPNL: formatApiNum(o.realizedPNL) || "0",
+    // Bitunix documents these on Get Pending Orders too ("Analog zu Get
+    // History Orders", docs/bitunix-api/07_trade.md:500) but they were
+    // never mapped through — the order tooltip's Leverage/Margin Mode/TP-SL
+    // rows always rendered empty regardless of what the exchange sent.
+    leverage: o.leverage,
+    marginMode: o.marginMode,
+    positionMode: o.positionMode,
+    tpPrice: o.tpPrice,
+    tpStopType: o.tpStopType,
+    tpOrderType: o.tpOrderType,
+    slPrice: o.slPrice,
+    slStopType: o.slStopType,
+    slOrderType: o.slOrderType,
   }));
 }
 
@@ -498,6 +512,20 @@ async function fetchBitunixHistoryOrders(apiKey: string, apiSecret: string, limi
     status: o.status || "UNKNOWN",
     // Hardening: Explicitly validate time, default to 0 only if missing/invalid
     time: (o.ctime && !isNaN(Number(o.ctime))) ? Number(o.ctime) : 0,
+    mtime: o.mtime,
+    // Bitunix documents all of these on Get History Orders
+    // (docs/bitunix-api/07_trade.md:294-325) but they were never mapped
+    // through — the order tooltip's Leverage/Margin Mode/TP-SL rows always
+    // rendered empty regardless of what the exchange sent.
+    leverage: o.leverage,
+    marginMode: o.marginMode,
+    positionMode: o.positionMode,
+    tpPrice: o.tpPrice,
+    tpStopType: o.tpStopType,
+    tpOrderType: o.tpOrderType,
+    slPrice: o.slPrice,
+    slStopType: o.slStopType,
+    slOrderType: o.slOrderType,
   }));
 }
 

--- a/src/routes/api/orders/orders_leverage_marginmode.test.ts
+++ b/src/routes/api/orders/orders_leverage_marginmode.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./+server";
+import * as clientToken from "../../../lib/server/clientToken";
+
+// Regression: Bitunix's get_pending_orders/get_history_orders responses
+// carry leverage, marginMode, positionMode and TP/SL fields on every order
+// (docs/bitunix-api/07_trade.md:294-325, "Analog zu Get History Orders" for
+// pending), but the route never mapped them into NormalizedOrder — the
+// order tooltip's Leverage/Margin Mode rows always rendered empty
+// regardless of what the exchange returned.
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const getClientAddress = () => "127.0.0.1";
+
+function makeRequest(body: unknown): Request {
+  return {
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(clientToken, "checkClientToken").mockReturnValue(null);
+});
+
+const rawOrder = {
+  orderId: "1", symbol: "XRPUSDT", type: "LIMIT", side: "BUY",
+  price: "1.0349", qty: "9.5", tradeQty: "0", status: "NEW",
+  ctime: 1700000000000, mtime: 1700000001000,
+  leverage: 15, marginMode: "ISOLATION", positionMode: "HEDGE",
+  tpPrice: "1.06", tpStopType: "MARK", tpOrderType: "MARKET",
+  slPrice: "1.02", slStopType: "MARK", slOrderType: "MARKET",
+};
+
+describe("POST /api/orders maps leverage/marginMode/positionMode/TP-SL", () => {
+  it("for pending orders", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({ code: 0, data: { orderList: [rawOrder] }, msg: "Success" }),
+    });
+
+    const res = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "pending",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    const body = await res.json();
+    const order = body.orders[0];
+    expect(order.leverage).toBe(15);
+    expect(order.marginMode).toBe("ISOLATION");
+    expect(order.positionMode).toBe("HEDGE");
+    expect(order.tpPrice).toBe("1.06");
+    expect(order.slPrice).toBe("1.02");
+    expect(order.mtime).toBe(1700000001000);
+  });
+
+  it("for history orders", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({ code: 0, data: { orderList: [rawOrder] }, msg: "Success" }),
+    });
+
+    const res = await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "history",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    const body = await res.json();
+    const order = body.orders[0];
+    expect(order.leverage).toBe(15);
+    expect(order.marginMode).toBe("ISOLATION");
+    expect(order.positionMode).toBe("HEDGE");
+    expect(order.tpPrice).toBe("1.06");
+    expect(order.slPrice).toBe("1.02");
+    expect(order.mtime).toBe(1700000001000);
+  });
+});

--- a/src/stores/account.svelte.ts
+++ b/src/stores/account.svelte.ts
@@ -43,6 +43,23 @@ export interface OpenOrder {
   filled: Decimal;
   status: string;
   timestamp: number;
+  // Descriptive metadata, not live-price data — plain strings rather than
+  // Decimal since nothing here needs arithmetic. Both REST (Get Pending
+  // Orders) and the WS order channel send all of these on every push
+  // (docs/bitunix-api/07_trade.md:294-325,
+  // docs/bitunix-api/08_websocket.md:216-256) — they were previously
+  // dropped at this exact type boundary, which is why the Orders tab's
+  // tooltip showed them empty even after the server started sending them.
+  mtime?: number;
+  leverage?: string;
+  marginMode?: string;
+  positionMode?: string;
+  tpPrice?: string;
+  tpStopType?: string;
+  tpOrderType?: string;
+  slPrice?: string;
+  slStopType?: string;
+  slOrderType?: string;
 }
 
 export interface Asset {
@@ -82,6 +99,19 @@ export interface RawWsOrder {
   qty?: string | number;
   dealAmount?: string | number;
   ctime?: string | number;
+  mtime?: string | number;
+  leverage?: string | number;
+  // The order channel names margin mode "positionType", not "marginMode"
+  // (docs/bitunix-api/08_websocket.md:235) — unlike the position channel,
+  // which does use "marginMode". Not a typo to "fix" into consistency.
+  positionType?: string;
+  positionMode?: string;
+  tpPrice?: string;
+  tpStopType?: string;
+  tpOrderType?: string;
+  slPrice?: string;
+  slStopType?: string;
+  slOrderType?: string;
 }
 
 interface RawWsBalance {
@@ -262,6 +292,16 @@ class AccountManager {
           filled: safeDecimal(data.dealAmount, existing.filled),
           status: data.orderStatus || existing.status,
           timestamp: parseTimestamp(data.ctime) || existing.timestamp,
+          mtime: parseTimestamp(data.mtime) || existing.mtime,
+          leverage: data.leverage !== undefined ? String(data.leverage) : existing.leverage,
+          marginMode: data.positionType ?? existing.marginMode,
+          positionMode: data.positionMode ?? existing.positionMode,
+          tpPrice: data.tpPrice ?? existing.tpPrice,
+          tpStopType: data.tpStopType ?? existing.tpStopType,
+          tpOrderType: data.tpOrderType ?? existing.tpOrderType,
+          slPrice: data.slPrice ?? existing.slPrice,
+          slStopType: data.slStopType ?? existing.slStopType,
+          slOrderType: data.slOrderType ?? existing.slOrderType,
         };
         this.openOrders[index] = newOrder;
       } else {
@@ -275,6 +315,16 @@ class AccountManager {
           filled: safeDecimal(data.dealAmount, new Decimal(0)),
           status: data.orderStatus || "",
           timestamp: parseTimestamp(data.ctime) || Date.now(),
+          mtime: parseTimestamp(data.mtime) || undefined,
+          leverage: data.leverage !== undefined ? String(data.leverage) : undefined,
+          marginMode: data.positionType,
+          positionMode: data.positionMode,
+          tpPrice: data.tpPrice,
+          tpStopType: data.tpStopType,
+          tpOrderType: data.tpOrderType,
+          slPrice: data.slPrice,
+          slStopType: data.slStopType,
+          slOrderType: data.slOrderType,
         };
         this.openOrders.push(newOrder);
       }
@@ -374,6 +424,16 @@ class AccountManager {
       filled: parseDecimal(o.filled),
       status: o.status || "",
       timestamp: Number(o.time) || Date.now(),
+      mtime: o.mtime,
+      leverage: o.leverage,
+      marginMode: o.marginMode,
+      positionMode: o.positionMode,
+      tpPrice: o.tpPrice,
+      tpStopType: o.tpStopType,
+      tpOrderType: o.tpOrderType,
+      slPrice: o.slPrice,
+      slStopType: o.slStopType,
+      slOrderType: o.slOrderType,
     }));
     this.notifyListeners();
   }

--- a/src/stores/account.test.ts
+++ b/src/stores/account.test.ts
@@ -244,6 +244,65 @@ describe('AccountManager', () => {
             expect(order.type).toBe('limit');
             expect(order.price.toString()).toBe('3000');
         });
+
+        // Regression (order tooltip): leverage/marginMode/positionMode/TP-SL
+        // were dropped at the OpenOrder type boundary even after the server
+        // started sending them — the Orders tab tooltip showed "Leverage: x"
+        // and a blank Margin Mode regardless of what the exchange returned.
+        it('carries leverage/marginMode/positionMode/TP-SL through', () => {
+            accountState.hydrateOpenOrders([
+                {
+                    id: '1', orderId: '1', symbol: 'ETHUSDT', type: 'LIMIT', side: 'BUY',
+                    price: '3000', amount: '2', filled: '0', status: 'NEW', time: 1700000000000,
+                    fee: '0', realizedPNL: '0', leverage: '15', marginMode: 'ISOLATION',
+                    positionMode: 'HEDGE', tpPrice: '3100', slPrice: '2900',
+                },
+            ]);
+
+            const order = accountState.openOrders[0];
+            expect(order.leverage).toBe('15');
+            expect(order.marginMode).toBe('ISOLATION');
+            expect(order.positionMode).toBe('HEDGE');
+            expect(order.tpPrice).toBe('3100');
+            expect(order.slPrice).toBe('2900');
+        });
+    });
+
+    describe('updateOrderFromWs — descriptive metadata (order tooltip)', () => {
+        it('sets leverage/marginMode/TP-SL from a WS push (positionType, not marginMode)', () => {
+            accountState.updateOrderFromWs({
+                orderId: '1', symbol: 'ETHUSDT', side: 'BUY', type: 'LIMIT',
+                price: '3000', qty: '2', dealAmount: '0', orderStatus: 'NEW',
+                leverage: '15', positionType: 'ISOLATION', positionMode: 'HEDGE',
+                tpPrice: '3100', slPrice: '2900',
+            });
+
+            const order = accountState.openOrders[0];
+            expect(order.leverage).toBe('15');
+            expect(order.marginMode).toBe('ISOLATION');
+            expect(order.positionMode).toBe('HEDGE');
+            expect(order.tpPrice).toBe('3100');
+            expect(order.slPrice).toBe('2900');
+        });
+
+        it('preserves descriptive metadata across an update that omits it', () => {
+            accountState.updateOrderFromWs({
+                orderId: '1', symbol: 'ETHUSDT', side: 'BUY', type: 'LIMIT',
+                price: '3000', qty: '2', dealAmount: '0', orderStatus: 'NEW',
+                leverage: '15', positionType: 'ISOLATION',
+            });
+
+            // A later push (e.g. a PART_FILLED update) that doesn't repeat
+            // leverage/marginMode must not wipe them.
+            accountState.updateOrderFromWs({
+                orderId: '1', dealAmount: '1', orderStatus: 'PART_FILLED',
+            });
+
+            const order = accountState.openOrders[0];
+            expect(order.leverage).toBe('15');
+            expect(order.marginMode).toBe('ISOLATION');
+            expect(order.filled.toString()).toBe('1');
+        });
     });
 
     describe('hydrateBalance', () => {


### PR DESCRIPTION
## Summary

Follow-up to BUG-0060: the order tooltip (Orders tab and History tab) shows
"Leverage: x" (no number), an empty "Margin" row, and "Qty: -" — even for a
filled order whose "Filled" row correctly shows a real quantity.

Three independent gaps, all in the order data path:

1. **Server never mapped it.** `fetchBitunixPendingOrders()`/
   `fetchBitunixHistoryOrders()` (`src/routes/api/orders/+server.ts`) built
   `NormalizedOrder` without `leverage`, `marginMode`, `positionMode`,
   `mtime`, or the six TP/SL fields — even though Bitunix documents all of
   them on both endpoints and `NormalizedOrder` already declared the fields
   to hold them.
2. **The Orders-tab store type dropped them again.** `OpenOrder`
   (`src/stores/account.svelte.ts`) had no fields for any of this, so
   `hydrateOpenOrders()` silently discarded whatever the server started
   sending, and `updateOrderFromWs()` had nowhere to put the WS order
   channel's equivalent fields (which use `positionType` for margin mode,
   not `marginMode` — confirmed against the docs, not a typo to unify).
   Only affected the pending Orders tab; History reads the server response
   directly and is fixed by #1 alone.
3. **The tooltip read the wrong field names.** `order.qty` doesn't exist on
   `NormalizedOrder` (only `order.amount` does), and the "Created" row read
   `order.ctime` instead of `order.time`.

## Fix

- `src/routes/api/orders/+server.ts`: both mapping functions now include
  the previously-dropped fields.
- `src/stores/account.svelte.ts`: extended `OpenOrder`/`RawWsOrder`;
  `updateOrderFromWs()` preserves the fields across a push that omits them
  (same pattern as `liquidationPrice`/`markPrice` on positions).
- `PositionsSidebar.svelte`: threads them through to the tooltip.
- `OrderDetailsTooltip.svelte`: reads the correct field names.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — 1071 passed, 6 skipped (full suite, no regressions)
- [x] New tests: server-side mapping for both pending/history
      (`orders_leverage_marginmode.test.ts`), store-level hydration + WS
      update/preservation (`account.test.ts`)
- [x] `npm run backlog:check` — index up to date, front matter valid
- [ ] Manual verification against a live/test Bitunix account — not done in
      this sandbox, no live keys available

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_