### PR TITLE
docs: add Bitunix API integration status overview

### DIFF
--- a/docs/backlog/INDEX.md
+++ b/docs/backlog/INDEX.md
@@ -2,9 +2,9 @@
 
 # Backlog index
 
-66 items. How to read and add them: [README.md](README.md).
+75 items. How to read and add them: [README.md](README.md).
 
-Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 28
+Counts by status: 💡 idea 14 · 📋 specced 31 · 🟢 ready 2 · ✅ done 28
 
 ---
 
@@ -63,11 +63,17 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 28
 | [FEAT-0024](features/FEAT-0024-confirmation-policy.md) | Let the user decide which actions need confirming | P1 | 📋 specced | trade-panel |
 | [FEAT-0026](features/FEAT-0026-multi-account.md) | Support several exchange accounts with an unmistakable active one | P1 | 📋 specced | trade-panel |
 | [FEAT-0057](features/FEAT-0057-market-activity-panel-redesign.md) | Show the full Bitunix position/order dataset in the Market Activity panel | P1 | 📋 specced | trade-panel |
+| [FEAT-0067](features/FEAT-0067-bitunix-trading-pair-metadata.md) | Fetch Bitunix trading-pair metadata and validate orders against it | P1 | 📋 specced | exchange |
+| [FEAT-0068](features/FEAT-0068-bitunix-account-settings.md) | Read and change leverage, margin mode and position margin from the trade panel | P1 | 📋 specced | exchange |
+| [FEAT-0069](features/FEAT-0069-bitunix-place-order-completion.md) | Send TP/SL, time-in-force and a client order ID with Bitunix order placement | P1 | 📋 specced | execution |
+| [FEAT-0070](features/FEAT-0070-bitunix-tpsl-placement.md) | Place new TP/SL orders on existing Bitunix positions | P1 | 📋 specced | execution |
 | [BUG-0054](bugs/BUG-0054-orders-tab-loading-indicator-broken.md) | Orders-tab loading indicator is broken in both directions | P2 | ✅ done | trade-panel |
 | [BUG-0056](bugs/BUG-0056-order-history-tab-stale.md) | Order history tab shows stale trades | P2 | ✅ done | trade-panel |
 | [BUG-0061](bugs/BUG-0061-order-tooltip-metadata-dropped.md) | Order tooltip shows empty leverage/margin mode/qty/created date regardless of what the exchange returns | P2 | ✅ done | trade-panel |
 | [BUG-0066](bugs/BUG-0066-position-tooltip-mislabeled-pnl-row.md) | Position tooltip labels the live unrealized PnL row "Realized PnL | P2 | ✅ done | trade-panel |
 | [FEAT-0025](features/FEAT-0025-trading-notifications.md) | Notify on fills, margin thresholds and connection loss | P2 | 📋 specced | trade-panel |
+| [FEAT-0071](features/FEAT-0071-bitunix-native-bulk-endpoints.md) | Replace client-side cancel and close loops with native Bitunix endpoints | P2 | 📋 specced | execution |
+| [FEAT-0072](features/FEAT-0072-bitunix-tpsl-ws-channel.md) | Subscribe the private Bitunix TP/SL WebSocket channel | P2 | 📋 specced | exchange |
 
 ### M4
 
@@ -130,6 +136,9 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 28
 | [BUG-0010](bugs/BUG-0010-modal-extraclasses-ignored.md) | modalState.show() accepts extraClasses and never applies it | P3 | 📋 specced | ui |
 | [FEAT-0022](features/FEAT-0022-settings-search.md) | Make settings findable with a search box | P3 | 💡 idea | ui |
 | [IDEA-0036](ideas/IDEA-0036-gamification-fork.md) | A gamified fork built on SpacetimeDB and the 3D layer | P3 | 💡 idea | experiment |
+| [IDEA-0073](ideas/IDEA-0073-bitunix-best-bid-ask.md) | Show best bid/ask and spread from the Bitunix tickers batch channel | P3 | 💡 idea | ui |
+| [IDEA-0074](ideas/IDEA-0074-bitunix-funding-history.md) | Surface funding-rate history for a symbol | P3 | 💡 idea | exchange |
+| [IDEA-0075](ideas/IDEA-0075-bitunix-position-tiers.md) | Use Bitunix position tiers for precise liquidation and margin estimates | P3 | 💡 idea | calculation |
 
 ---
 
@@ -170,6 +179,10 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 28
 | [FEAT-0041](features/FEAT-0041-window-layer-contract.md) | Give every floating surface its z-index from one layer contract | P1 | 📋 specced | M0 | community, pro, private | none | ADR-0006 | — |
 | [FEAT-0050](features/FEAT-0050-window-manager-test-coverage.md) | Put tests under the window manager before more surfaces depend on it | P1 | ✅ done | none | community, pro, private | A | ADR-0006 | — |
 | [FEAT-0057](features/FEAT-0057-market-activity-panel-redesign.md) | Show the full Bitunix position/order dataset in the Market Activity panel | P1 | 📋 specced | M3 | community, pro, private | none | none | — |
+| [FEAT-0067](features/FEAT-0067-bitunix-trading-pair-metadata.md) | Fetch Bitunix trading-pair metadata and validate orders against it | P1 | 📋 specced | M3 | community, pro, private | C | none | — |
+| [FEAT-0068](features/FEAT-0068-bitunix-account-settings.md) | Read and change leverage, margin mode and position margin from the trade panel | P1 | 📋 specced | M3 | community, pro, private | A | none | — |
+| [FEAT-0069](features/FEAT-0069-bitunix-place-order-completion.md) | Send TP/SL, time-in-force and a client order ID with Bitunix order placement | P1 | 📋 specced | M3 | community, pro, private | A | none | — |
+| [FEAT-0070](features/FEAT-0070-bitunix-tpsl-placement.md) | Place new TP/SL orders on existing Bitunix positions | P1 | 📋 specced | M3 | community, pro, private | A | none | — |
 | [BUG-0005](bugs/BUG-0005-gpu-chop-field-mismatch.md) | GPU-accelerated Choppiness writes to a field nothing reads | P2 | 📋 specced | M0 | community, pro, private | none | none | — |
 | [BUG-0006](bugs/BUG-0006-sentiment-response-unvalidated.md) | Sentiment cache and AI response are trusted without schema validation | P2 | 📋 specced | M0 | community, pro, private | none | none | — |
 | [BUG-0009](bugs/BUG-0009-symbolpicker-null-resolution.md) | SymbolPickerWindow resolves with null against a type that excludes it | P2 | 📋 specced | none | community, pro, private | none | none | — |
@@ -197,13 +210,18 @@ Counts by status: 💡 idea 11 · 📋 specced 25 · 🟢 ready 2 · ✅ done 28
 | [FEAT-0044](features/FEAT-0044-modalframe-through-window-manager.md) | Make ModalFrame an adapter over WindowFrame instead of a second implementation | P2 | ✅ done | none | community, pro, private | A | ADR-0006 | [FEAT-0041](features/FEAT-0041-window-layer-contract.md) |
 | [FEAT-0045](features/FEAT-0045-academy-as-window-type.md) | Register the Trading Academy as its own window type | P2 | ✅ done | none | community, pro, private | A | ADR-0006 | [FEAT-0044](features/FEAT-0044-modalframe-through-window-manager.md) |
 | [FEAT-0046](features/FEAT-0046-sidepanel-onto-window-manager.md) | Move the SidePanel onto the window manager and drop interactjs | P2 | ✅ done | none | community, pro, private | A | ADR-0006 | [FEAT-0041](features/FEAT-0041-window-layer-contract.md) |
+| [FEAT-0071](features/FEAT-0071-bitunix-native-bulk-endpoints.md) | Replace client-side cancel and close loops with native Bitunix endpoints | P2 | 📋 specced | M3 | community, pro, private | A | none | — |
+| [FEAT-0072](features/FEAT-0072-bitunix-tpsl-ws-channel.md) | Subscribe the private Bitunix TP/SL WebSocket channel | P2 | 📋 specced | M3 | community, pro, private | A | none | — |
 | [BUG-0007](bugs/BUG-0007-hardcoded-ui-strings.md) | Several UI strings are hardcoded instead of translated | P3 | 🟢 ready | none | community, pro, private | none | none | — |
 | [BUG-0008](bugs/BUG-0008-toast-array-unbounded.md) | The toast array grows without a bound | P3 | 🟢 ready | none | community, pro, private | none | none | — |
 | [BUG-0010](bugs/BUG-0010-modal-extraclasses-ignored.md) | modalState.show() accepts extraClasses and never applies it | P3 | 📋 specced | none | community, pro, private | none | none | — |
 | [FEAT-0022](features/FEAT-0022-settings-search.md) | Make settings findable with a search box | P3 | 💡 idea | none | community, pro, private | none | none | — |
 | [IDEA-0036](ideas/IDEA-0036-gamification-fork.md) | A gamified fork built on SpacetimeDB and the 3D layer | P3 | 💡 idea | none | community | none | required | — |
 | [IDEA-0037](ideas/IDEA-0037-android-alert-companion.md) | A native Android companion that runs only the alert engine | P3 | 💡 idea | M4 | community, pro, private | A | none | [FEAT-0027](features/FEAT-0027-alert-engine.md) |
+| [IDEA-0073](ideas/IDEA-0073-bitunix-best-bid-ask.md) | Show best bid/ask and spread from the Bitunix tickers batch channel | P3 | 💡 idea | none | community, pro, private | C | none | — |
+| [IDEA-0074](ideas/IDEA-0074-bitunix-funding-history.md) | Surface funding-rate history for a symbol | P3 | 💡 idea | none | community, pro, private | C | none | — |
+| [IDEA-0075](ideas/IDEA-0075-bitunix-position-tiers.md) | Use Bitunix position tiers for precise liquidation and margin estimates | P3 | 💡 idea | none | community, pro, private | C | none | — |
 
 ---
 
-Next free number: **0067**
+Next free number: **0076**

--- a/docs/backlog/features/FEAT-0067-bitunix-trading-pair-metadata.md
+++ b/docs/backlog/features/FEAT-0067-bitunix-trading-pair-metadata.md
@@ -1,0 +1,64 @@
+---
+id: FEAT-0067
+title: Fetch Bitunix trading-pair metadata and validate orders against it
+type: feature
+status: specced
+priority: P1
+milestone: M3
+editions: [community, pro, private]
+area: exchange
+data_class: C
+adr: none
+depends_on: []
+---
+
+# FEAT-0067 — Fetch Bitunix trading-pair metadata and validate orders against it
+
+## Problem
+
+Cachy never calls `GET /api/v1/futures/market/trading_pairs`, so it does not
+know a symbol's price/quantity precision, minimum trade volume, maximum order
+volumes, leverage range, `priceProtectScope`, `symbolStatus` or
+`isApiSupported`. Every order the trade panel will place needs these to round
+and validate its values; today any such check would be guesswork. The API doc
+chapter is [`04_market.md`](../../bitunix-api/04_market.md), the gap is
+recorded in
+[`INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §1.
+
+## Proposal
+
+A proxy route (public endpoint, no key needed) plus a client-side instrument
+store: fetch once per session, cache per symbol, expose precision and limits as
+`Decimal`-safe values. Order construction and the M1 verification gate
+([`FEAT-0011`](FEAT-0011-preflight-order-verification.md)) read from it; the UI
+uses it to round inputs and to disable trading when `symbolStatus` is not
+`OPEN` or `isApiSupported` is false.
+
+## Acceptance criteria
+
+- [ ] Trading-pair metadata for the active symbol is available in a store
+      before the trade panel enables its submit action.
+- [ ] Quantity and price inputs are rounded to `basePrecision` /
+      `quotePrecision` using `decimal.js`, never native floats.
+- [ ] An order below `minTradeVolume` or above the max order volume is refused
+      client-side with a message naming the violated limit.
+- [ ] A symbol with `symbolStatus != OPEN` or `isApiSupported == false` shows
+      trading as unavailable instead of failing at submission.
+
+## Out of scope
+
+- Leverage range enforcement UI (belongs to
+  [`FEAT-0068`](FEAT-0068-bitunix-account-settings.md)).
+- The generic per-exchange capability model (M2); this item may start
+  Bitunix-only and be folded into the adapter later.
+
+## Open questions
+
+- Cache lifetime: per session, or refreshed on a timer? Pair metadata changes
+  rarely but `symbolStatus` can flip.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md)
+- [`docs/bitunix-api/04_market.md`](../../bitunix-api/04_market.md)
+- [`docs/MILESTONES.md`](../../MILESTONES.md) — M3

--- a/docs/backlog/features/FEAT-0068-bitunix-account-settings.md
+++ b/docs/backlog/features/FEAT-0068-bitunix-account-settings.md
@@ -1,0 +1,69 @@
+---
+id: FEAT-0068
+title: Read and change leverage, margin mode and position margin from the trade panel
+type: feature
+status: specced
+priority: P1
+milestone: M3
+editions: [community, pro, private]
+area: exchange
+data_class: A
+adr: none
+depends_on: []
+---
+
+# FEAT-0068 — Read and change leverage, margin mode and position margin from the trade panel
+
+## Problem
+
+The Bitunix API can read and change leverage, margin mode (ISOLATION/CROSS),
+position mode (ONE_WAY/HEDGE) and isolated-position margin — see
+[`02_account.md`](../../bitunix-api/02_account.md). Cachy integrates none of
+it: the trade panel neither shows the active leverage/margin mode for a symbol
+nor lets the user change it, so every settings change requires the exchange's
+own UI. M3 lists "account state, displayed and editable" as a milestone bullet.
+
+## Proposal
+
+One proxy route for the account-settings endpoint family:
+
+- `GET get_leverage_margin_mode` — display current leverage + margin mode per
+  symbol in the trade panel.
+- `POST change_leverage`, `POST change_margin_mode`,
+  `POST change_position_mode`, `POST adjust_position_margin` — write actions,
+  each surfaced in the panel with the API's own preconditions reflected in the
+  UI (margin mode only without open position/order on the symbol; position
+  mode only without any open positions; margin adjust only for isolated).
+
+Write actions follow the existing signed-proxy pattern and confirm success via
+the private WebSocket state rather than trusting the REST response alone.
+
+## Acceptance criteria
+
+- [ ] The trade panel shows current leverage and margin mode for the active
+      symbol, fetched from the API rather than assumed.
+- [ ] Leverage can be changed within the pair's `minLeverage`/`maxLeverage`
+      range; values outside are rejected client-side.
+- [ ] Margin-mode and position-mode controls are disabled — with a reason —
+      when the API precondition (open positions/orders) is not met.
+- [ ] Isolated-position margin can be increased and reduced; the position's
+      updated margin is reflected via WS/refetch, not optimistic-only.
+- [ ] API keys are used only as credentials of the user-initiated request
+      through the proxy (ADR-0001 exception); nothing else leaves the device.
+
+## Out of scope
+
+- Asset mode (single/multi-asset) — no Bitunix endpoint in the current doc
+  crawl.
+- Bitget equivalents (follow the M2 adapter shape when it exists).
+
+## Open questions
+
+- Should changing leverage while a position is open be gated behind an extra
+  confirmation, given it changes liquidation distance immediately?
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md)
+- [`docs/bitunix-api/02_account.md`](../../bitunix-api/02_account.md)
+- [`docs/MILESTONES.md`](../../MILESTONES.md) — M3

--- a/docs/backlog/features/FEAT-0069-bitunix-place-order-completion.md
+++ b/docs/backlog/features/FEAT-0069-bitunix-place-order-completion.md
@@ -1,0 +1,72 @@
+---
+id: FEAT-0069
+title: Send TP/SL, time-in-force and a client order ID with Bitunix order placement
+type: feature
+status: specced
+priority: P1
+milestone: M3
+editions: [community, pro, private]
+area: execution
+data_class: A
+adr: none
+depends_on: []
+---
+
+# FEAT-0069 — Send TP/SL, time-in-force and a client order ID with Bitunix order placement
+
+## Problem
+
+Cachy's `place_order` call sends only a subset of what the endpoint accepts
+(see [`07_trade.md`](../../bitunix-api/07_trade.md) and
+[`INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §1). Three
+omissions hurt:
+
+- **No `tpPrice`/`slPrice`:** TP/SL cannot be attached atomically at entry.
+  The position exists unprotected until a separate TP/SL call succeeds — and
+  today that separate call does not even exist
+  ([`FEAT-0070`](FEAT-0070-bitunix-tpsl-placement.md)).
+- **No `clientId`:** a network retry after an ambiguous response can double an
+  order; without a client order ID there is no idempotent way to resubmit or
+  to correlate the WS confirmation with the attempt.
+- **No `effect`:** the panel cannot offer IOC/FOK/POST_ONLY; everything is
+  implicitly GTC.
+
+## Proposal
+
+Extend `PlaceOrderSchema`, the `/api/orders` proxy (`type: "place-order"`) and
+`placeBitunixOrder` to pass `tpPrice`/`tpStopType`/`tpOrderType`/`tpOrderPrice`,
+the `sl*` counterparts, `effect`, and a Cachy-generated `clientId` per attempt.
+The trade panel gains TP/SL-at-entry fields (values it already computes for the
+position-size calculation) and a time-in-force selector. The order audit trail
+([`FEAT-0015`](FEAT-0015-order-audit-trail.md)) records the `clientId`.
+
+## Acceptance criteria
+
+- [ ] An order placed with TP and SL set produces the position and its
+      protective orders from a single `place_order` request, confirmed via the
+      WS order channel.
+- [ ] Every submission carries a unique `clientId`; resubmitting the same
+      attempt reuses it, and the WS confirmation is matched to the attempt by
+      it.
+- [ ] `effect` is selectable (GTC default, IOC, FOK, POST_ONLY) for limit
+      orders and omitted for market orders.
+- [ ] All prices/quantities pass through `decimal.js` formatting; no native
+      float serialisation.
+
+## Out of scope
+
+- Trigger/plan orders (endpoint family missing from the doc crawl — see the
+  TODO in `INTEGRATION_STATUS.md`).
+- Batch orders (`batch_order`).
+
+## Open questions
+
+- `clientId` format: random per attempt vs. derived (deterministic) so a
+  crash-and-reload can rediscover an in-flight attempt.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md)
+- [`docs/bitunix-api/07_trade.md`](../../bitunix-api/07_trade.md)
+- [`FEAT-0011`](FEAT-0011-preflight-order-verification.md) — every extension of
+  the order payload widens what the M1 gate must recompute

--- a/docs/backlog/features/FEAT-0070-bitunix-tpsl-placement.md
+++ b/docs/backlog/features/FEAT-0070-bitunix-tpsl-placement.md
@@ -1,0 +1,62 @@
+---
+id: FEAT-0070
+title: Place new TP/SL orders on existing Bitunix positions
+type: feature
+status: specced
+priority: P1
+milestone: M3
+editions: [community, pro, private]
+area: execution
+data_class: A
+adr: none
+depends_on: []
+---
+
+# FEAT-0070 — Place new TP/SL orders on existing Bitunix positions
+
+## Problem
+
+Cachy can list, modify and cancel Bitunix TP/SL orders but cannot **create**
+one: neither `POST /tpsl/place_order` (partial quantity) nor
+`POST /tpsl/position/place_order` (position-wide, max one per position) is
+integrated — see [`06_tp_sl.md`](../../bitunix-api/06_tp_sl.md) and
+[`INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §1. A
+position opened without TP/SL (or whose TP/SL was cancelled) can only be
+protected through the exchange's own UI.
+
+## Proposal
+
+Add `place` and `place-position` actions to the `/api/tpsl` proxy route and
+`tradeService`, and extend the TP/SL edit modal so it can create where nothing
+exists: position-wide TP/SL (closes at market, tracks position size) and
+partial TP/SL with explicit `tpQty`/`slQty`. Success is confirmed via
+WS/refetch, not the REST response alone.
+
+## Acceptance criteria
+
+- [ ] A position without TP/SL can be given a position-wide TP, SL or both
+      from the positions UI; the new order appears in the pending TP/SL list.
+- [ ] A partial TP/SL with explicit quantity can be created; quantities are
+      validated against the position size.
+- [ ] The API constraint "one position-TP/SL per position" is reflected in the
+      UI (offer edit instead of a second create).
+- [ ] Trigger type (`LAST_PRICE`/`MARK_PRICE`) is selectable and defaults
+      consistently with the existing modify flow.
+
+## Out of scope
+
+- Trailing stops (no endpoint in the current doc crawl; M3 lists them —
+  revisit when the API supports it or emulate client-side under a separate
+  item).
+
+## Open questions
+
+- Default for new TP/SL: position-wide or partial? Position-wide matches the
+  exchange UI's primary flow.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md)
+- [`docs/bitunix-api/06_tp_sl.md`](../../bitunix-api/06_tp_sl.md)
+- [`FEAT-0069`](FEAT-0069-bitunix-place-order-completion.md) — atomic TP/SL at
+  entry; this item covers the after-entry case

--- a/docs/backlog/features/FEAT-0071-bitunix-native-bulk-endpoints.md
+++ b/docs/backlog/features/FEAT-0071-bitunix-native-bulk-endpoints.md
@@ -1,0 +1,69 @@
+---
+id: FEAT-0071
+title: Replace client-side cancel and close loops with native Bitunix endpoints
+type: feature
+status: specced
+priority: P2
+milestone: M3
+editions: [community, pro, private]
+area: execution
+data_class: A
+adr: none
+depends_on: []
+---
+
+# FEAT-0071 — Replace client-side cancel and close loops with native Bitunix endpoints
+
+## Problem
+
+Four operations that Bitunix offers as single atomic calls are currently
+emulated client-side (see
+[`INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §1):
+
+- "Cancel all" fetches pending orders and cancels them one by one — an order
+  filled between fetch and cancel is silently missed, and the loop burns rate
+  limit.
+- "Close all" fires parallel MARKET reduce-only orders per position instead of
+  `close_all_position`.
+- "Flash close" is a MARKET reduce-only `place_order` instead of
+  `flash_close_position`, which closes exactly the position referenced by
+  `positionId` — in hedge mode that distinction prevents closing the wrong
+  side.
+- An open order's price/quantity can only be changed by cancel + re-place
+  (losing queue position) instead of `modify_order`.
+
+## Proposal
+
+Proxy the four native endpoints (`cancel_all_orders`, `close_all_position`,
+`flash_close_position`, `modify_order`) and switch
+`tradeService.cancelAllOrders`, `closeAllPositions`, `flashClosePosition` and
+a new `modifyOrder` to them. Keep the response-handling discipline of the
+existing cancel path: per-item `failureList` entries surface as errors, and
+the WS channels remain the source of truth for final state.
+
+## Acceptance criteria
+
+- [ ] Cancel-all issues exactly one API request (per symbol filter) and
+      surfaces partial failures from `failureList`.
+- [ ] Close-all and flash-close use the native endpoints; flash close targets
+      a `positionId`, proven correct in hedge mode with a long and short open
+      on the same symbol.
+- [ ] An open limit order's price/quantity can be modified without losing its
+      order ID.
+- [ ] The old loop implementations are removed, not left as dead fallbacks.
+
+## Out of scope
+
+- Batch order placement (`batch_order`) — separate concern.
+- UI redesign of the order list; only the actions behind existing controls
+  change.
+
+## Open questions
+
+- `modify_order` requires `qty` and `price` even when only TP/SL changes —
+  confirm against live behaviour before relying on partial modification.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md)
+- [`docs/bitunix-api/07_trade.md`](../../bitunix-api/07_trade.md)

--- a/docs/backlog/features/FEAT-0072-bitunix-tpsl-ws-channel.md
+++ b/docs/backlog/features/FEAT-0072-bitunix-tpsl-ws-channel.md
@@ -1,0 +1,58 @@
+---
+id: FEAT-0072
+title: Subscribe the private Bitunix TP/SL WebSocket channel
+type: feature
+status: specced
+priority: P2
+milestone: M3
+editions: [community, pro, private]
+area: exchange
+data_class: A
+adr: none
+depends_on: []
+---
+
+# FEAT-0072 — Subscribe the private Bitunix TP/SL WebSocket channel
+
+## Problem
+
+The private WebSocket connection subscribes `order`, `position` and `wallet`,
+but not the TP/SL channel (see
+[`08_websocket.md`](../../bitunix-api/08_websocket.md) and
+[`INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §2). TP/SL
+creations, triggers and cancellations reach the UI only when a REST poll
+happens to run — a triggered stop can be minutes stale on screen, and the
+Bitunix docs explicitly say the WS push, not the REST response, is the
+reliable confirmation for TP/SL mutations.
+
+## Proposal
+
+Add the TP/SL channel to the private subscription set in `bitunixWs.ts`,
+validate its payload like the existing channels, and feed events into the
+store that backs the pending-TP/SL list so create/update/close events update
+the UI immediately. This also becomes the confirmation path for
+[`FEAT-0070`](FEAT-0070-bitunix-tpsl-placement.md).
+
+## Acceptance criteria
+
+- [ ] Creating, modifying, cancelling or triggering a TP/SL on the exchange
+      side updates Cachy's TP/SL list without a manual refresh.
+- [ ] Channel payloads are schema-validated; unknown events are logged, not
+      crashed on.
+- [ ] Reconnect/resubscribe covers the new channel like the existing three.
+
+## Out of scope
+
+- Notification UX for triggered stops (M3 "Notifications" bullet — separate
+  item when specced).
+
+## Open questions
+
+- Exact channel name on the wire: the doc crawl's private-channel tables all
+  carry a copy-paste `ch: position` artefact; verify against live traffic
+  (the balance channel is `wallet` in practice, not what its doc table says).
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md)
+- [`docs/bitunix-api/08_websocket.md`](../../bitunix-api/08_websocket.md)

--- a/docs/backlog/ideas/IDEA-0073-bitunix-best-bid-ask.md
+++ b/docs/backlog/ideas/IDEA-0073-bitunix-best-bid-ask.md
@@ -1,0 +1,33 @@
+---
+id: IDEA-0073
+title: Show best bid/ask and spread from the Bitunix tickers batch channel
+type: idea
+status: idea
+priority: P3
+milestone: none
+editions: [community, pro, private]
+area: ui
+data_class: C
+adr: none
+depends_on: []
+---
+
+# IDEA-0073 — Show best bid/ask and spread from the Bitunix tickers batch channel
+
+## The thought
+
+The public `tickers` batch channel carries best bid/ask price and volume
+(`bd`/`ak`/`bv`/`av`) that the currently used single-`ticker` channel does not
+(see [`08_websocket.md`](../../bitunix-api/08_websocket.md)). A trade panel
+could show spread and a realistic market-order fill estimate without the
+heavier `depth_book5` subscription, and the market overview could get best
+bid/ask for many symbols from one stream.
+
+## What would have to be true first
+
+- The trade panel redesign (M3) decides whether spread display earns its
+  screen space — data availability alone is not a reason to show it.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §2

--- a/docs/backlog/ideas/IDEA-0074-bitunix-funding-history.md
+++ b/docs/backlog/ideas/IDEA-0074-bitunix-funding-history.md
@@ -1,0 +1,33 @@
+---
+id: IDEA-0074
+title: Surface funding-rate history for a symbol
+type: idea
+status: idea
+priority: P3
+milestone: none
+editions: [community, pro, private]
+area: exchange
+data_class: C
+adr: none
+depends_on: []
+---
+
+# IDEA-0074 — Surface funding-rate history for a symbol
+
+## The thought
+
+`GET /api/v1/futures/market/get_funding_rate_history` (public, up to 200
+entries — see [`04_market.md`](../../bitunix-api/04_market.md)) is unused.
+Historical funding matters to anyone holding perp positions across settlement:
+a small chart or average-funding figure next to the current rate would show
+whether a symbol is chronically expensive to hold long or short, and the
+journal could attribute realised funding cost per trade more precisely.
+
+## What would have to be true first
+
+- A concrete UI home: market details window or journal analytics — decided as
+  part of the M3/M4 UI work, not bolted on.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §1

--- a/docs/backlog/ideas/IDEA-0075-bitunix-position-tiers.md
+++ b/docs/backlog/ideas/IDEA-0075-bitunix-position-tiers.md
@@ -1,0 +1,36 @@
+---
+id: IDEA-0075
+title: Use Bitunix position tiers for precise liquidation and margin estimates
+type: idea
+status: idea
+priority: P3
+milestone: none
+editions: [community, pro, private]
+area: calculation
+data_class: C
+adr: none
+depends_on: []
+---
+
+# IDEA-0075 — Use Bitunix position tiers for precise liquidation and margin estimates
+
+## The thought
+
+`GET /api/v1/futures/position/get_position_tiers` (public — see
+[`05_position.md`](../../bitunix-api/05_position.md)) returns the maintenance
+margin rate per position-size tier. Cachy's risk display currently relies on
+the `liqPrice` the exchange reports for open positions; with the tier table
+the calculator could estimate liquidation price and maintenance margin
+**before** a position exists — at planning time, where Cachy's whole value
+proposition lives — and show how a planned size change moves the position into
+a worse tier.
+
+## What would have to be true first
+
+- Verify the tier formula against exchange-reported `liqPrice` for live
+  positions before showing planning-time estimates; a wrong liquidation
+  estimate is worse than none.
+
+## Links
+
+- [`docs/bitunix-api/INTEGRATION_STATUS.md`](../../bitunix-api/INTEGRATION_STATUS.md) §1

--- a/docs/bitunix-api/INTEGRATION_STATUS.md
+++ b/docs/bitunix-api/INTEGRATION_STATUS.md
@@ -1,0 +1,157 @@
+# Bitunix API – Integrationsstatus in Cachy
+
+Abgleich der offiziellen Bitunix-Futures-API (Crawl vom 08.08.2026, siehe
+[README.md](README.md)) mit dem tatsächlichen Integrationsstand im Code.
+Stand des Abgleichs: **09.08.2026**.
+
+Zweck: Grundlage für die Tradepanel-UI-Überarbeitung und die geplante
+Trade-Ausführung (zuerst Bitunix, dann Bitget). Kein Plandokument — was wann
+gebaut wird, steht in `docs/MILESTONES.md` / `docs/backlog/`.
+
+**Legende:** ✅ integriert · 🟡 teilweise · ❌ nicht integriert
+
+---
+
+## Architektur-Kurzfassung
+
+Alle Bitunix-REST-Aufrufe laufen über SvelteKit-Proxy-Routen
+(`src/routes/api/*`), signiert mit `generateBitunixSignature`
+([src/utils/server/bitunix.ts](../../src/utils/server/bitunix.ts)).
+Client-seitig kapseln [tradeService](../../src/services/tradeService.ts)
+(Trading-Aktionen), [apiService](../../src/services/apiService.ts)
+(Marktdaten) und [syncService](../../src/services/syncService.ts)
+(Journal-Sync) die Zugriffe. WebSocket:
+[bitunixWs.ts](../../src/services/bitunixWs.ts) (public + private inkl.
+Login, Reconnect, Resubscribe).
+
+---
+
+## 1. REST-Endpunkte
+
+### Account (`02_account.md`)
+
+| Endpoint | Zweck | Status | Code |
+|---|---|---|---|
+| `GET /api/v1/futures/account` | Balance, frozen, margin, transfer, positionMode, cross/isolation-UPNL, bonus | ✅ | [routes/api/account](../../src/routes/api/account/+server.ts), [routes/api/balance](../../src/routes/api/balance/+server.ts) |
+| `GET …/account/get_leverage_margin_mode` | Hebel + Margin-Mode je Symbol lesen | ❌ | — |
+| `POST …/account/change_leverage` | Hebel ändern (je Symbol) | ❌ | — |
+| `POST …/account/change_margin_mode` | ISOLATION/CROSS; nur ohne offene Position/Order auf dem Symbol | ❌ | — |
+| `POST …/account/change_position_mode` | ONE_WAY/HEDGE; nur ohne offene Positionen | ❌ | — |
+| `POST …/account/adjust_position_margin` | Margin erhöhen/reduzieren; nur Isolated | ❌ | — |
+
+Hebel, Margin-Mode, Position-Mode und Positions-Margin sind also per API
+änderbar — nichts davon ist bisher integriert. Für ein vollwertiges
+Tradepanel ist das der größte fehlende Block.
+
+### Market (`04_market.md`) — public, kein API-Key nötig
+
+| Endpoint | Status | Code / Anmerkung |
+|---|---|---|
+| `GET …/market/tickers` | ✅ | [routes/api/tickers](../../src/routes/api/tickers/+server.ts) |
+| `GET …/market/kline` | ✅ | [routes/api/klines](../../src/routes/api/klines/+server.ts) |
+| `GET …/market/funding_rate/batch` | ✅ | [routes/api/funding-rate](../../src/routes/api/funding-rate/+server.ts); Prozent→Bruch-Normalisierung in `apiService.fetchBitunixFundingRates` |
+| `GET …/market/funding_rate` (single) | ❌ | Durch Batch abgedeckt — bewusst nicht nötig |
+| `GET …/market/get_funding_rate_history` | ❌ | — |
+| `GET …/market/depth` (REST) | ❌ | WS `depth_book5` wird stattdessen genutzt |
+| `GET …/market/trading_pairs` | ❌ | **Wichtig für Trade-Ausführung**: `basePrecision`/`quotePrecision`, `minTradeVolume`, `maxLimitOrderVolume`/`maxMarketOrderVolume`, `min`/`maxLeverage`, `priceProtectScope`, `symbolStatus`, `isApiSupported` — ohne diese Daten kann das Tradepanel Orders nicht zuverlässig validieren und runden |
+
+### Position (`05_position.md`)
+
+| Endpoint | Status | Code / Anmerkung |
+|---|---|---|
+| `GET …/position/get_pending_positions` | ✅ | [routes/api/positions](../../src/routes/api/positions/+server.ts), [routes/api/sync/positions-pending](../../src/routes/api/sync/positions-pending/+server.ts) |
+| `GET …/position/get_history_positions` | ✅ | [routes/api/sync/positions-history](../../src/routes/api/sync/positions-history/+server.ts) |
+| `GET …/position/get_position_tiers` | ❌ | Maintenance-Margin-Stufen → präzisere Liquidationspreis-/Risiko-Berechnung möglich |
+
+### Trade (`07_trade.md`)
+
+| Endpoint | Status | Code / Anmerkung |
+|---|---|---|
+| `POST …/trade/place_order` | 🟡 | [routes/api/orders](../../src/routes/api/orders/+server.ts) (`type: "place-order"`). Gesendet: `symbol`, `side`, `orderType`, `qty`, `price`, `reduceOnly`, `tradeSide`/`positionId` (Hedge), `triggerPrice`. **Nicht genutzt:** `tpPrice`/`slPrice` (kein atomares TP/SL beim Öffnen), `effect` (GTC/IOC/FOK/POST_ONLY), `clientId` (Idempotenz bei Netzwerk-Retries) |
+| `POST …/trade/cancel_orders` | ✅ | `cancelBitunixOrder` in [routes/api/orders](../../src/routes/api/orders/+server.ts) |
+| `POST …/trade/cancel_all_orders` | ❌ | Cachy loopt stattdessen über pending + Einzel-Cancel (`type: "cancel-all"`) — race-anfällig, mehr Rate-Limit-Last |
+| `POST …/trade/close_all_position` | ❌ | `tradeService.closeAllPositions()` feuert parallele MARKET-reduceOnly-Orders |
+| `POST …/trade/flash_close_position` | ❌ | Cachys „Flash Close" (`tradeService.flashClosePosition`) ist eine MARKET-reduceOnly-`place_order`, nicht der native Endpoint |
+| `POST …/trade/modify_order` | ❌ | Offene Order kann nur per cancel + neu platzieren geändert werden |
+| `POST …/trade/batch_order` | ❌ | Max. 5 Orders/Request, inkl. TP/SL je Order — interessant für Scale-In/Ladder-Strategien |
+| `GET …/trade/get_pending_orders` | ✅ | [routes/api/orders](../../src/routes/api/orders/+server.ts) |
+| `GET …/trade/get_history_orders` | ✅ | [routes/api/orders](../../src/routes/api/orders/+server.ts), [routes/api/sync/orders](../../src/routes/api/sync/orders/+server.ts) |
+| `GET …/trade/get_history_trades` | ✅ | [routes/api/sync](../../src/routes/api/sync/+server.ts) (Journal) |
+| `GET …/trade/get_order_detail` | ✅ | [routes/api/sync/order-detail](../../src/routes/api/sync/order-detail/+server.ts) |
+
+### TP/SL (`06_tp_sl.md`)
+
+| Endpoint | Status | Code / Anmerkung |
+|---|---|---|
+| `GET …/tpsl/get_pending_orders` | ✅ | [routes/api/tpsl](../../src/routes/api/tpsl/+server.ts) (`action: "pending"`) |
+| `GET …/tpsl/get_history_orders` | ✅ | [routes/api/tpsl](../../src/routes/api/tpsl/+server.ts) (`action: "history"`) |
+| `POST …/tpsl/cancel_order` | ✅ | [routes/api/tpsl](../../src/routes/api/tpsl/+server.ts) (`action: "cancel"`) |
+| `POST …/tpsl/modify_order` | ✅ | [routes/api/tpsl](../../src/routes/api/tpsl/+server.ts) (`action: "modify"`); UI: [TpSlEditModal](../../src/components/shared/TpSlEditModal.svelte) |
+| `POST …/tpsl/place_order` | ❌ | **Lücke:** Neue TP/SL-Order (Teilmenge) auf bestehende Position kann nicht angelegt werden — nur existierende ändern |
+| `POST …/tpsl/position/place_order` | ❌ | Positions-weites TP/SL (max. 1 pro Position, schließt zum Marktpreis) |
+| `POST …/tpsl/position/modify_order` | ❌ | — |
+
+### Sonstiges
+
+- **Plan-Orders (Trigger-Orders):** `GET /api/v1/futures/plan/get_history_plan_orders`
+  wird im Journal-Sync genutzt
+  ([routes/api/sync/orders](../../src/routes/api/sync/orders/+server.ts)),
+  aber die restliche Plan-Order-Familie (place/cancel/get_pending) **fehlt im
+  Doku-Crawl** unter `docs/bitunix-api/`. TODO: beim nächsten Crawl ergänzen.
+- **CopyTrading** (`03_copytrading.md`): Asset-Query + Sub-Account-Transfers —
+  nicht integriert, derzeit out of scope.
+
+---
+
+## 2. WebSocket-Channels (`08_websocket.md`)
+
+| Channel | Typ | Status | Anmerkung |
+|---|---|---|---|
+| `price` (MarketPrice: Mark/Index, Funding) | public | ✅ | |
+| `ticker` (24h, einzeln) | public | ✅ | |
+| `tickers` (Batch, inkl. Best-Bid/Ask `bd`/`ak`/`bv`/`av`) | public | ❌ | Best-Bid/Ask wäre fürs Tradepanel nützlich (Spread-Anzeige, Market-Order-Schätzung) |
+| `depth_book5` | public | ✅ | `books`/`book1`/`book15` ungenutzt |
+| `market_kline_*`, `mark_kline_1day` | public | ✅ | Inkl. synthetischer Timeframes via `BROKER_CAPABILITIES` |
+| `trade` (public Trades) | public | ✅ | |
+| `order` | private | ✅ | |
+| `position` | private | ✅ | |
+| `wallet` (Balance) | private | ✅ | Felder `expMoney`, `isolationFrozen`, `crossFrozen` werden empfangen, aber nicht angezeigt |
+| TP/SL-Channel | private | ❌ | TP/SL-Änderungen erreichen die UI nur per REST-Polling, nicht in Echtzeit |
+
+Wichtiger Doku-Hinweis (aus `07_trade.md`/`06_tp_sl.md`): Eine erfolgreiche
+REST-Antwort bei order-verändernden Endpoints garantiert **nicht**, dass die
+Operation durchging — die WS-Push-Nachricht ist die verlässliche Bestätigung.
+Neue Schreib-Endpoints sollten daher wie die bestehenden über das
+OMS-/WS-Bestätigungsmuster laufen.
+
+---
+
+## 3. Account-Daten: verfügbar vs. angezeigt
+
+Bereits geholt und angezeigt
+([AccountSummary](../../src/components/shared/AccountSummary.svelte) +
+`AccountTooltip`): `available`, `margin`, PnL, `frozen`, `transfer`, `bonus`,
+`positionMode`, `crossUnrealizedPNL`, `isolationUnrealizedPNL`,
+`totalPositionSize` (client-berechnet).
+
+Verfügbar, aber weder geholt noch angezeigt:
+
+- **Hebel + Margin-Mode je Symbol** (`get_leverage_margin_mode`)
+- Position-Tiers (Maintenance-Margin-Stufen)
+- Trading-Pair-Limits (Präzision, Min-/Max-Ordergrößen, Max-Hebel)
+- `expMoney`, `isolationFrozen`, `crossFrozen` aus dem Wallet-Channel
+
+---
+
+## 4. Priorisierte Lücken (Empfehlung)
+
+1. **`trading_pairs`** — Order-Validierung/Präzision; Grundlage für alles Weitere
+2. **Account-Settings-Block** — `get_leverage_margin_mode` (lesen) +
+   `change_leverage`, `change_margin_mode`, `adjust_position_margin` (schreiben)
+3. **`place_order` vervollständigen** — `tpPrice`/`slPrice` atomar, `effect`, `clientId`
+4. **`tpsl/place_order` + `tpsl/position/place_order`** — TP/SL nachträglich setzen
+5. **Native Endpoints statt Client-Loops** — `cancel_all_orders`,
+   `close_all_position`, `flash_close_position`, `modify_order`
+6. **Privater TP/SL-WS-Channel** abonnieren
+7. Nice-to-have: `tickers`-Batch-Channel (Best Bid/Ask), Funding-History,
+   Position-Tiers

--- a/docs/bitunix-api/README.md
+++ b/docs/bitunix-api/README.md
@@ -25,6 +25,7 @@ OpenAPI-Dokumentation unter:
 | `08_websocket.md` | WebSocket-Verbindung, Login, alle Private- & Public-Channels |
 | `09_error_codes.md` | Vollständige Fehlercode-Tabelle |
 | `10_change_log.md` | Änderungsprotokoll der offiziellen Doku |
+| `INTEGRATION_STATUS.md` | Abgleich: welche Endpunkte/Channels Cachy bereits nutzt, was fehlt |
 
 ## Kurzüberblick über die API-Struktur
 


### PR DESCRIPTION
## Summary

Comparison of the complete Bitunix Futures API (local doc crawl under `docs/bitunix-api/`) against what Cachy actually integrates — preparation for the trade-panel UI overhaul and the planned trade execution work (Bitunix → Bitget).

### 1. New document `docs/bitunix-api/INTEGRATION_STATUS.md`

- **REST comparison** by category (Account, Market, Position, Trade, TP/SL) with status ✅/🟡/❌ and code references
- **WebSocket comparison** (public + private channels)
- **Account data:** available vs. shown in the UI
- **Prioritized gap list** for the milestones
- Notes a **doc gap**: the plan-order endpoint family is used by the journal sync but missing from the crawl.

Plus one line in the file overview of `docs/bitunix-api/README.md` (linking only, no duplication).

## Verification

- Docs-only change, no code affected
- All relative links in the new document checked for existence

🤖 Generated with [Claude Code](https://claude.com/claude-code)