### PR TITLE
fix: send tradeSide/positionId unconditionally when closing a position (BUG-0063)

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-62 items. How to read and add them: [README.md](README.md).
+63 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 24
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 25
 
 ---
 
@@ -52,6 +52,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 24
 | [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | trade-panel |
 | [BUG-0060](bugs/BUG-0060-positions-account-envelope-mismatch.md) | PositionsSidebar reads /api/positions and /api/account through the wrong response envelope | P0 | ✅ done | trade-panel |
 | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) | Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId) | P0 | ✅ done | trade-panel |
+| [BUG-0063](bugs/BUG-0063-close-position-500s-must-not-be-null.md) | Closing a position still 500s after BUG-0062 on a ONE_WAY/Isolated account | P0 | ✅ done | trade-panel |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | trade-panel |
 | [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | trade-panel |
 | [FEAT-0020](features/FEAT-0020-account-settings-panel.md) | Show and change exchange account settings from Cachy | P1 | 📋 specced | trade-panel |
@@ -139,6 +140,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 24
 | [BUG-0058](bugs/BUG-0058-ws-position-update-missing-qty-closes-position.md) | A WS position push that omits qty silently closes a still-open position | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0060](bugs/BUG-0060-positions-account-envelope-mismatch.md) | PositionsSidebar reads /api/positions and /api/account through the wrong response envelope | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) | Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId) | P0 | ✅ done | M3 | community, pro, private | none | none | — |
+| [BUG-0063](bugs/BUG-0063-close-position-500s-must-not-be-null.md) | Closing a position still 500s after BUG-0062 on a ONE_WAY/Isolated account | P0 | ✅ done | M3 | community, pro, private | none | none | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
@@ -198,4 +200,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 24
 
 ---
 
-Next free number: **0063**
+Next free number: **0064**

--- a/docs/backlog/bugs/BUG-0063-close-position-500s-must-not-be-null.md
+++ b/docs/backlog/bugs/BUG-0063-close-position-500s-must-not-be-null.md
@@ -1,0 +1,89 @@
+---
+id: BUG-0063
+title: Closing a position still 500s after BUG-0062 on a ONE_WAY/Isolated account
+type: bug
+status: done
+priority: P0
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: [BUG-0062]
+---
+
+# BUG-0063 — Closing a position still 500s after BUG-0062 on a ONE_WAY/Isolated account
+
+## Symptom
+
+Reported live, immediately after BUG-0062 (HEDGE-mode `tradeSide`/
+`positionId`) merged: clicking "Close" on an open position still fails.
+Browser console still shows `POST https://dev.cachy.app/api/orders 500
+(Internal Server Error)`, and the UI now additionally surfaces the
+exchange's real rejection reason (visible only because BUG-0062 also fixed
+`handleClosePosition()`'s swallowed-error bug): **"must not be null"**. The
+user confirmed the position under test was in **Isolated margin mode /
+ONE_WAY position mode** — not HEDGE.
+
+## Evidence
+
+**Demonstrated** — live 500 + "must not be null", confirmed against a
+ONE_WAY account, plus a re-read of the exact API contract.
+
+BUG-0062 read `docs/bitunix-api/07_trade.md:583`'s description text ("Nur
+im Hedge-Modus erforderlich") and concluded `tradeSide`/`positionId` could
+be omitted outside HEDGE mode — so `buildCloseOrderFields()`
+(`src/services/tradeService.ts`) only sent them when
+`position.positionMode === "hedge"`, falling back to the original
+inverted-`side`-only shape otherwise. That fallback is the exact shape this
+code sent before BUG-0062 too — closing was never confirmed working in that
+shape, only orders (a different endpoint/flow) were.
+
+Re-reading the same table more carefully: the **Required** column for
+`tradeSide` is `true` (`docs/bitunix-api/07_trade.md:32` and `:583`, both
+`place_order` and `batch_order`), with no mode qualifier on the column
+itself — only the description text carries the "Hedge-Modus" caveat, and
+that caveat describes when the *value* matters for disambiguation, not
+whether the *field* may be absent. `positionId`'s row says "Erforderlich,
+wenn `tradeSide` = `CLOSE`" — again no Hedge-only qualifier. The documented
+request example pairs `side=BUY` with `tradeSide=CLOSE` for "Close Long",
+i.e. `side` matches the position's own side, not inverted. Bitunix's
+backend rejecting a `place_order` missing these fields with a validation
+message ("must not be null") on a confirmed ONE_WAY account is consistent
+with the field being unconditionally required, contradicting only the
+description text BUG-0062 relied on.
+
+## Cause
+
+`buildCloseOrderFields()` only added `tradeSide`/`positionId` (and switched
+`side` to match the position instead of inverting it) when
+`positionMode === "hedge"`. Bitunix requires both fields for every close,
+regardless of position mode, so the ONE_WAY/unknown-mode branch kept
+sending a payload Bitunix rejects.
+
+## Fix
+
+`buildCloseOrderFields()` (`src/services/tradeService.ts`) now always
+returns `tradeSide: "CLOSE"` and `positionId` (when known), with `side`
+matching the position's own side (BUY closes a long, SELL closes a short)
+— the `positionMode` branch is removed entirely. `positionMode` stays on
+`OMSPosition` for display purposes only (Account Summary "Mode:
+HEDGE/ONE_WAY").
+
+## Acceptance criteria
+
+- [x] `closePosition()`/`flashClosePosition()` send `tradeSide: "CLOSE"`
+      and `positionId` (when known) for both HEDGE and ONE_WAY/unknown-mode
+      positions
+- [x] `side` matches the position (not inverted) in both cases
+- [x] `npm run check` and the full Vitest suite pass (updated
+      `tradeService_hedgeClose.test.ts`,
+      `tradeService_flashClose_hardening.test.ts`, `tradeService_safety.test.ts`,
+      `src/tests/flash-close.test.ts`, `src/tests/flash_close_race_repro.test.ts`
+      — all previously asserted the now-corrected inverted-`side`-only shape)
+
+## Links
+
+- `src/services/tradeService.ts` — `buildCloseOrderFields()`
+- `docs/bitunix-api/07_trade.md:32,583-584` ("Place Order" / "Batch Order")
+- `docs/backlog/bugs/BUG-0062-hedge-mode-close-position-fails.md`

--- a/src/services/omsTypes.ts
+++ b/src/services/omsTypes.ts
@@ -63,10 +63,11 @@ export interface OMSPosition {
     // funding excluded) — live via WS on Bitunix, REST-snapshot-only
     // elsewhere.
     realizedPnl?: Decimal;
-    // Needed to close a position correctly (BUG-0062): Bitunix's place_order
-    // requires positionId whenever tradeSide="CLOSE", and tradeSide itself
-    // is required in HEDGE mode — closePosition()/flashClosePosition() use
-    // positionMode to decide which order shape to send.
+    // Needed to close a position correctly (BUG-0062/BUG-0063): Bitunix's
+    // place_order requires both tradeSide="CLOSE" and positionId
+    // unconditionally to close a position — see buildCloseOrderFields() in
+    // tradeService.ts. positionMode itself is display-only now (Account
+    // Summary "Mode: HEDGE/ONE_WAY").
     positionId?: string;
     positionMode?: "one_way" | "hedge";
 }

--- a/src/services/tradeService.ts
+++ b/src/services/tradeService.ts
@@ -248,13 +248,11 @@ class TradeService {
 
             // 2. Execute Close
             // True execution direction, for local optimistic-order bookkeeping
-            // only — accurate regardless of account mode. The API payload's
-            // own `side` (and whether tradeSide/positionId are needed) is
-            // mode-dependent; see buildCloseOrderFields.
+            // only — the API payload's own `side` matches the position side
+            // instead (not inverted); see buildCloseOrderFields.
             const side: OMSOrderSide = positionSide === "long" ? "sell" : "buy";
             const { side: apiSide, tradeSide, positionId } = this.buildCloseOrderFields(
                 positionSide,
-                position.positionMode,
                 position.positionId,
             );
 
@@ -302,7 +300,8 @@ class TradeService {
                 qty,
                 reduceOnly: true,
                 clientOrderId,
-                ...(tradeSide ? { tradeSide, positionId } : {}),
+                tradeSide,
+                positionId,
             });
 
             return { success: true, data: result };
@@ -457,36 +456,31 @@ class TradeService {
     }
 
     /**
-     * Bitunix's place_order needs a different payload shape to close a
-     * position depending on account mode (docs/bitunix-api/07_trade.md:
-     * 583-584, see BUG-0062):
-     *  - ONE_WAY (the default, and the only shape this ever sent before
-     *    BUG-0062): `side` is the literal execution direction — closing a
-     *    long means selling — and `tradeSide`/`positionId` are absent.
-     *  - HEDGE: `side` instead identifies *which* position (BUY = the long
-     *    side, SELL = the short side, matching the position's own side, not
-     *    inverted), and `tradeSide: "CLOSE"` + `positionId` are required to
-     *    disambiguate from opening — a symbol can carry both a long and a
-     *    short position at once.
-     *
-     * Falls back to the ONE_WAY shape whenever positionMode can't be
-     * determined (e.g. no REST-hydrated position yet), since that was the
-     * only behavior this ever had — never silently switch shapes without
-     * being sure.
+     * Bitunix's place_order/batch_order docs (docs/bitunix-api/07_trade.md:
+     * 32/583) list `tradeSide` as unconditionally `Required: true` — the
+     * "nur im Hedge-Modus erforderlich" wording only describes when the
+     * value matters for disambiguation, not when the field may be omitted.
+     * BUG-0062 trusted the wording and only sent `tradeSide`/`positionId`
+     * when `positionMode === "hedge"`, falling back to the old
+     * inverted-`side`-only shape otherwise — confirmed live (BUG-0063) that
+     * this fallback still 500s with "must not be null" on a ONE_WAY
+     * account, so it was never a working shape to begin with. `positionId`
+     * is documented as required whenever `tradeSide = CLOSE`, again with no
+     * Hedge-only qualifier, so it's sent unconditionally too. `side`
+     * matches the position's own side (BUY closes a long, SELL closes a
+     * short) per the documented request example — not inverted — since
+     * `tradeSide`/`positionId` now carry the open/close and which-position
+     * disambiguation in all modes.
      */
     private buildCloseOrderFields(
         positionSide: "long" | "short",
-        positionMode: "one_way" | "hedge" | undefined,
         positionId: string | undefined,
-    ): { side: "BUY" | "SELL"; tradeSide?: "CLOSE"; positionId?: string } {
-        if (positionMode === "hedge") {
-            return {
-                side: positionSide === "long" ? "BUY" : "SELL",
-                tradeSide: "CLOSE",
-                positionId,
-            };
-        }
-        return { side: positionSide === "long" ? "SELL" : "BUY" };
+    ): { side: "BUY" | "SELL"; tradeSide: "CLOSE"; positionId?: string } {
+        return {
+            side: positionSide === "long" ? "BUY" : "SELL",
+            tradeSide: "CLOSE",
+            positionId,
+        };
     }
 
     public async closePosition(params: { symbol: string, positionSide: "long" | "short", amount?: Decimal, forceFullClose?: boolean }) {
@@ -501,7 +495,6 @@ class TradeService {
 
         const { side, tradeSide, positionId } = this.buildCloseOrderFields(
             positionSide,
-            position.positionMode,
             position.positionId,
         );
 
@@ -523,7 +516,8 @@ class TradeService {
             orderType: "MARKET",
             qty,
             reduceOnly: true,
-            ...(tradeSide ? { tradeSide, positionId } : {}),
+            tradeSide,
+            positionId,
         });
     }
 

--- a/src/services/tradeService_flashClose_hardening.test.ts
+++ b/src/services/tradeService_flashClose_hardening.test.ts
@@ -98,11 +98,13 @@ describe('TradeService Flash Close Vulnerability', () => {
         // Verify cancel was called
         expect(cancelSpy).toHaveBeenCalledWith('BTCUSDT', true);
 
-        // Verify close order WAS called (despite abort)
+        // Verify close order WAS called (despite abort). Closing a long:
+        // side matches the position (BUY), not inverted — see
+        // buildCloseOrderFields (BUG-0062/BUG-0063).
         expect(requestSpy).toHaveBeenCalledWith(
             'POST',
             '/api/orders',
-            expect.objectContaining({ side: 'SELL', orderType: 'MARKET', reduceOnly: true })
+            expect.objectContaining({ side: 'BUY', tradeSide: 'CLOSE', orderType: 'MARKET', reduceOnly: true })
         );
     });
 });

--- a/src/services/tradeService_hedgeClose.test.ts
+++ b/src/services/tradeService_hedgeClose.test.ts
@@ -20,14 +20,17 @@ import { tradeService } from "./tradeService";
 import { omsService } from "./omsService";
 import { Decimal } from "decimal.js";
 
-// Regression (BUG-0062): closing a position on a HEDGE-mode account 500'd
-// with no usable error message. Root cause: Bitunix's place_order requires
-// `tradeSide: "CLOSE"` (and, with it, `positionId`) whenever the account is
-// in HEDGE mode — a symbol can carry both a long and a short position at
-// once, so `side` alone doesn't disambiguate — but neither closePosition()
-// nor flashClosePosition() ever sent either field, and `side` itself needs
-// to mean something different in HEDGE mode (the position's own side, not
-// inverted) per docs/bitunix-api/07_trade.md:583-584.
+// Regression (BUG-0062/BUG-0063): closing a position 500'd with "must not
+// be null" for every account, HEDGE or ONE_WAY alike. Root cause: Bitunix's
+// place_order docs (docs/bitunix-api/07_trade.md:32/583) list `tradeSide` as
+// unconditionally `Required: true`, and `positionId` as required whenever
+// `tradeSide = CLOSE` — neither is scoped to HEDGE mode, despite the
+// description text ("nur im Hedge-Modus erforderlich") suggesting otherwise.
+// BUG-0062 trusted that text and only sent tradeSide/positionId when
+// positionMode === "hedge", so ONE_WAY accounts (confirmed live, BUG-0063)
+// kept 500ing exactly as before. The fix sends tradeSide="CLOSE" and
+// positionId unconditionally, with `side` matching the position's own side
+// (not inverted) per the documented request example.
 
 vi.mock("./omsService", () => ({
   omsService: {
@@ -60,7 +63,7 @@ vi.mock("./logger", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), log: vi.fn(), debug: vi.fn() },
 }));
 
-describe("TradeService close-order fields by account mode (BUG-0062)", () => {
+describe("TradeService close-order fields (BUG-0062/BUG-0063)", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -103,7 +106,31 @@ describe("TradeService close-order fields by account mode (BUG-0062)", () => {
       expect(body.positionId).toBe("662491704776252252");
     });
 
-    it("sends the inverted side with no tradeSide/positionId when positionMode is unknown (unchanged behavior)", async () => {
+    it("sends tradeSide=CLOSE and positionId, with side matching the position (not inverted), in ONE_WAY mode too", async () => {
+      vi.mocked(omsService.getPositions).mockReturnValue([
+        {
+          symbol: "XRPUSDT",
+          side: "long",
+          amount: new Decimal(9.1),
+          lastUpdated: Date.now(),
+          positionId: "662491704776252252",
+          positionMode: "one_way",
+        },
+      ]);
+
+      await tradeService.closePosition({
+        symbol: "XRPUSDT",
+        positionSide: "long",
+        forceFullClose: true,
+      });
+
+      const body = lastBody();
+      expect(body.side).toBe("BUY");
+      expect(body.tradeSide).toBe("CLOSE");
+      expect(body.positionId).toBe("662491704776252252");
+    });
+
+    it("still sends tradeSide=CLOSE when positionMode is unknown, omitting positionId only if truly absent", async () => {
       vi.mocked(omsService.getPositions).mockReturnValue([
         {
           symbol: "XRPUSDT",
@@ -120,12 +147,12 @@ describe("TradeService close-order fields by account mode (BUG-0062)", () => {
       });
 
       const body = lastBody();
-      expect(body.side).toBe("SELL");
-      expect(body.tradeSide).toBeUndefined();
+      expect(body.side).toBe("BUY");
+      expect(body.tradeSide).toBe("CLOSE");
       expect(body.positionId).toBeUndefined();
     });
 
-    it("uses SELL (not BUY) to close a short position in HEDGE mode", async () => {
+    it("uses SELL (not BUY) to close a short position", async () => {
       vi.mocked(omsService.getPositions).mockReturnValue([
         {
           symbol: "XRPUSDT",
@@ -170,22 +197,24 @@ describe("TradeService close-order fields by account mode (BUG-0062)", () => {
       expect(body.positionId).toBe("662491704776252252");
     });
 
-    it("sends the inverted side with no tradeSide/positionId when positionMode is unknown (unchanged behavior)", async () => {
+    it("sends tradeSide=CLOSE and positionId in ONE_WAY mode too", async () => {
       vi.mocked(omsService.getPositions).mockReturnValue([
         {
           symbol: "XRPUSDT",
           side: "long",
           amount: new Decimal(9.1),
           lastUpdated: Date.now(),
+          positionId: "662491704776252252",
+          positionMode: "one_way",
         },
       ]);
 
       await tradeService.flashClosePosition("XRPUSDT", "long");
 
       const body = lastBody();
-      expect(body.side).toBe("SELL");
-      expect(body.tradeSide).toBeUndefined();
-      expect(body.positionId).toBeUndefined();
+      expect(body.side).toBe("BUY");
+      expect(body.tradeSide).toBe("CLOSE");
+      expect(body.positionId).toBe("662491704776252252");
     });
   });
 });

--- a/src/services/tradeService_safety.test.ts
+++ b/src/services/tradeService_safety.test.ts
@@ -164,9 +164,12 @@ describe("TradeService Safety - Flash Close", () => {
 
         // 5. Assert close request WAS sent (capital preservation > clean state)
         expect(result.success).toBe(true);
+        // Closing a long: side matches the position (BUY), not inverted —
+        // see buildCloseOrderFields (BUG-0062/BUG-0063).
         expect(requestSpy).toHaveBeenCalledWith("POST", "/api/orders", expect.objectContaining({
             symbol: "BTCUSDT",
-            side: "SELL",
+            side: "BUY",
+            tradeSide: "CLOSE",
             reduceOnly: true
         }));
     });

--- a/src/tests/flash-close.test.ts
+++ b/src/tests/flash-close.test.ts
@@ -150,7 +150,7 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
 
         // [HARDENING FIX] Now that we call cancelAllOrders first, we must find the CLOSE order
         const calls = signedRequestSpy.mock.calls;
-        const callArgs = calls.find((c) => c[2] && c[2].side === 'SELL');
+        const callArgs = calls.find((c) => c[2] && c[2].side === 'BUY');
 
         if (!callArgs) {
             throw new Error(`Flash close order not found in ${calls.length} calls: ${JSON.stringify(calls)}`);
@@ -216,12 +216,14 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
 
         // [HARDENING FIX] Find the CLOSE order call
         const calls = signedRequestSpy.mock.calls;
-        const callArgs = calls.find((c) => c[2] && c[2].side === 'SELL');
+        const callArgs = calls.find((c) => c[2] && c[2].side === 'BUY');
         const body = callArgs![2];
 
-        // Opposite side for long = sell
-        expect(body.side).toBe('SELL');
-        // CRITICAL: reduceOnly prevents opening short position
+        // side matches the position being closed (BUY = long), not
+        // inverted — see buildCloseOrderFields (BUG-0062/BUG-0063).
+        expect(body.side).toBe('BUY');
+        expect(body.tradeSide).toBe('CLOSE');
+        // CRITICAL: reduceOnly prevents opening a bigger opposite position
         expect(body.reduceOnly).toBe(true);
     });
 
@@ -247,7 +249,7 @@ describe('Flash Close Position Binding (CRITICAL)', () => {
         expect(cancelCall).toBeDefined();
 
         // Ensure Close call is also present
-        const closeCall = calls.find((call) => call[2] && call[2].side === 'SELL');
+        const closeCall = calls.find((call) => call[2] && call[2].side === 'BUY');
         expect(closeCall).toBeDefined();
 
         // Ensure Cancel happens BEFORE Close

--- a/src/tests/flash_close_race_repro.test.ts
+++ b/src/tests/flash_close_race_repro.test.ts
@@ -103,7 +103,7 @@ describe('Flash Close Race Condition Reproduction', () => {
             // Assuming generic check for now, but looking at tradeService implementation is better.
 
             // Allow Place Order
-            if (endpoint === '/api/orders' && method === 'POST' && body.side === 'SELL') {
+            if (endpoint === '/api/orders' && method === 'POST' && body.side === 'BUY') {
                 return { code: 0, msg: 'success', data: { orderId: '123' } };
             }
             return {};
@@ -121,7 +121,7 @@ describe('Flash Close Race Condition Reproduction', () => {
         // We can check if any call threw? No, we mocked it to throw.
 
         // Verify Close WAS called
-        const closeCall = calls.find((call) => call[1] === '/api/orders' && call[2] && call[2].side === 'SELL');
+        const closeCall = calls.find((call) => call[1] === '/api/orders' && call[2] && call[2].side === 'BUY');
         expect(closeCall).toBeDefined();
     });
 });


### PR DESCRIPTION
## Summary

- BUG-0062 (merged) only sent `tradeSide`/`positionId` when the account's position mode was confirmed HEDGE, based on the description text in `docs/bitunix-api/07_trade.md:583` ("nur im Hedge-Modus erforderlich"). Live testing right after that merge showed closing still 500s — now with a visible "must not be null" — on a confirmed **ONE_WAY/Isolated** account.
- Re-reading the same doc table: `tradeSide`'s **Required** column is `true` (no mode qualifier), and `positionId` is documented as required whenever `tradeSide = CLOSE` — also with no Hedge-only qualifier. The description text only explains when the *value* matters for disambiguation, not when the *field* may be omitted.
- `buildCloseOrderFields()` (`src/services/tradeService.ts`) now always returns `tradeSide: "CLOSE"` and `positionId` (when known), with `side` matching the position's own side (BUY closes a long, SELL closes a short) instead of inverting it — matching the documented request example. The `positionMode` branch is removed; `positionMode` stays on `OMSPosition` for display only (Account Summary "Mode: HEDGE/ONE_WAY").
- New backlog entry `docs/backlog/bugs/BUG-0063-close-position-500s-must-not-be-null.md`, linked to BUG-0062.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — full suite green (1083 passed, 6 skipped)
- [x] Updated tests that previously asserted the incorrect inverted-`side`-only shape: `tradeService_hedgeClose.test.ts`, `tradeService_flashClose_hardening.test.ts`, `tradeService_safety.test.ts`, `src/tests/flash-close.test.ts`, `src/tests/flash_close_race_repro.test.ts`
- [ ] Live verification against a real Bitunix account (ONE_WAY/Isolated, per the report that triggered this fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_