### PR TITLE
fix(account): stop hydrateBalance from erasing WS-only wallet fields

### DIFF
--- a/src/stores/account.svelte.ts
+++ b/src/stores/account.svelte.ts
@@ -459,14 +459,26 @@ class AccountManager {
     const available = parseDecimal(raw.available);
     const margin = parseDecimal(raw.margin);
     const frozen = parseDecimal(raw.frozen);
+    const idx = this.assets.findIndex((a) => a.currency === "USDT");
+    // REST /api/account has no isolationMargin/crossMargin/isolationFrozen/
+    // crossFrozen/expMoney — only the WS wallet channel does. Without this,
+    // a REST poll here would silently erase whatever the wallet channel had
+    // last pushed (BUG found during dev.cachy.app testing: the AccountTooltip
+    // rows for those fields never appeared because this REST hydration kept
+    // winning the race against the WS push).
+    const existing = idx !== -1 ? this.assets[idx] : null;
     const newAsset: Asset = {
       currency: "USDT",
       available,
       margin,
       frozen,
       total: available.plus(margin).plus(frozen),
+      isolationMargin: existing?.isolationMargin,
+      crossMargin: existing?.crossMargin,
+      isolationFrozen: existing?.isolationFrozen,
+      crossFrozen: existing?.crossFrozen,
+      expMoney: existing?.expMoney,
     };
-    const idx = this.assets.findIndex((a) => a.currency === "USDT");
     if (idx !== -1) this.assets[idx] = newAsset;
     else this.assets.push(newAsset);
     this.notifyListeners();

--- a/src/stores/account.test.ts
+++ b/src/stores/account.test.ts
@@ -334,6 +334,31 @@ describe('AccountManager', () => {
             expect(asset.available.toString()).toBe('1000');
             expect(asset.total.toString()).toBe('1060');
         });
+
+        // Bug found during dev.cachy.app testing: REST /api/account has no
+        // isolationFrozen/crossFrozen/expMoney (WS-only fields, see
+        // updateBalanceFromWs). A later REST poll was silently erasing
+        // whatever the wallet WS push had set for these, so the
+        // AccountTooltip rows for them never appeared in practice even
+        // though the WS parsing itself was correct.
+        it('preserves WS-only wallet fields across a later REST poll', () => {
+            accountState.updateBalanceFromWs({
+                coin: 'USDT',
+                available: '1000',
+                margin: '50',
+                frozen: '10',
+                isolationFrozen: '5',
+                crossFrozen: '2',
+                expMoney: '3.5',
+            });
+
+            accountState.hydrateBalance({ available: '1000', margin: '50', frozen: '10' });
+
+            const asset = accountState.assets.find((a) => a.currency === 'USDT');
+            expect(asset?.isolationFrozen?.toString()).toBe('5');
+            expect(asset?.crossFrozen?.toString()).toBe('2');
+            expect(asset?.expMoney?.toString()).toBe('3.5');
+        });
     });
 
     // Regression: marginRate is REST-only (Bitunix never sends it over WS),


### PR DESCRIPTION
hydrateBalance() (called on every REST account poll) replaced the whole USDT asset entry without isolationMargin/crossMargin/ isolationFrozen/crossFrozen/expMoney, which only the WS wallet channel ever sets (updateBalanceFromWs). Whichever of {REST poll, WS push} landed last decided whether those fields existed, so a REST poll after a WS push silently wiped them back to undefined and the new AccountTooltip rows never appeared in practice.

Found while testing the read-only data display on dev.cachy.app.