### PR TITLE
fix: correct mislabeled unrealized PnL row in the position tooltip (BUG-0066)

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-65 items. How to read and add them: [README.md](README.md).
+66 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 27
+Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 28
 
 ---
 
@@ -66,6 +66,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 27
 | [BUG-0054](bugs/BUG-0054-orders-tab-loading-indicator-broken.md) | Orders-tab loading indicator is broken in both directions | P2 | ✅ done | trade-panel |
 | [BUG-0056](bugs/BUG-0056-order-history-tab-stale.md) | Order history tab shows stale trades | P2 | ✅ done | trade-panel |
 | [BUG-0061](bugs/BUG-0061-order-tooltip-metadata-dropped.md) | Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns | P2 | ✅ done | trade-panel |
+| [BUG-0066](bugs/BUG-0066-position-tooltip-mislabeled-pnl-row.md) | Position tooltip labels the live unrealized PnL row "Realized PnL | P2 | ✅ done | trade-panel |
 | [FEAT-0025](features/FEAT-0025-trading-notifications.md) | Notify on fills, margin thresholds and connection loss | P2 | 📋 specced | trade-panel |
 
 ### M4
@@ -180,6 +181,7 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 27
 | [BUG-0054](bugs/BUG-0054-orders-tab-loading-indicator-broken.md) | Orders-tab loading indicator is broken in both directions | P2 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0056](bugs/BUG-0056-order-history-tab-stale.md) | Order history tab shows stale trades | P2 | ✅ done | M3 | community, pro, private | none | none | — |
 | [BUG-0061](bugs/BUG-0061-order-tooltip-metadata-dropped.md) | Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns | P2 | ✅ done | M3 | community, pro, private | none | none | — |
+| [BUG-0066](bugs/BUG-0066-position-tooltip-mislabeled-pnl-row.md) | Position tooltip labels the live unrealized PnL row "Realized PnL | P2 | ✅ done | M3 | community, pro, private | none | none | — |
 | [FEAT-0019](features/FEAT-0019-agentic-web-search.md) | Let the assistant research the web when it needs to | P2 | 💡 idea | M8 | pro, private | C | none | [FEAT-0016](features/FEAT-0016-exchange-adapter-interface.md) |
 | [FEAT-0025](features/FEAT-0025-trading-notifications.md) | Notify on fills, margin thresholds and connection loss | P2 | 📋 specced | M3 | community, pro, private | A | none | — |
 | [FEAT-0028](features/FEAT-0028-indicator-alerts.md) | Alerts on indicator conditions | P2 | 📋 specced | M4 | community, pro, private | A | none | [FEAT-0027](features/FEAT-0027-alert-engine.md) |
@@ -204,4 +206,4 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 27
 
 ---
 
-Next free number: **0066**
+Next free number: **0067**

--- a/docs/backlog/bugs/BUG-0066-position-tooltip-mislabeled-pnl-row.md
+++ b/docs/backlog/bugs/BUG-0066-position-tooltip-mislabeled-pnl-row.md
@@ -1,0 +1,74 @@
+---
+id: BUG-0066
+title: Position tooltip labels the live unrealized PnL row "Realized PnL"
+type: bug
+status: done
+priority: P2
+milestone: M3
+editions: [community, pro, private]
+area: trade-panel
+data_class: none
+adr: none
+depends_on: []
+---
+
+# BUG-0066 — Position tooltip labels the live unrealized PnL row "Realized PnL"
+
+## Symptom
+
+Reported live, with a screenshot: the position tooltip
+(`PositionTooltip.svelte`) shows two rows both labeled "Realized PnL" —
+one green (bound to the position's live PnL) and one red/negative
+(bound to the actual cumulative realized PnL). User's own read: "Warum
+sehe ich einen positiven und einen negativen PnL? Der grüne wäre der
+Unrealized PnL" — correctly suspecting the green row is mislabeled.
+
+## Evidence
+
+**Demonstrated** — traced to the exact shared i18n key.
+
+`PositionTooltip.svelte`'s first PnL row (bound to
+`position.unrealizedPnl`) used the translation key
+`dashboard.orderHistory.details.pnl`. That key's English/German values are
+literally `"Realized PnL"` / `"Realisierter PnL"`
+(`src/locales/locales/{en,de}.json`) — correct for its original owner,
+`OrderDetailsTooltip.svelte`, where a filled order's PnL genuinely *is*
+realized (an order has no "unrealized" state). Reusing the same key for a
+still-open position's PnL mislabeled a genuinely unrealized value as
+realized, directly beside the tooltip's other row
+(`positionsList.realizedPnl`, correctly labeled) showing the *actual*
+realized PnL — hence two differently-signed numbers under the same label.
+
+## Cause
+
+Key reuse across two components with different semantics for "PnL".
+
+## Fix
+
+`PositionTooltip.svelte`'s unrealized PnL row now uses
+`positionsList.unrealizedPnl` (already present, previously unused —
+`docs/backlog/features/FEAT-0057-market-activity-panel-redesign.md`'s
+margin-rate/realized-PnL work added the sibling `realizedPnl` key but this
+one was never wired up). Both locale values updated from the terse "uPnL"
+to "Unrealized PnL" / "Unrealisierter PnL" for consistency with the
+tooltip's other full-word labels ("Realized PnL", "Margin Rate").
+
+Also added a `title` tooltip on the clickable PnL badge in
+`PositionsList.svelte` (both view modes) explaining what the number is and
+that clicking cycles between value/percent/bar display — previously
+undocumented UI, flagged by the same report.
+
+## Acceptance criteria
+
+- [x] The position tooltip's live-PnL row is labeled "Unrealized PnL", not
+      "Realized PnL"
+- [x] The PnL badge on a position card has a hover tooltip explaining its
+      meaning and the click-to-cycle behavior
+- [x] `npm run check`, `scripts/check_translations.sh`, and the full
+      Vitest suite pass
+
+## Links
+
+- `src/components/shared/PositionTooltip.svelte`
+- `src/components/shared/PositionsList.svelte` — `togglePnlMode()`
+- `src/locales/locales/en.json`, `de.json` — `positionsList.*`

--- a/src/components/shared/PositionTooltip.svelte
+++ b/src/components/shared/PositionTooltip.svelte
@@ -94,7 +94,7 @@
 
     <!-- PnL & Margin -->
     <div class="flex justify-between">
-      <span class="text-[var(--text-secondary)]">{$_("dashboard.orderHistory.details.pnl")}:</span>
+      <span class="text-[var(--text-secondary)]">{$_("positionsList.unrealizedPnl")}:</span>
       <span
         class:text-[var(--success-color)]={position.unrealizedPnl > 0}
         class:text-[var(--danger-color)]={position.unrealizedPnl < 0}

--- a/src/components/shared/PositionsList.svelte
+++ b/src/components/shared/PositionsList.svelte
@@ -163,6 +163,7 @@
                   onclick={togglePnlMode}
                   role="button"
                   tabindex="0"
+                  title={$_("positionsList.pnlToggleHint")}
                   onkeydown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
@@ -273,6 +274,7 @@
                 onclick={togglePnlMode}
                 role="button"
                 tabindex="0"
+                title={$_("positionsList.pnlToggleHint")}
                 onkeydown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();

--- a/src/locales/locales/de.json
+++ b/src/locales/locales/de.json
@@ -2176,7 +2176,8 @@
     "margin": "Margin",
     "marginRate": "Margin-Rate",
     "realizedPnl": "Realisiert",
-    "unrealizedPnl": "uPnL"
+    "unrealizedPnl": "Unrealisierter PnL",
+    "pnlToggleHint": "Unrealisierter PnL dieser Position. Klicken zum Wechseln zwischen Betrag, Prozent (ROI) und Balkenansicht."
   },
   "trade": {
     "apiError": "API-Fehler: {error}",

--- a/src/locales/locales/en.json
+++ b/src/locales/locales/en.json
@@ -1462,7 +1462,8 @@
     "margin": "Margin",
     "marginRate": "Margin Rate",
     "realizedPnl": "Realized PnL",
-    "unrealizedPnl": "uPnL"
+    "unrealizedPnl": "Unrealized PnL",
+    "pnlToggleHint": "Unrealized PnL for this position. Click to switch between value, percent (ROI) and bar view."
   },
   "symbolPicker": {
     "title": "Select Symbol",

--- a/src/locales/schema.d.ts
+++ b/src/locales/schema.d.ts
@@ -1288,6 +1288,7 @@ export type TranslationKey =
   | "positionsList.marginRate"
   | "positionsList.realizedPnl"
   | "positionsList.unrealizedPnl"
+  | "positionsList.pnlToggleHint"
   | "symbolPicker.title"
   | "symbolPicker.searchPlaceholder"
   | "symbolPicker.favorites"


### PR DESCRIPTION
## Summary

- Reported live with a screenshot: the position tooltip shows two rows both labeled "Realized PnL" — one green, one red/negative. User correctly suspected the green one was mislabeled.
- Root cause: `PositionTooltip.svelte`'s live-PnL row (bound to `position.unrealizedPnl`) reused the i18n key `dashboard.orderHistory.details.pnl`, whose English/German values are literally "Realized PnL" / "Realisierter PnL" — correct for its original owner `OrderDetailsTooltip.svelte` (a filled order's PnL genuinely is realized), wrong for a still-open position.
- Switched to the existing (previously unused) `positionsList.unrealizedPnl` key, and upgraded its value from the terse "uPnL" to "Unrealized PnL" / "Unrealisierter PnL" for consistency with the tooltip's other full-word labels.
- Also added a `title` tooltip on the clickable PnL badge in `PositionsList.svelte` (both "detailed" and "focus" view modes) explaining what the number shows and that clicking cycles between value/percent(ROI)/bar display — this was previously undocumented UI, flagged in the same report.
- New backlog entry `docs/backlog/bugs/BUG-0066-position-tooltip-mislabeled-pnl-row.md`.

## Test plan

- [x] `npm run check` — 0 errors (regenerated `src/locales/schema.d.ts` via `node scripts/generate-i18n-types.js` for the new key)
- [x] `bash scripts/check_translations.sh` — 0 critical issues (no missing/empty keys in either locale)
- [x] `npm test` — full suite green (1086 passed, 6 skipped)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUqXKiRZNh3cEz9LQEwSjr)_