### PR TITLE
chore: ensure all files have valid AGPL license headers

### DIFF
--- a/scripts/ensure_agpl_headers.py
+++ b/scripts/ensure_agpl_headers.py
@@ -24,6 +24,7 @@ EXTENSIONS = {
     '.html': 'html',
     '.py': 'hash',
     '.sh': 'hash',
+    '.rs': 'block',
 }
 
 SKIP_DIRS = {'node_modules', '.git', '.svelte-kit', 'dist', 'coverage', 'test-results', 'info', 'docs', '.github', '.vscode', 'benchmarks', 'static'}
@@ -75,7 +76,7 @@ def process_file(filepath):
         f.write(new_content)
 
 def main():
-    root_dirs = ['src', 'server', 'scripts', 'tests']
+    root_dirs = ['src', 'server', 'scripts', 'tests', 'technicals-wasm']
 
     # Process root directories
     for root_dir in root_dirs:

--- a/scripts/maintenance/patch_news_final_clean.js
+++ b/scripts/maintenance/patch_news_final_clean.js
@@ -1,1 +1,17 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 

--- a/src/services/apiService_infinity.test.ts
+++ b/src/services/apiService_infinity.test.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Hoist mocks

--- a/src/services/appEffects.svelte.ts
+++ b/src/services/appEffects.svelte.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { untrack } from "svelte";
 import { tradeState } from "../stores/trade.svelte";
 import { settingsState, type Settings } from "../stores/settings.svelte";

--- a/src/services/engineBenchmark.test.ts
+++ b/src/services/engineBenchmark.test.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { IndicatorSettings } from '../types/indicators';
 import type { TechnicalsData } from './technicalsTypes';

--- a/src/services/tradeService_errors.test.ts
+++ b/src/services/tradeService_errors.test.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Decimal } from "decimal.js";
 

--- a/src/tests/closeAllPositions.bench.ts
+++ b/src/tests/closeAllPositions.bench.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { bench, describe, vi } from 'vitest';
 import { tradeService } from '../services/tradeService';
 import { omsService } from '../services/omsService';

--- a/src/utils/apiResponse.test.ts
+++ b/src/utils/apiResponse.test.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { jsonSuccess, jsonError, handleApiError } from './apiResponse';
 

--- a/technicals-wasm/src/indicator_settings.rs
+++ b/technicals-wasm/src/indicator_settings.rs
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 // Additional indicator settings structures for missing indicators
 
 #[derive(Serialize, Deserialize, Clone, Default)] 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 MYDCT
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import 'fake-indexeddb/auto';
 import { vi } from 'vitest';
 import { webcrypto } from 'node:crypto';


### PR DESCRIPTION
Ensures all existing and newly created files are correctly licensed under the GNU Affero General Public License (AGPL) and contain the appropriate header. Updated the `scripts/ensure_agpl_headers.py` script to include Rust (`.rs`) files and the `technicals-wasm` directory, then executed the script to fix any files missing the header.

---
*PR created automatically by Jules for task [3753984778003124708](https://jules.google.com/task/3753984778003124708) started by @mydcc*