### PR TITLE
fix: BUG-0064 omsService position merge + BUG-0065 market price buffer clobber

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-63 items. How to read and add them: [README.md](README.md).
+64 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 25
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 26
 
 ---
 
@@ -53,6 +53,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 25
 | [BUG-0060](bugs/BUG-0060-positions-account-envelope-mismatch.md) | PositionsSidebar reads /api/positions and /api/account through the wrong response envelope | P0 | ✅ done | trade-panel |
 | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) | Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId) | P0 | ✅ done | trade-panel |
 | [BUG-0063](bugs/BUG-0063-close-position-500s-must-not-be-null.md) | Closing a position still 500s after BUG-0062 on a ONE_WAY/Isolated account | P0 | ✅ done | trade-panel |
+| [BUG-0064](bugs/BUG-0064-oms-position-update-wipes-positionid.md) | omsService.updatePosition() overwrites positionId/positionMode on partial WS pushes | P0 | ✅ done | trade-panel |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | trade-panel |
 | [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | trade-panel |
 | [FEAT-0020](features/FEAT-0020-account-settings-panel.md) | Show and change exchange account settings from Cachy | P1 | 📋 specced | trade-panel |
@@ -141,6 +142,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 25
 | [BUG-0060](bugs/BUG-0060-positions-account-envelope-mismatch.md) | PositionsSidebar reads /api/positions and /api/account through the wrong response envelope | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) | Closing a position 500s on a HEDGE-mode account (missing tradeSide/positionId) | P0 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0063](bugs/BUG-0063-close-position-500s-must-not-be-null.md) | Closing a position still 500s after BUG-0062 on a ONE_WAY/Isolated account | P0 | ✅ done | M3 | community, pro, private | none | none | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md) |
+| [BUG-0064](bugs/BUG-0064-oms-position-update-wipes-positionid.md) | omsService.updatePosition() overwrites positionId/positionMode on partial WS pushes | P0 | ✅ done | M3 | community, pro, private | none | none | [BUG-0062](bugs/BUG-0062-hedge-mode-close-position-fails.md), [BUG-0063](bugs/BUG-0063-close-position-500s-must-not-be-null.md) |
 | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) | Verify every order against displayed state before it leaves the client | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
 | [FEAT-0012](features/FEAT-0012-paper-trading-mode.md) | Add a paper-trading mode that shares the live execution path | P0 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0013](features/FEAT-0013-risk-limits-and-kill-switch.md) | Enforce hard risk limits and a kill switch at the execution boundary | P0 | 📋 specced | M1 | community, pro, private | A | none | — |
@@ -200,4 +202,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 25
 
 ---
 
-Next free number: **0064**
+Next free number: **0065**

--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-64 items. How to read and add them: [README.md](README.md).
+65 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 26
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 27
 
 ---
 
@@ -56,6 +56,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 26
 | [BUG-0064](bugs/BUG-0064-oms-position-update-wipes-positionid.md) | omsService.updatePosition() overwrites positionId/positionMode on partial WS pushes | P0 | ✅ done | trade-panel |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | trade-panel |
 | [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | trade-panel |
+| [BUG-0065](bugs/BUG-0065-market-price-buffer-clobbered-by-partial-push.md) | A partial WS price push can erase a real markPrice buffered earlier in the same flush window | P1 | ✅ done | trade-panel |
 | [FEAT-0020](features/FEAT-0020-account-settings-panel.md) | Show and change exchange account settings from Cachy | P1 | 📋 specced | trade-panel |
 | [FEAT-0021](features/FEAT-0021-order-types.md) | Support market, limit, trigger and fixed-risk orders with TP/SL attached | P1 | 📋 specced | trade-panel |
 | [FEAT-0023](features/FEAT-0023-position-management.md) | Manage open positions without leaving Cachy | P1 | 📋 specced | trade-panel |
@@ -153,6 +154,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 26
 | [BUG-0052](bugs/BUG-0052-app-access-token-blocks-public-byok-users.md) | APP_ACCESS_TOKEN blocks BYOK users who have no way to know it | P1 | ✅ done | none | community, pro, private | none | ADR-0002 | — |
 | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) | Position mark price always renders as "0 → 0 | P1 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0059](bugs/BUG-0059-account-fetch-error-silently-swallowed.md) | A failed account-balance fetch is silently swallowed, indistinguishable from a genuinely empty account | P1 | ✅ done | M3 | community, pro, private | none | none | — |
+| [BUG-0065](bugs/BUG-0065-market-price-buffer-clobbered-by-partial-push.md) | A partial WS price push can erase a real markPrice buffered earlier in the same flush window | P1 | ✅ done | M3 | community, pro, private | none | none | [BUG-0055](bugs/BUG-0055-position-mark-price-always-zero.md) |
 | [FEAT-0014](features/FEAT-0014-edition-build-targets.md) | Produce Community, Pro and Private builds from one tree | P1 | 📋 specced | M5 | community, pro, private | none | ADR-0003 | — |
 | [FEAT-0015](features/FEAT-0015-order-audit-trail.md) | Record every order submission attempt locally | P1 | 📋 specced | M1 | community, pro, private | A | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
 | [FEAT-0016](features/FEAT-0016-exchange-adapter-interface.md) | Put every exchange behind one adapter interface | P1 | 📋 specced | M2 | community, pro, private | none | none | [FEAT-0011](features/FEAT-0011-preflight-order-verification.md) |
@@ -202,4 +204,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 26
 
 ---
 
-Next free number: **0065**
+Next free number: **0066**

--- a/docs/backlog/bugs/BUG-0064-oms-position-update-wipes-positionid.md
+++ b/docs/backlog/bugs/BUG-0064-oms-position-update-wipes-positionid.md
@@ -1,0 +1,95 @@
+---
+id: BUG-0064
+title: omsService.updatePosition() overwrites positionId/positionMode on partial WS pushes
+type: bug
+status: done
+priority: P0
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: [BUG-0062, BUG-0063]
+---
+
+# BUG-0064 — omsService.updatePosition() overwrites positionId/positionMode on partial WS pushes
+
+## Symptom
+
+Reported live, immediately after BUG-0063 (unconditional `tradeSide`/
+`positionId` on close) merged and its CI passed: closing a position still
+fails. The browser console still shows `POST
+https://dev.cachy.app/api/orders 500 (Internal Server Error)`, and Cachy's
+own error display still shows "must not be null" — the same failure
+signature BUG-0063 was meant to fix.
+
+## Evidence
+
+**Demonstrated** — reproduced by tracing the data path BUG-0063's fix
+actually depends on, not just the payload-building code itself.
+
+BUG-0063 made `buildCloseOrderFields()` (`src/services/tradeService.ts`)
+always send `positionId` — but only when `position.positionId` is actually
+populated on the `OMSPosition` object `closePosition()`/
+`flashClosePosition()` read from `omsService.getPositions()`. Two
+independent paths write to that store:
+
+1. `ensurePositionFreshness()` (`tradeService.ts`), which REST-fetches via
+   `/api/sync/positions-pending` and calls `omsService.updatePosition(
+   mapToOMSPosition(validation.data))` with a fully Zod-validated payload —
+   `positionId`/`positionMode` present (BUG-0062 already fixed this path).
+2. The WS position channel handler (`src/services/bitunixWs.ts:1422`),
+   which calls `omsService.updatePosition(mapToOMSPosition(item))` on
+   *every* push for that symbol — including partial `UPDATE` events (e.g.
+   a PnL-only push) that don't repeat every field. Bitunix's WS position
+   channel docs (`docs/bitunix-api/08_websocket.md:261-291`) list
+   `positionId`/`positionMode` without ever confirming they're repeated on
+   every push type — the same undocumented-omission pattern already
+   confirmed for `qty` (BUG-0058) and order metadata (BUG-0061).
+
+`mapToOMSPosition()` maps a missing `positionId`/`positionMode` to
+`undefined` (`src/services/mappers.ts:83-86`) — correct, since it has no
+notion of "previous state". The bug is in
+`omsService.updatePosition()` (`src/services/omsService.ts:129`), which
+used `this.positions.set(key, position)` — a **blind overwrite**, unlike
+`accountState.updatePositionFromWs()` (`src/stores/account.svelte.ts`),
+which already merges incoming WS fields with the existing entry via
+`safeDecimal(data.field, existing.field)` for exactly this reason. Any WS
+push landing between `ensurePositionFreshness()`'s REST refresh and the
+user's "Close" click — very likely for an actively-traded symbol — wiped
+the just-fetched `positionId`. Worse, `updatePosition()` also resets
+`lastUpdated` to "now" on every call, so `ensurePositionFreshness()`'s
+staleness check (>200ms) treated the now positionId-less entry as fresh
+and skipped refetching it, silently reproducing the exact payload BUG-0063
+was meant to eliminate.
+
+## Cause
+
+`omsService.updatePosition()` replaces the stored position outright instead
+of merging incoming fields onto the existing entry, so a WS push that omits
+`positionId`/`positionMode` deletes previously known values.
+
+## Fix
+
+`updatePosition()` now falls back to the existing entry's
+`positionId`/`positionMode` when the incoming position doesn't carry them,
+mirroring `accountState.updatePositionFromWs()`'s established merge
+pattern. All other fields keep overwriting fresh on every push (intentional
+— PnL, margin, etc. are genuinely live).
+
+## Acceptance criteria
+
+- [x] A WS push that omits `positionId`/`positionMode` preserves the
+      previously known values on the stored `OMSPosition`
+- [x] A WS push that *does* carry new values still overwrites (adoption of
+      genuinely new data isn't blocked)
+- [x] `npm run check` and the full Vitest suite pass
+
+## Links
+
+- `src/services/omsService.ts` — `updatePosition()`
+- `src/services/mappers.ts` — `mapToOMSPosition()`
+- `src/services/bitunixWs.ts:1411-1424` — position channel handler
+- `docs/bitunix-api/08_websocket.md:261-291` ("Position Channel")
+- `docs/backlog/bugs/BUG-0062-hedge-mode-close-position-fails.md`
+- `docs/backlog/bugs/BUG-0063-close-position-500s-must-not-be-null.md`

--- a/docs/backlog/bugs/BUG-0065-market-price-buffer-clobbered-by-partial-push.md
+++ b/docs/backlog/bugs/BUG-0065-market-price-buffer-clobbered-by-partial-push.md
@@ -1,0 +1,84 @@
+---
+id: BUG-0065
+title: A partial WS price push can erase a real markPrice buffered earlier in the same flush window
+type: bug
+status: done
+priority: P1
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: [BUG-0055]
+---
+
+# BUG-0065 — A partial WS price push can erase a real markPrice buffered earlier in the same flush window
+
+## Symptom
+
+Reported live: prices in the Market Activity panel (position mark price)
+stay static even though Bitunix's own trade panel visibly moves for the
+same symbol at the same time — "Der Kurs ändert sich im Bitunix
+TradePanel aber auf Cachy bleibt er starr bei der einmal abgefragten
+Daten."
+
+## Evidence
+
+**Demonstrated** — regression test
+(`src/stores/marketStore.test.ts`, "does not let a later push omitting
+markPrice erase one buffered earlier in the same flush window") fails
+without the fix and passes with it.
+
+`MarketManager.updateSymbol()` (`src/stores/market.svelte.ts`) buffers
+incoming WS partials before a 250ms flush loop applies them:
+
+```ts
+const existing = this.pendingUpdates.get(symbol) || {};
+this.pendingUpdates.set(symbol, { ...existing, ...partial });
+```
+
+Callers build `partial` objects like `bitunixWs.ts`'s price-channel
+handler does: `{ markPrice: mp ? new Decimal(mp) : undefined }`. When a
+push doesn't repeat `mp` (Bitunix's WS docs,
+`docs/bitunix-api/08_websocket.md`, do not confirm every price-channel
+tick repeats every field — the same undocumented-omission pattern already
+confirmed for `qty` on the position channel, BUG-0058), `partial` still
+carries an **explicit** `markPrice: undefined` key. A plain object spread
+applies that key regardless of its `undefined` value, so a second push
+landing in the same 250ms flush window — a normal occurrence, since the
+WS throttle only limits updates to one per 200ms per symbol/channel —
+silently overwrites a real, not-yet-flushed `markPrice` from an earlier
+push in that same window with `undefined`. `applyUpdate()` (the flush
+step) already guards against applying an `undefined` field to `current`,
+but by then the real value buffered in `pendingUpdates` is already gone —
+the guard never gets a chance to see it.
+
+## Cause
+
+`updateSymbol()`'s buffer merge used a plain object spread, which does not
+distinguish "this field is intentionally absent from this push" from
+"this field should reset to nothing" — both look like a present key with
+value `undefined` after the ternaries callers use.
+
+## Fix
+
+`updateSymbol()` now merges only the keys of `partial` whose value is not
+`undefined` into the buffered entry, leaving any real, not-yet-flushed
+value already in the buffer untouched. `null` (used elsewhere to mean
+"explicitly cleared", distinct from "not provided") still passes through
+unchanged.
+
+## Acceptance criteria
+
+- [x] A push that omits a field (explicit `undefined`) does not erase a
+      real value for that field buffered by an earlier push in the same
+      flush window
+- [x] A push that provides a real value (including `null`) for a field
+      still overwrites the buffer as before
+- [x] `npm run check` and the full Vitest suite pass
+
+## Links
+
+- `src/stores/market.svelte.ts` — `updateSymbol()`, `applyUpdate()`
+- `src/services/bitunixWs.ts:930-970` — price channel handler
+- `docs/backlog/bugs/BUG-0055-position-mark-price-always-zero.md`

--- a/src/services/omsService.test.ts
+++ b/src/services/omsService.test.ts
@@ -266,4 +266,74 @@ describe('OrderManagementSystem', () => {
     // After all overflows, map should be at exactly MAX_ORDERS
     expect(omsService.getAllOrders().length).toBe(limit);
   });
+
+  describe('updatePosition preserves positionId/positionMode across partial pushes (BUG-0064)', () => {
+    it('keeps a previously known positionId/positionMode when a later push omits them', () => {
+      omsService.updatePosition({
+        symbol: 'BTCUSDT',
+        side: 'long',
+        amount: new Decimal('1.5'),
+        entryPrice: new Decimal('50000'),
+        unrealizedPnl: new Decimal('0'),
+        leverage: new Decimal('10'),
+        marginMode: 'isolated',
+        positionId: '662491704776252252',
+        positionMode: 'one_way',
+        lastUpdated: Date.now(),
+      });
+
+      // A PnL-only WS UPDATE push, mapped without positionId/positionMode —
+      // mapToOMSPosition() returns undefined for both when the raw WS item
+      // doesn't repeat them, which is not the same as "this position has no
+      // positionId".
+      omsService.updatePosition({
+        symbol: 'BTCUSDT',
+        side: 'long',
+        amount: new Decimal('1.5'),
+        entryPrice: new Decimal('50000'),
+        unrealizedPnl: new Decimal('12.34'),
+        leverage: new Decimal('10'),
+        marginMode: 'isolated',
+        lastUpdated: Date.now(),
+      });
+
+      const [position] = omsService.getPositions();
+      expect(position.positionId).toBe('662491704776252252');
+      expect(position.positionMode).toBe('one_way');
+      // The rest of the push still applies fresh.
+      expect(position.unrealizedPnl.toString()).toBe('12.34');
+    });
+
+    it('adopts a newly provided positionId/positionMode over the previous value', () => {
+      omsService.updatePosition({
+        symbol: 'ETHUSDT',
+        side: 'short',
+        amount: new Decimal('2'),
+        entryPrice: new Decimal('3000'),
+        unrealizedPnl: new Decimal('0'),
+        leverage: new Decimal('5'),
+        marginMode: 'cross',
+        positionId: 'old-id',
+        positionMode: 'hedge',
+        lastUpdated: Date.now(),
+      });
+
+      omsService.updatePosition({
+        symbol: 'ETHUSDT',
+        side: 'short',
+        amount: new Decimal('2'),
+        entryPrice: new Decimal('3000'),
+        unrealizedPnl: new Decimal('0'),
+        leverage: new Decimal('5'),
+        marginMode: 'cross',
+        positionId: 'new-id',
+        positionMode: 'one_way',
+        lastUpdated: Date.now(),
+      });
+
+      const [position] = omsService.getPositions();
+      expect(position.positionId).toBe('new-id');
+      expect(position.positionMode).toBe('one_way');
+    });
+  });
 });

--- a/src/services/omsService.ts
+++ b/src/services/omsService.ts
@@ -131,7 +131,24 @@ class OrderManagementSystem {
         if (!position.lastUpdated) {
             position.lastUpdated = Date.now();
         }
-        this.positions.set(position.symbol + ":" + position.side, position);
+        const key = position.symbol + ":" + position.side;
+        const existing = this.positions.get(key);
+        // Bitunix's WS position channel doesn't repeat positionId/positionMode
+        // on every push (e.g. a PnL-only UPDATE) — mapToOMSPosition() then maps
+        // them to undefined, and since this used to be a blind overwrite, that
+        // wiped an already-known positionId moments before a close, resetting
+        // `lastUpdated` in the process so ensurePositionFreshness() saw the
+        // corrupted entry as "fresh" and never refetched it. Bitunix's
+        // place_order requires positionId unconditionally to close (BUG-0063),
+        // so losing it here reproduces the same "must not be null" rejection
+        // even after that fix (BUG-0064). Falling back to the previous value
+        // mirrors accountState.updatePositionFromWs's existing merge pattern.
+        const merged: OMSPosition = {
+            ...position,
+            positionId: position.positionId ?? existing?.positionId,
+            positionMode: position.positionMode ?? existing?.positionMode,
+        };
+        this.positions.set(key, merged);
         logger.log("market", `[OMS] Position Updated: ${position.symbol} ${position.side}`);
 
         if (this.positions.size > this.MAX_POSITIONS) {

--- a/src/stores/market.svelte.ts
+++ b/src/stores/market.svelte.ts
@@ -293,8 +293,25 @@ export class MarketManager {
 
     // Merge partials manually to ensure nested objects like depth/technicals don't get lost if partial is shallow
     // However, partial is flat except for depth/technicals/klines.
-    // Simple spread is efficient for gathering updates.
-    this.pendingUpdates.set(symbol, { ...existing, ...partial });
+    // `{ ...existing, ...partial }` would silently clobber a real, not-yet-
+    // flushed value: callers build partial objects like
+    // `{ markPrice: mp ? new Decimal(mp) : undefined }`, so a WS push that
+    // doesn't repeat every field (e.g. an index-price-only price channel
+    // tick) still carries an explicit `markPrice: undefined` key, which a
+    // plain spread applies — wiping out an earlier, real markPrice buffered
+    // in this same flush window before it ever reaches `current` (BUG-0065).
+    // applyUpdate() already skips `undefined` fields once flushed; the
+    // buffer merge must skip them for the same reason, or that guard never
+    // gets to see the real value at all.
+    const merged: MarketUpdatePayload = { ...existing };
+    const mergedRecord = merged as Record<string, unknown>;
+    for (const key of Object.keys(partial) as (keyof MarketUpdatePayload)[]) {
+      const value = partial[key];
+      if (value !== undefined) {
+        mergedRecord[key] = value;
+      }
+    }
+    this.pendingUpdates.set(symbol, merged);
 
     // Safety: Prevent memory leak if flush interval stalls
     // Dynamic limit based on cache size (5x cache size to allow for burst)

--- a/src/stores/marketStore.test.ts
+++ b/src/stores/marketStore.test.ts
@@ -107,6 +107,28 @@ describe("marketStore", () => {
       await vi.advanceTimersByTimeAsync(300);
       expect(marketState.data[symbol].markPrice?.toString()).toBe("50002");
     });
+
+    it("does not let a later push omitting markPrice erase one buffered earlier in the same flush window (BUG-0065)", async () => {
+      const symbol = "BTCUSDT";
+
+      // Two WS pushes land inside the same 250ms flush window (throttle is
+      // 200ms, flush is 250ms — this is the normal case, not an edge case):
+      // one with a real markPrice, one that only carries indexPrice because
+      // that's the only field Bitunix's push happened to include this tick.
+      // Callers build partials like `{ markPrice: mp ? new Decimal(mp) :
+      // undefined }`, so the second push still has an explicit
+      // `markPrice: undefined` key.
+      marketState.updateSymbol(symbol, { markPrice: "50002", indexPrice: "50001" });
+      marketState.updateSymbol(symbol, { indexPrice: "50003", markPrice: undefined });
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      // The real markPrice from the first push must survive the flush —
+      // not get clobbered by the second push's `undefined` before either
+      // ever reaches `current`.
+      expect(marketState.data[symbol].markPrice?.toString()).toBe("50002");
+      expect(marketState.data[symbol].indexPrice?.toString()).toBe("50003");
+    });
   });
 
   describe("Kline Protection (Single Source of Truth)", () => {


### PR DESCRIPTION
## Summary

**BUG-0064** — `omsService.updatePosition()` overwrites `positionId`/`positionMode` on partial WS pushes

- BUG-0063 (merged) made `closePosition()`/`flashClosePosition()` always send `tradeSide`/`positionId` — but that only helps if `position.positionId` is actually still populated on the `OMSPosition` object read from `omsService.getPositions()`. Live testing right after BUG-0063 merged showed the close STILL 500s with the same "must not be null".
- Root cause: `omsService.updatePosition()` did a blind `Map.set()` overwrite of the stored position on **every** call — including the WS position channel handler (`src/services/bitunixWs.ts:1422`), which calls it on partial `UPDATE` pushes (e.g. PnL-only) that don't repeat `positionId`/`positionMode`. That wiped a previously REST-fetched `positionId` and reset `lastUpdated`, so `ensurePositionFreshness()`'s staleness check never refetched it.
- `updatePosition()` now falls back to the existing entry's `positionId`/`positionMode` when the incoming push omits them, mirroring the merge pattern `accountState.updatePositionFromWs()` already uses.

**BUG-0065** — a partial WS price push can erase a real `markPrice` buffered earlier in the same flush window

- Reported live, high priority: Market Activity's position mark price stays frozen while Bitunix's own trade panel visibly moves for the same symbol.
- Root cause: `MarketManager.updateSymbol()` (`src/stores/market.svelte.ts`) merges incoming WS partials into a 250ms flush buffer via a plain object spread. `bitunixWs.ts`'s price-channel handler builds partials like `{ markPrice: mp ? new Decimal(mp) : undefined }` — a push that doesn't repeat `mp` still carries an explicit `markPrice: undefined` key, which the spread applies, silently erasing a real `markPrice` buffered by an earlier push in the same flush window before `applyUpdate()`'s `undefined`-guard ever gets a chance to see it.
- `updateSymbol()` now only merges keys whose value isn't `undefined`, leaving a real buffered value untouched. `null` (explicit "cleared") still passes through.

Both new backlog entries (`BUG-0064`, `BUG-0065`) linked to their respective predecessors.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm test` — full suite green (1086 passed, 6 skipped)
- [x] New tests: `omsService.test.ts` (positionId/positionMode preserved across a push that omits them, adopted when a push provides new ones), `marketStore.test.ts` (a later push omitting `markPrice` doesn't erase one buffered earlier in the same flush window — verified this test fails without the fix)
- [ ] Live verification against a real Bitunix account (the reports that triggered these fixes)
