### PR TITLE
fix(account): stop hydrateBalance from erasing WS-only wallet fields

### DIFF
--- a/src/stores/account.svelte.ts
+++ b/src/stores/account.svelte.ts
@@ -459,14 +459,26 @@ class AccountManager {
     const available = parseDecimal(raw.available);
     const margin = parseDecimal(raw.margin);
     const frozen = parseDecimal(raw.frozen);
+    const idx = this.assets.findIndex((a) => a.currency === "USDT");
+    // REST /api/account has no isolationMargin/crossMargin/isolationFrozen/
+    // crossFrozen/expMoney — only the WS wallet channel does. Without this,
+    // a REST poll here would silently erase whatever the wallet channel had
+    // last pushed (BUG found during dev.cachy.app testing: the AccountTooltip
+    // rows for those fields never appeared because this REST hydration kept
+    // winning the race against the WS push).
+    const existing = idx !== -1 ? this.assets[idx] : null;
     const newAsset: Asset = {
       currency: "USDT",
       available,
       margin,
       frozen,
       total: available.plus(margin).plus(frozen),
+      isolationMargin: existing?.isolationMargin,
+      crossMargin: existing?.crossMargin,
+      isolationFrozen: existing?.isolationFrozen,
+      crossFrozen: existing?.crossFrozen,
+      expMoney: existing?.expMoney,
     };
-    const idx = this.assets.findIndex((a) => a.currency === "USDT");
     if (idx !== -1) this.assets[idx] = newAsset;
     else this.assets.push(newAsset);
     this.notifyListeners();

--- a/src/stores/account.test.ts
+++ b/src/stores/account.test.ts
@@ -334,6 +334,31 @@ describe('AccountManager', () => {
             expect(asset.available.toString()).toBe('1000');
             expect(asset.total.toString()).toBe('1060');
         });
+
+        // Bug found during dev.cachy.app testing: REST /api/account has no
+        // isolationFrozen/crossFrozen/expMoney (WS-only fields, see
+        // updateBalanceFromWs). A later REST poll was silently erasing
+        // whatever the wallet WS push had set for these, so the
+        // AccountTooltip rows for them never appeared in practice even
+        // though the WS parsing itself was correct.
+        it('preserves WS-only wallet fields across a later REST poll', () => {
+            accountState.updateBalanceFromWs({
+                coin: 'USDT',
+                available: '1000',
+                margin: '50',
+                frozen: '10',
+                isolationFrozen: '5',
+                crossFrozen: '2',
+                expMoney: '3.5',
+            });
+
+            accountState.hydrateBalance({ available: '1000', margin: '50', frozen: '10' });
+
+            const asset = accountState.assets.find((a) => a.currency === 'USDT');
+            expect(asset?.isolationFrozen?.toString()).toBe('5');
+            expect(asset?.crossFrozen?.toString()).toBe('2');
+            expect(asset?.expMoney?.toString()).toBe('3.5');
+        });
     });
 
     // Regression: marginRate is REST-only (Bitunix never sends it over WS),


### PR DESCRIPTION
## Summary

Bug found while testing the read-only Bitunix data display (#1685, already merged) on dev.cachy.app: the new AccountTooltip rows for `isolationFrozen`/`crossFrozen`/`expMoney` never appeared, even with a connected account and open positions.

Root cause: `hydrateBalance()` (called on every REST `/api/account` poll from `PositionsSidebar.svelte`) replaced the whole USDT asset entry with an object literal that only sets `available`/`margin`/`frozen`/`total`. Those three extended fields only ever come from the WS wallet channel (`updateBalanceFromWs`). Whichever of {REST poll, WS push} ran last decided whether the fields existed on the asset — a REST poll after a WS push silently wiped them back to `undefined`, hiding the rows again.

Fix: `hydrateBalance` now carries the existing asset's extended fields forward, since REST has no equivalent data for them at all.

## Verification

- `npm run check`: 0 errors, 0 warnings
- New regression test in `account.test.ts`: pushes a WS wallet update with the three fields set, then calls `hydrateBalance`, and asserts the fields survive
- Full `account.test.ts` suite: 26 passed
- Browser sanity check on the dev server: app loads and renders without error after the change (outbound Bitunix API calls were blocked by the sandbox network at test time, unrelated to this fix — `hydrateBalance`/`updateBalanceFromWs` don't touch that code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)