### PR TITLE
docs: fix nonexistent talib-web reference in whitepaper

### DIFF
--- a/src/lib/assets/content/whitepaper.de.md
+++ b/src/lib/assets/content/whitepaper.de.md
@@ -181,13 +181,13 @@ Cachy berechnet nicht nur einen ATR. Es führt einen **Parallelen Scan** der fav
 #### 2. Technische Analyse-Engine
 
 _Ziel: Bereitstellung von Standardindikatoren ohne externe Charting-Bibliotheken._
-Der `technicalsService.ts` nutzt die **`talib-web`-Bibliothek** (WebAssembly-Port von TA-Lib) zur Berechnung von:
+Der `technicalsService.ts` routet die Berechnung über die `calculationStrategy` an das eigene **Rust/WebAssembly-Modul** (`technicals-wasm/`) bzw. dessen TypeScript-Pendant zur Berechnung von:
 
 - **Oszillatoren**: RSI, Stochastic, CCI, Awesome Oscillator, ADX, Momentum.
 - **Trend**: SMA, EMA, MACD.
 - **Pivot Points**: Manuell berechnet aus den High/Low/Close-Werten des Vortages.
 
-**Upgrade (Januar 2026)**: Migration von `technicalindicators` auf `talib-web` für exakte Übereinstimmung mit TradingView. In der neuesten Iteration wurde dies weiter optimiert, indem wir wo möglich auf reine TypeScript-Implementierungen umgestiegen sind, um WASM-Abhängigkeiten zu entfernen und die Ladezeiten auf mobilen Geräten zu verbessern.
+**Upgrade (Januar 2026)**: Migration von `technicalindicators` auf die eigene WASM-Implementierung für exakte Übereinstimmung mit TradingView. In der neuesten Iteration wurde dies weiter optimiert, indem wir wo möglich auf reine TypeScript-Implementierungen umgestiegen sind, um WASM-Abhängigkeiten zu entfernen und die Ladezeiten auf mobilen Geräten zu verbessern.
 
 Diese Daten werden im **Technicals Panel** visualisiert, einem dedizierten Overlay für schnelle Marktbewertungen.
 

--- a/src/lib/assets/content/whitepaper.en.md
+++ b/src/lib/assets/content/whitepaper.en.md
@@ -184,13 +184,13 @@ Cachy doesn't just calculate one ATR. It executes a **Parallel Scan** of the use
 #### 2. Technical Analysis Engine
 
 _Goal: Provide standard indicators without external charting libraries._
-The `technicalsService.ts` leverages the **`talib-web` library** (WebAssembly port of TA-Lib) to compute:
+The `technicalsService.ts` routes calculation via `calculationStrategy` to our own **Rust/WebAssembly module** (`technicals-wasm/`) or its TypeScript counterpart to compute:
 
 - **Oscillators**: RSI, Stochastic, CCI, Awesome Oscillator, ADX, Momentum.
 - **Trend**: SMA, EMA, MACD.
 - **Pivot Points**: Calculated manually from the previous day's High/Low/Close.
 
-**Upgrade (January 2026)**: Migrated from `technicalindicators` to `talib-web` for exact alignment with TradingView. The WebAssembly-based implementation offers maximum accuracy and uses the same algorithms as professional trading platforms. In the latest iteration, we have further optimized this by transitioning to pure TypeScript implementations where possible to remove WASM dependencies and improve load times on mobile devices.
+**Upgrade (January 2026)**: Migrated from `technicalindicators` to our own WASM implementation for exact alignment with TradingView. The WebAssembly-based implementation offers maximum accuracy and uses the same algorithms as professional trading platforms. In the latest iteration, we have further optimized this by transitioning to pure TypeScript implementations where possible to remove WASM dependencies and improve load times on mobile devices.
 
 This data is visualized in the **Technicals Panel**, a dedicated overlay for rapid market assessment.
 


### PR DESCRIPTION
## Summary
- The technical-analysis section of the whitepaper (DE + EN) claimed `technicalsService.ts` uses a `talib-web` WebAssembly port of TA-Lib.
- No such library exists anywhere in the codebase — the actual implementation is the in-house `technicals-wasm/` Rust/WASM module, routed via `calculationStrategy`, with a pure-TS fallback. The tech-stack table already documented this correctly; the fließtext contradicted it.
- Fixed both language versions for consistency.

## Test plan
- [x] `npx vitest run src/lib/whitepaper-claims.test.ts` passes