### PR TITLE
fix: closing a position 500s on a HEDGE-mode account (BUG-0062)

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-61 items. How to read and add them: [README.md](README.md).
+62 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 23
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 24
 
 ---
 
@@ -51,6 +51,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 23
 | --- | --- | --- | --- | --- |
 | [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | trade-panel |
 | [BUG-0060](bugs/BUG-0060-positions-account-envelope-mismatch.md) | PositionsSidebar reads /api/positions and /api/account through the wrong response envelope | P0 | ✅ done | trade-panel |
+| [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) | Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId) | P0 | ✅ done | trade-panel |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | trade-panel |
 | [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | trade-panel |
 | [FEAT-0020](features/FEAT-0020-account-settings-panel.md) | Show and change exchange account settings from Cachy | P1 | 📋 specced | trade-panel |
@@ -137,6 +138,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 23
 | [BUG-0053](bugs/BUG-0053-device-key-loss-orphans-secrets.md) | A lost or regenerated IndexedDB device key silently orphans every encrypted secret | P0 | 📋 specced | M0 | community, pro, private | A | none | — |
 | [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0060](bugs/BUG-0060-positions-account-envelope-mismatch.md) | PositionsSidebar reads /api/positions and /api/account through the wrong response envelope | P0 | ✅ done | M3 | community, pro, private | none | none | — |
+| [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) | Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId) | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
@@ -196,4 +198,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 23
 
 ---
 
-Next free number: **0062**
+Next free number: **0063**

--- a/docs/backlog/bugs/BUG-0062-hedge-mode-close-position-fails.md
+++ b/docs/backlog/bugs/BUG-0062-hedge-mode-close-position-fails.md
@@ -1,0 +1,112 @@
+---
+id: BUG-0062
+title: Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId)
+type: bug
+status: done
+priority: P0
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: []
+---
+
+# BUG-0062 — Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId)
+
+## Symptom
+
+Reported live: clicking "Close" on an open position in the Positions tab
+does nothing visible. The browser console shows `Failed to load resource:
+the server responded with a status of 500 (Internal Server Error)`.
+Cancelling a pending order (Orders tab) works fine with the same account.
+
+## Evidence
+
+**Demonstrated + confirmed against Bitunix's documented API contract.**
+
+The reporting account is in **HEDGE** mode (confirmed via the Account
+Summary tooltip's "Mode: HEDGE", already fixed by BUG-0060). Bitunix's
+`Place Order` endpoint documents (`docs/bitunix-api/07_trade.md:583-584`):
+
+| Parameter | Required | Description |
+|---|---|---|
+| `tradeSide` | **Nur im Hedge-Modus erforderlich** | `OPEN`/`CLOSE`. Close Long: `side=BUY, tradeSide=CLOSE`. Close Short: `side=SELL, tradeSide=CLOSE` |
+| `positionId` | Required when `tradeSide=CLOSE` | identifies *which* position — a HEDGE-mode symbol can carry both a long and a short position at once |
+
+Neither `closePosition()` nor `flashClosePosition()`
+(`src/services/tradeService.ts`) ever sent `tradeSide` or `positionId` —
+and both used the ONE_WAY-only `side` convention (the *inverted* execution
+direction: close-long → `SELL`) unconditionally, which is the wrong value
+for `side` in HEDGE mode too (there it identifies the position, not the
+trade direction — `side=BUY` for closing a **long**). Bitunix legitimately
+rejects an order missing required fields; that rejection was thrown as an
+`Error` in `placeBitunixOrder()` (`src/routes/api/orders/+server.ts`) and
+caught by the route's outer handler, which converts **any** thrown error —
+a genuine bug or an expected exchange-side rejection alike — into an HTTP
+500 with the real reason in the (JSON) body.
+
+A second, independent bug hid the diagnosis: `handleClosePosition()`
+(`src/components/shared/PositionsSidebar.svelte`) had a bare `catch {}`
+that discarded the caught error entirely and always showed a fixed generic
+toast — the exchange's actual rejection reason was never visible, even
+though the sibling `handleCancelOrder()` already used
+`getDisplayMessage(e)` correctly for the same class of error.
+
+A third gap made the fix impossible without first fixing the data path:
+`positionId`/`positionMode` are present on Bitunix's raw position payload
+(REST and WS) but were dropped at **two** points before reaching
+`tradeService.ts`: `PositionRawSchema` (`src/types/apiSchemas.ts`) didn't
+declare either field (Zod silently strips undeclared keys), and
+`OMSPosition` (`src/services/omsTypes.ts`) had no fields for them either —
+so even a correct `mapToOMSPosition()` would have had nothing to map.
+
+## Fix
+
+1. `PositionRawSchema`: added `positionId`/`positionMode`.
+2. `OMSPosition`: added `positionId?: string` and
+   `positionMode?: "one_way" | "hedge"`.
+3. `mapToOMSPosition()`: maps both, normalizing `positionMode` to
+   lowercase.
+4. `PlaceOrderSchema` / `BitunixOrderPayload`: added optional
+   `tradeSide`/`positionId`.
+5. `/api/orders/+server.ts`'s place-order branch: forwards both to
+   `placeBitunixOrder()`.
+6. `tradeService.ts`: new `buildCloseOrderFields()` computes the correct
+   `side` (and `tradeSide`/`positionId` when applicable) from
+   `position.positionMode` — **only** switches to the HEDGE-mode shape when
+   `positionMode === "hedge"` is confirmed; falls back to the original
+   ONE_WAY-only behavior (inverted `side`, no `tradeSide`/`positionId`)
+   whenever the mode can't be determined, since that was the only shape
+   this ever sent and must not silently change for accounts already working
+   correctly. Used by both `closePosition()` and `flashClosePosition()`.
+7. `handleClosePosition()`: uses `getDisplayMessage(e)` instead of
+   discarding the caught error, matching `handleCancelOrder()`.
+
+## Acceptance criteria
+
+- [x] `closePosition()`/`flashClosePosition()` send `side` matching the
+      position (not inverted) plus `tradeSide: "CLOSE"` and `positionId`
+      when `positionMode === "hedge"`
+- [x] Both send the original inverted-`side`-only shape, with no
+      `tradeSide`/`positionId`, when `positionMode` is unknown (regression
+      guard — must not change behavior for the case that was already
+      working)
+- [x] `PositionRawSchema` preserves `positionId`/`positionMode` through
+      parsing
+- [x] `/api/orders` forwards `tradeSide`/`positionId` to Bitunix when
+      provided, and omits both entirely when not
+- [x] A close failure shows the exchange's actual message, not a fixed
+      generic string
+- [x] `npm run check` and the full Vitest suite pass
+
+## Links
+
+- `src/services/tradeService.ts` — `buildCloseOrderFields()`,
+  `closePosition()`, `flashClosePosition()`
+- `src/services/mappers.ts`, `src/services/omsTypes.ts`
+- `src/types/apiSchemas.ts` — `PositionRawSchema`
+- `src/types/orderSchemas.ts` — `PlaceOrderSchema`
+- `src/routes/api/orders/+server.ts`
+- `src/components/shared/PositionsSidebar.svelte` — `handleClosePosition()`
+- `docs/bitunix-api/07_trade.md:564-619` ("Place Order")

--- a/src/components/shared/PositionsSidebar.svelte
+++ b/src/components/shared/PositionsSidebar.svelte
@@ -522,8 +522,14 @@
         );
         // Trigger refresh or wait for WS
       }
-    } catch {
-      uiState.showError($_("dashboard.alerts.failedClose"));
+    } catch (e: unknown) {
+      // Previously discarded `e` entirely and showed a fixed generic
+      // message — the exchange's actual rejection reason (e.g. a HEDGE-mode
+      // account rejecting a close that's missing tradeSide/positionId, see
+      // BUG-0062) was never visible to the user. Same pattern
+      // handleCancelOrder already used correctly below.
+      const msg = getDisplayMessage(e);
+      uiState.showError(msg || $_("dashboard.alerts.failedClose"));
     }
   }
 

--- a/src/routes/api/orders/+server.ts
+++ b/src/routes/api/orders/+server.ts
@@ -133,6 +133,9 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
           price: payload.price,
           reduceOnly: Boolean(payload.reduceOnly),
           triggerPrice: payload.triggerPrice || payload.stopPrice,
+          // HEDGE-mode close (BUG-0062) — see PlaceOrderSchema's comment.
+          tradeSide: payload.tradeSide,
+          positionId: payload.positionId,
         };
         // Remove undefined safe
         const cleanedPayload = cleanPayload(orderPayload);

--- a/src/routes/api/orders/orders_place_order_hedge.test.ts
+++ b/src/routes/api/orders/orders_place_order_hedge.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./+server";
+import * as clientToken from "../../../lib/server/clientToken";
+
+// Regression (BUG-0062): PlaceOrderSchema didn't declare tradeSide/
+// positionId, so the route silently dropped them from the request body
+// before forwarding to Bitunix — a HEDGE-mode close order was always
+// missing both fields, which Bitunix requires (docs/bitunix-api/
+// 07_trade.md:583-584) and rejects the order without them.
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const getClientAddress = () => "127.0.0.1";
+
+function makeRequest(body: unknown): Request {
+  return {
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(clientToken, "checkClientToken").mockReturnValue(null);
+  fetchMock.mockResolvedValue({
+    ok: true,
+    text: async () => JSON.stringify({ code: 0, data: { orderId: "1" }, msg: "Success" }),
+  });
+});
+
+describe("POST /api/orders place-order forwards tradeSide/positionId", () => {
+  it("includes tradeSide and positionId in the outbound Bitunix request when provided", async () => {
+    await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "place-order",
+        symbol: "XRPUSDT",
+        side: "BUY",
+        orderType: "MARKET",
+        qty: "9.1",
+        reduceOnly: true,
+        tradeSide: "CLOSE",
+        positionId: "662491704776252252",
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    const [, options] = fetchMock.mock.calls[0];
+    const sentBody = JSON.parse(options.body as string);
+    expect(sentBody.tradeSide).toBe("CLOSE");
+    expect(sentBody.positionId).toBe("662491704776252252");
+  });
+
+  it("omits tradeSide/positionId entirely when not provided (ONE_WAY mode)", async () => {
+    await POST({
+      request: makeRequest({
+        exchange: "bitunix",
+        type: "place-order",
+        symbol: "XRPUSDT",
+        side: "SELL",
+        orderType: "MARKET",
+        qty: "9.1",
+        reduceOnly: true,
+        apiKey: "validApiKey123",
+        apiSecret: "validSecret123456",
+      }),
+      getClientAddress,
+    } as unknown as Parameters<typeof POST>[0]);
+
+    const [, options] = fetchMock.mock.calls[0];
+    const sentBody = JSON.parse(options.body as string);
+    expect(sentBody.tradeSide).toBeUndefined();
+    expect(sentBody.positionId).toBeUndefined();
+  });
+});

--- a/src/services/mappers.test.ts
+++ b/src/services/mappers.test.ts
@@ -79,6 +79,31 @@ describe("Mappers", () => {
             const result = mapToOMSPosition(raw);
             expect(result.entryPrice.toString()).toBe("200");
         });
+
+        // Regression (BUG-0062): closePosition()/flashClosePosition() need
+        // positionId/positionMode to close a HEDGE-mode position correctly.
+        // Both are present on Bitunix's raw position payload but were
+        // silently dropped before reaching OMSPosition.
+        it("carries positionId through and normalizes positionMode to lowercase", () => {
+            const result = mapToOMSPosition({
+                symbol: "BTCUSDT",
+                positionId: "662491704776252252",
+                positionMode: "HEDGE",
+            });
+            expect(result.positionId).toBe("662491704776252252");
+            expect(result.positionMode).toBe("hedge");
+        });
+
+        it("normalizes ONE_WAY to one_way", () => {
+            const result = mapToOMSPosition({ symbol: "BTCUSDT", positionMode: "ONE_WAY" });
+            expect(result.positionMode).toBe("one_way");
+        });
+
+        it("leaves positionId/positionMode undefined when absent", () => {
+            const result = mapToOMSPosition({ symbol: "BTCUSDT" });
+            expect(result.positionId).toBeUndefined();
+            expect(result.positionMode).toBeUndefined();
+        });
     });
 
     describe("mapToOMSOrder", () => {

--- a/src/services/mappers.ts
+++ b/src/services/mappers.ts
@@ -79,7 +79,11 @@ export function mapToOMSPosition(data: any): OMSPosition {
         margin: parseDecimalOrUndefined(data.margin || data.isolatedMargin || data.crossMargin),
         markPrice: parseDecimalOrUndefined(data.markPrice),
         size: amount,
-        lastUpdated: Date.now()
+        lastUpdated: Date.now(),
+        positionId: data.positionId !== undefined ? String(data.positionId) : undefined,
+        positionMode: data.positionMode
+            ? (String(data.positionMode).toUpperCase() === "HEDGE" ? "hedge" : "one_way")
+            : undefined,
     };
 }
 

--- a/src/services/omsTypes.ts
+++ b/src/services/omsTypes.ts
@@ -63,4 +63,10 @@ export interface OMSPosition {
     // funding excluded) — live via WS on Bitunix, REST-snapshot-only
     // elsewhere.
     realizedPnl?: Decimal;
+    // Needed to close a position correctly (BUG-0062): Bitunix's place_order
+    // requires positionId whenever tradeSide="CLOSE", and tradeSide itself
+    // is required in HEDGE mode — closePosition()/flashClosePosition() use
+    // positionMode to decide which order shape to send.
+    positionId?: string;
+    positionMode?: "one_way" | "hedge";
 }

--- a/src/services/tradeService.ts
+++ b/src/services/tradeService.ts
@@ -247,10 +247,16 @@ class TradeService {
             }
 
             // 2. Execute Close
-            // Close Long -> Sell
-            // Close Short -> Buy
+            // True execution direction, for local optimistic-order bookkeeping
+            // only — accurate regardless of account mode. The API payload's
+            // own `side` (and whether tradeSide/positionId are needed) is
+            // mode-dependent; see buildCloseOrderFields.
             const side: OMSOrderSide = positionSide === "long" ? "sell" : "buy";
-            const apiSide = side === "sell" ? "SELL" : "BUY";
+            const { side: apiSide, tradeSide, positionId } = this.buildCloseOrderFields(
+                positionSide,
+                position.positionMode,
+                position.positionId,
+            );
 
             // CRITICAL: Use exact amount from OMS
             if (!position.amount || position.amount.isZero() || position.amount.isNegative()) {
@@ -295,7 +301,8 @@ class TradeService {
                 orderType: "MARKET",
                 qty,
                 reduceOnly: true,
-                clientOrderId
+                clientOrderId,
+                ...(tradeSide ? { tradeSide, positionId } : {}),
             });
 
             return { success: true, data: result };
@@ -449,6 +456,39 @@ class TradeService {
         }
     }
 
+    /**
+     * Bitunix's place_order needs a different payload shape to close a
+     * position depending on account mode (docs/bitunix-api/07_trade.md:
+     * 583-584, see BUG-0062):
+     *  - ONE_WAY (the default, and the only shape this ever sent before
+     *    BUG-0062): `side` is the literal execution direction — closing a
+     *    long means selling — and `tradeSide`/`positionId` are absent.
+     *  - HEDGE: `side` instead identifies *which* position (BUY = the long
+     *    side, SELL = the short side, matching the position's own side, not
+     *    inverted), and `tradeSide: "CLOSE"` + `positionId` are required to
+     *    disambiguate from opening — a symbol can carry both a long and a
+     *    short position at once.
+     *
+     * Falls back to the ONE_WAY shape whenever positionMode can't be
+     * determined (e.g. no REST-hydrated position yet), since that was the
+     * only behavior this ever had — never silently switch shapes without
+     * being sure.
+     */
+    private buildCloseOrderFields(
+        positionSide: "long" | "short",
+        positionMode: "one_way" | "hedge" | undefined,
+        positionId: string | undefined,
+    ): { side: "BUY" | "SELL"; tradeSide?: "CLOSE"; positionId?: string } {
+        if (positionMode === "hedge") {
+            return {
+                side: positionSide === "long" ? "BUY" : "SELL",
+                tradeSide: "CLOSE",
+                positionId,
+            };
+        }
+        return { side: positionSide === "long" ? "SELL" : "BUY" };
+    }
+
     public async closePosition(params: { symbol: string, positionSide: "long" | "short", amount?: Decimal, forceFullClose?: boolean }) {
         const { symbol, positionSide, amount, forceFullClose } = params;
 
@@ -459,7 +499,11 @@ class TradeService {
             throw new Error(TRADE_ERRORS.POSITION_NOT_FOUND);
         }
 
-        const side = positionSide === "long" ? "SELL" : "BUY";
+        const { side, tradeSide, positionId } = this.buildCloseOrderFields(
+            positionSide,
+            position.positionMode,
+            position.positionId,
+        );
 
         // Use explicit amount or full position amount
         // If explicit amount is provided, use it.
@@ -478,7 +522,8 @@ class TradeService {
             side,
             orderType: "MARKET",
             qty,
-            reduceOnly: true
+            reduceOnly: true,
+            ...(tradeSide ? { tradeSide, positionId } : {}),
         });
     }
 

--- a/src/services/tradeService_hedgeClose.test.ts
+++ b/src/services/tradeService_hedgeClose.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tradeService } from "./tradeService";
+import { omsService } from "./omsService";
+import { Decimal } from "decimal.js";
+
+// Regression (BUG-0062): closing a position on a HEDGE-mode account 500'd
+// with no usable error message. Root cause: Bitunix's place_order requires
+// `tradeSide: "CLOSE"` (and, with it, `positionId`) whenever the account is
+// in HEDGE mode — a symbol can carry both a long and a short position at
+// once, so `side` alone doesn't disambiguate — but neither closePosition()
+// nor flashClosePosition() ever sent either field, and `side` itself needs
+// to mean something different in HEDGE mode (the position's own side, not
+// inverted) per docs/bitunix-api/07_trade.md:583-584.
+
+vi.mock("./omsService", () => ({
+  omsService: {
+    getPositions: vi.fn(),
+    updatePosition: vi.fn(),
+    addOptimisticOrder: vi.fn(),
+    removeOrder: vi.fn(),
+    getOrder: vi.fn(),
+    updateOrder: vi.fn(),
+  },
+}));
+
+vi.mock("../stores/settings.svelte", () => ({
+  settingsState: {
+    apiProvider: "bitunix",
+    apiKeys: { bitunix: { key: "test", secret: "test" } },
+    appAccessToken: "test-token",
+    secretsReady: Promise.resolve(),
+  },
+}));
+
+vi.mock("../stores/market.svelte", async () => {
+  const { Decimal } = await import("decimal.js");
+  return {
+    marketState: { data: { XRPUSDT: { lastPrice: new Decimal(1.05) } } },
+  };
+});
+
+vi.mock("./logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), log: vi.fn(), debug: vi.fn() },
+}));
+
+describe("TradeService close-order fields by account mode (BUG-0062)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ code: "0", data: { orderId: "1" } }),
+      json: async () => ({ code: "0", data: { orderId: "1" } }),
+    } as Response);
+  });
+
+  function lastBody(): Record<string, unknown> {
+    const calls = fetchSpy.mock.calls;
+    const call = calls[calls.length - 1];
+    return JSON.parse(call[1]?.body as string);
+  }
+
+  describe("closePosition", () => {
+    it("sends tradeSide=CLOSE and positionId, with side matching the position (not inverted), in HEDGE mode", async () => {
+      vi.mocked(omsService.getPositions).mockReturnValue([
+        {
+          symbol: "XRPUSDT",
+          side: "long",
+          amount: new Decimal(9.1),
+          lastUpdated: Date.now(),
+          positionId: "662491704776252252",
+          positionMode: "hedge",
+        },
+      ]);
+
+      await tradeService.closePosition({
+        symbol: "XRPUSDT",
+        positionSide: "long",
+        forceFullClose: true,
+      });
+
+      const body = lastBody();
+      expect(body.side).toBe("BUY");
+      expect(body.tradeSide).toBe("CLOSE");
+      expect(body.positionId).toBe("662491704776252252");
+    });
+
+    it("sends the inverted side with no tradeSide/positionId when positionMode is unknown (unchanged behavior)", async () => {
+      vi.mocked(omsService.getPositions).mockReturnValue([
+        {
+          symbol: "XRPUSDT",
+          side: "long",
+          amount: new Decimal(9.1),
+          lastUpdated: Date.now(),
+        },
+      ]);
+
+      await tradeService.closePosition({
+        symbol: "XRPUSDT",
+        positionSide: "long",
+        forceFullClose: true,
+      });
+
+      const body = lastBody();
+      expect(body.side).toBe("SELL");
+      expect(body.tradeSide).toBeUndefined();
+      expect(body.positionId).toBeUndefined();
+    });
+
+    it("uses SELL (not BUY) to close a short position in HEDGE mode", async () => {
+      vi.mocked(omsService.getPositions).mockReturnValue([
+        {
+          symbol: "XRPUSDT",
+          side: "short",
+          amount: new Decimal(9.1),
+          lastUpdated: Date.now(),
+          positionId: "999",
+          positionMode: "hedge",
+        },
+      ]);
+
+      await tradeService.closePosition({
+        symbol: "XRPUSDT",
+        positionSide: "short",
+        forceFullClose: true,
+      });
+
+      const body = lastBody();
+      expect(body.side).toBe("SELL");
+      expect(body.tradeSide).toBe("CLOSE");
+    });
+  });
+
+  describe("flashClosePosition", () => {
+    it("sends tradeSide=CLOSE and positionId in HEDGE mode", async () => {
+      vi.mocked(omsService.getPositions).mockReturnValue([
+        {
+          symbol: "XRPUSDT",
+          side: "long",
+          amount: new Decimal(9.1),
+          lastUpdated: Date.now(),
+          positionId: "662491704776252252",
+          positionMode: "hedge",
+        },
+      ]);
+
+      await tradeService.flashClosePosition("XRPUSDT", "long");
+
+      const body = lastBody();
+      expect(body.side).toBe("BUY");
+      expect(body.tradeSide).toBe("CLOSE");
+      expect(body.positionId).toBe("662491704776252252");
+    });
+
+    it("sends the inverted side with no tradeSide/positionId when positionMode is unknown (unchanged behavior)", async () => {
+      vi.mocked(omsService.getPositions).mockReturnValue([
+        {
+          symbol: "XRPUSDT",
+          side: "long",
+          amount: new Decimal(9.1),
+          lastUpdated: Date.now(),
+        },
+      ]);
+
+      await tradeService.flashClosePosition("XRPUSDT", "long");
+
+      const body = lastBody();
+      expect(body.side).toBe("SELL");
+      expect(body.tradeSide).toBeUndefined();
+      expect(body.positionId).toBeUndefined();
+    });
+  });
+});

--- a/src/types/apiSchemas.test.ts
+++ b/src/types/apiSchemas.test.ts
@@ -16,7 +16,25 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { sanitizeErrorMessage } from './apiSchemas';
+import { sanitizeErrorMessage, PositionRawSchema } from './apiSchemas';
+
+// Regression (BUG-0062): PositionRawSchema didn't declare positionId/
+// positionMode, so Zod silently stripped both from a raw position object
+// before it reached mapToOMSPosition — closePosition() then had no way to
+// tell a HEDGE-mode account apart from ONE_WAY, or which position to
+// target.
+describe('PositionRawSchema', () => {
+  it('preserves positionId and positionMode', () => {
+    const result = PositionRawSchema.parse({
+      symbol: 'XRPUSDT',
+      qty: '9.1',
+      positionId: '662491704776252252',
+      positionMode: 'HEDGE',
+    });
+    expect(result.positionId).toBe('662491704776252252');
+    expect(result.positionMode).toBe('HEDGE');
+  });
+});
 
 describe('sanitizeErrorMessage', () => {
   it('should redact simple key=value pairs', () => {

--- a/src/types/apiSchemas.ts
+++ b/src/types/apiSchemas.ts
@@ -124,7 +124,14 @@ export const PositionRawSchema = z.object({
     leverage: z.union([z.string(), z.number()]).optional(),
     marginMode: z.string().optional(),
     liquidationPrice: z.union([z.string(), z.number()]).optional(),
-    liqPrice: z.union([z.string(), z.number()]).optional()
+    liqPrice: z.union([z.string(), z.number()]).optional(),
+    // Bitunix sends both on Get Pending Positions (docs/bitunix-api/05_position.md)
+    // and the position WS channel. Without positionId/positionMode surviving
+    // this schema, closePosition()/flashClosePosition() can't tell a
+    // HEDGE-mode account from a ONE_WAY one, or which position to target —
+    // see BUG-0062.
+    positionId: z.union([z.string(), z.number()]).optional(),
+    positionMode: z.string().optional()
 }).refine(data => {
     // Hardening: A position must have at least one quantity field to be valid.
     // Otherwise it's likely a malformed response or an empty object from a weird API state.

--- a/src/types/bitunix.ts
+++ b/src/types/bitunix.ts
@@ -118,6 +118,9 @@ export interface BitunixOrderPayload {
   price?: string | number;
   reduceOnly?: boolean;
   leverage?: string | number;
+  // HEDGE-mode-only (docs/bitunix-api/07_trade.md:583-584) — see BUG-0062.
+  tradeSide?: "OPEN" | "CLOSE";
+  positionId?: string;
   [key: string]: unknown;
 }
 

--- a/src/types/orderSchemas.ts
+++ b/src/types/orderSchemas.ts
@@ -75,6 +75,12 @@ export const PlaceOrderSchema = BaseRequestSchema.extend({
       return false;
     }).optional().default(false),
   marginCoin: z.string().optional().default("USDT"), // For Bitget
+  // HEDGE-mode-only fields (docs/bitunix-api/07_trade.md:583-584): tradeSide
+  // is required to disambiguate OPEN vs CLOSE when a symbol can carry both a
+  // long and a short position at once; positionId is then required too, to
+  // say which one. Omitted entirely for ONE_WAY accounts — see BUG-0062.
+  tradeSide: z.enum(["OPEN", "CLOSE"]).optional(),
+  positionId: z.string().optional(),
 });
 
 // --- Close Position ---


### PR DESCRIPTION
## ⚠️ This changes real order-placement parameters — please test carefully before merging

This PR changes the payload sent to Bitunix's `place_order` endpoint for
closing a position. I'm confident in the fix (verified against
`docs/bitunix-api/07_trade.md`'s documented contract and covered by tests),
but I have no live Bitunix credentials in this sandbox to execute a real
close against. Please verify with a small test position before merging —
ideally the same account/position size you've been testing the rest of
this panel with.

## Summary

Root cause of "closing a position does nothing, console shows a 500":
the reporting account is in **HEDGE** mode. Bitunix's `place_order`
requires `tradeSide` ("OPEN"/"CLOSE") whenever the account is in HEDGE
mode — a symbol can carry both a long and a short position at once — and
`positionId` when `tradeSide=CLOSE`, to say which one
(`docs/bitunix-api/07_trade.md:583-584`):

| Parameter | Required | Description |
|---|---|---|
| `tradeSide` | Nur im Hedge-Modus erforderlich | `OPEN`/`CLOSE`. Close Long: `side=BUY, tradeSide=CLOSE`. Close Short: `side=SELL, tradeSide=CLOSE` |
| `positionId` | Required when `tradeSide=CLOSE` | identifies which position |

`closePosition()`/`flashClosePosition()` (`src/services/tradeService.ts`)
never sent either field, and used the ONE_WAY-only inverted `side`
convention unconditionally — which is also the wrong value for `side` in
HEDGE mode (there it identifies the position, not the trade direction).
Bitunix legitimately rejected the order; that rejection surfaced as an
HTTP 500 (the route converts **any** thrown error, real bug or expected
exchange rejection alike, into a 500 with the reason in the body) — but
`handleClosePosition()`'s bare `catch {}` discarded the caught error
entirely and always showed a fixed generic message, hiding the actual
reason. The sibling `handleCancelOrder()` (which is why cancelling an
order worked fine) already used `getDisplayMessage(e)` correctly for the
same class of error.

Getting `positionId`/`positionMode` to `tradeService.ts` required fixing
two more silent-drop points first: `PositionRawSchema` (Zod strips
undeclared keys) and `OMSPosition` (no fields for either) — both present on
Bitunix's raw position payload, both dropped before ever reaching the
close logic.

## Fix

- `PositionRawSchema`, `OMSPosition`, `mapToOMSPosition()`: thread
  `positionId`/`positionMode` through.
- `PlaceOrderSchema`, `BitunixOrderPayload`, `/api/orders`'s place-order
  branch: accept and forward `tradeSide`/`positionId`.
- `tradeService.ts`: new `buildCloseOrderFields()` computes the correct
  `side` (and `tradeSide`/`positionId` when applicable) from
  `position.positionMode` — **only** switches to the HEDGE-mode shape when
  `positionMode === "hedge"` is confirmed; falls back to the exact original
  ONE_WAY-only behavior whenever the mode is unknown, so accounts where
  this already worked are unaffected. Used by both `closePosition()` and
  `flashClosePosition()`.
- `handleClosePosition()`: shows the real error via `getDisplayMessage()`.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — 1082 passed, 6 skipped (full suite, no regressions)
- [x] New tests: `buildCloseOrderFields` behavior for both `closePosition`/
      `flashClosePosition` in HEDGE mode and in the unknown-mode fallback
      (`tradeService_hedgeClose.test.ts`), schema field preservation
      (`apiSchemas.test.ts`, `mappers.test.ts`), server-side forwarding
      (`orders_place_order_hedge.test.ts`)
- [x] `npm run backlog:check` — index up to date, front matter valid
- [ ] **Manual close of a small real position on the reporting HEDGE-mode
      account — not done in this sandbox, no live keys available. Please do
      this before merging.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_