### PR TITLE
fix(positions): recompute unrealized PnL from live mark price

### DIFF
--- a/src/components/shared/PositionsSidebar.svelte
+++ b/src/components/shared/PositionsSidebar.svelte
@@ -31,6 +31,7 @@
   import { unwrapApiEnvelope } from "../../utils/utils";
   import { appFetch } from "../../lib/appAuth";
   import type { OMSPosition } from "../../services/omsTypes";
+  import { calculateLiveUnrealizedPnl } from "../../services/mappers";
   import type { NormalizedOrder, NormalizedPosition } from "../../types/bitunix";
   import type { TranslationKey } from "../../locales/schema";
 
@@ -160,24 +161,40 @@
     return undefined;
   }
 
+  // unrealizedPnl on accountState.positions only updates when Bitunix's WS
+  // position channel pushes — order create/fill/cancel events, NOT every
+  // price tick (08_websocket.md's Position Channel) — so it goes stale
+  // between those even while markPrice keeps updating live via the public
+  // price channel. Recompute it from the live mark price whenever one is
+  // available and the position has a real entry price (a brand-new WS-only
+  // position can still be at the placeholder 0 — see updatePositionFromWs —
+  // in which case fall back to the account-channel value rather than
+  // produce a nonsense PnL).
   let mappedPositions = $derived(
-    accountState.positions.map((p): OMSPosition => ({
+    accountState.positions.map((p): OMSPosition => {
+      const markPrice = resolveMarkPrice(p);
+      const liveUnrealizedPnl =
+        markPrice && p.entryPrice.gt(0)
+          ? calculateLiveUnrealizedPnl(p.side, p.entryPrice, markPrice, p.size)
+          : undefined;
+      return {
         symbol: p.symbol,
         side: p.side,
         amount: p.size, // Map size to amount
         entryPrice: p.entryPrice,
-        unrealizedPnl: p.unrealizedPnl,
+        unrealizedPnl: liveUnrealizedPnl ?? p.unrealizedPnl,
         leverage: p.leverage,
         marginMode: p.marginMode as "cross" | "isolated",
         liquidationPrice: p.liquidationPrice,
         margin: p.margin,
-        markPrice: resolveMarkPrice(p),
+        markPrice,
         size: p.size,
         // REST-only, never sent over WS — 0 means "not hydrated yet", not a
         // real margin rate, so treat it as absent rather than show "0%".
         marginRate: p.marginRate.gt(0) ? p.marginRate : undefined,
         realizedPnl: p.realizedPnl,
-    }))
+      };
+    })
   );
 
   // Total notional value of every open position — client-computed (Σ size ×
@@ -188,6 +205,14 @@
       (sum, p) => sum.plus(p.amount.mul(p.markPrice || p.entryPrice)),
       new Decimal(0),
     ),
+  );
+
+  // Sum of the live-recomputed per-position PnL above, NOT
+  // accountState.totalUnrealizedPnl — that getter sums the stale
+  // account-channel unrealizedPnl directly, so the account summary's
+  // "Total PnL" would go stale between order events too.
+  let totalUnrealizedPnl = $derived(
+    mappedPositions.reduce((sum, p) => sum.plus(p.unrealizedPnl), new Decimal(0)),
   );
 
   // Subscribe to live price updates for every symbol with an open position —
@@ -633,7 +658,7 @@
     <AccountSummary
       available={liveAsset ? liveAsset.available : accountInfo.available}
       margin={liveAsset ? liveAsset.margin : accountInfo.margin}
-      pnl={accountState.totalUnrealizedPnl}
+      pnl={totalUnrealizedPnl}
       currency={accountInfo.marginCoin}
       frozen={liveAsset ? liveAsset.frozen : accountInfo.frozen}
       transfer={accountInfo.transfer}

--- a/src/services/mappers.test.ts
+++ b/src/services/mappers.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, it, expect } from "vitest";
 import { Decimal } from "decimal.js";
-import { mapToOMSPosition, mapToOMSOrder } from "./mappers";
+import { mapToOMSPosition, mapToOMSOrder, calculateLiveUnrealizedPnl } from "./mappers";
 
 describe("Mappers", () => {
     describe("mapToOMSPosition", () => {
@@ -160,6 +160,51 @@ describe("Mappers", () => {
             expect(result.price.toString()).toBe("0");
             expect(result.amount.toString()).toBe("0");
             expect(result.filledAmount.toString()).toBe("0");
+        });
+    });
+
+    // Bug: a user reported PnL on an open position only refreshing after a
+    // full page reload — Bitunix's WS position channel doesn't push on
+    // every price tick, only on order events, so a value read straight off
+    // the account store goes stale between those.
+    describe("calculateLiveUnrealizedPnl", () => {
+        it("computes long PnL as (mark - entry) * size", () => {
+            const pnl = calculateLiveUnrealizedPnl(
+                "long",
+                new Decimal("100"),
+                new Decimal("110"),
+                new Decimal("2"),
+            );
+            expect(pnl.toString()).toBe("20");
+        });
+
+        it("computes short PnL as (entry - mark) * size", () => {
+            const pnl = calculateLiveUnrealizedPnl(
+                "short",
+                new Decimal("100"),
+                new Decimal("90"),
+                new Decimal("2"),
+            );
+            expect(pnl.toString()).toBe("20");
+        });
+
+        it("is negative when a long position is underwater", () => {
+            const pnl = calculateLiveUnrealizedPnl(
+                "long",
+                new Decimal("100"),
+                new Decimal("95"),
+                new Decimal("1"),
+            );
+            expect(pnl.toString()).toBe("-5");
+        });
+
+        it("tracks a rising mark price the way a page reload's REST snapshot would", () => {
+            const entry = new Decimal("1921.34");
+            const size = new Decimal("0.003");
+            const atOpen = calculateLiveUnrealizedPnl("short", entry, new Decimal("1921.34"), size);
+            const afterMove = calculateLiveUnrealizedPnl("short", entry, new Decimal("1918.00"), size);
+            expect(atOpen.toString()).toBe("0");
+            expect(afterMove.gt(atOpen)).toBe(true);
         });
     });
 });

--- a/src/services/mappers.ts
+++ b/src/services/mappers.ts
@@ -38,6 +38,26 @@ function parseDecimalOrUndefined(value: unknown): Decimal | undefined {
 }
 
 /**
+ * Recomputes unrealized PnL from a live mark price instead of trusting the
+ * account-channel snapshot. Bitunix's WS position channel only pushes on
+ * order lifecycle events — create/fill/cancel (docs/bitunix-api/
+ * 08_websocket.md's Position Channel) — not on every price tick, so
+ * `unrealizedPnl` read straight off the account store goes stale between
+ * those events even though markPrice (fed continuously by the public
+ * `price` channel) keeps updating. Reported by a user seeing PnL only
+ * refresh on a full page reload.
+ */
+export function calculateLiveUnrealizedPnl(
+    side: "long" | "short",
+    entryPrice: Decimal,
+    markPrice: Decimal,
+    size: Decimal,
+): Decimal {
+    const priceDiff = side === "long" ? markPrice.minus(entryPrice) : entryPrice.minus(markPrice);
+    return priceDiff.times(size);
+}
+
+/**
  * Maps raw API/WS data to a standardized OMSPosition.
  * Handles different field names (API vs WS) and ensures Decimal precision.
  */


### PR DESCRIPTION
## Summary

User report: an open position's PnL only reflected reality after a full page reload — otherwise it looked frozen.

Root cause: Bitunix's WS position channel only pushes on order lifecycle events (create/fill/cancel — see `docs/bitunix-api/08_websocket.md`'s Position Channel), never on every price tick. `accountState.positions[i].unrealizedPnl` is read straight from that channel, so it goes stale between those events — while `markPrice` for the same position keeps updating live via the public `price` WS channel. A page reload triggers a fresh REST snapshot (server-computed PnL), which is why it looked correct again right after reloading.

## Fix

- New `calculateLiveUnrealizedPnl(side, entryPrice, markPrice, size)` in `mappers.ts` — the standard perpetual-futures PnL formula, computed client-side from the live mark price.
- `PositionsSidebar.svelte`'s `mappedPositions` derivation now uses it whenever a live mark price and a real (non-placeholder) entry price are available, falling back to the account-channel value otherwise.
- The account summary's "Total PnL" now sums the same live-recomputed values instead of the stale `accountState.totalUnrealizedPnl` getter, so both figures move together.

## Verification

- `npm run check`: 0 errors, 0 warnings
- New unit tests for `calculateLiveUnrealizedPnl` (long/short/underwater/rising-price cases) — `mappers.test.ts`, 16/16 passing
- Full suite: 1094 passed, 6 skipped, 4 pre-existing unrelated failures (`WindowManager.test.ts` Academy-window dynamic-import timeouts — reproduced identically on a clean `develop` checkout with zero related changes, confirmed not a regression from this PR)
- Browser sanity check on the dev server: app loads and renders without console errors after the change
- **Not verified live against a real position**: no Bitunix test credentials available in this environment — the fix is unit-tested at the formula level and the wiring is a small, direct `$derived` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)